### PR TITLE
[Fournos testing] Continue the foreign testing integration

### DIFF
--- a/projects/cluster/toolbox/build_image/main.py
+++ b/projects/cluster/toolbox/build_image/main.py
@@ -23,6 +23,62 @@ from projects.core.dsl import (
 logger = logging.getLogger("TOOLBOX")
 
 
+def _capture_all_container_logs(pod_name: str, namespace: str, artifact_dir):
+    """
+    Capture logs from all containers in a pod
+
+    Args:
+        pod_name: Name of the pod
+        namespace: Kubernetes namespace
+        artifact_dir: Directory to save log files
+    """
+    # Get list of all containers in the pod
+    result = shell.run(
+        f"oc get pod {pod_name} -n {namespace} -o jsonpath='{{.spec.containers[*].name}}'",
+        check=False,
+    )
+
+    if not result.success or not result.stdout.strip():
+        logger.warning(f"Could not get container list for pod {pod_name}")
+        return
+
+    container_names = result.stdout.strip().split()
+    logger.info(f"Capturing logs from {len(container_names)} containers: {container_names}")
+
+    # Capture logs for each container
+    for container_name in container_names:
+        log_file = artifact_dir / "artifacts" / f"{pod_name}-{container_name}.log"
+        shell.run(
+            f"oc logs {pod_name} -n {namespace} -c {container_name}",
+            stdout_dest=log_file,
+            check=False,
+        )
+        logger.debug(f"Captured logs for container '{container_name}' to {log_file}")
+
+    # Also capture logs from init containers if any
+    result = shell.run(
+        f"oc get pod {pod_name} -n {namespace} -o jsonpath='{{.spec.initContainers[*].name}}'",
+        check=False,
+    )
+
+    if not result.success or not result.stdout.strip():
+        return
+
+    init_container_names = result.stdout.strip().split()
+    logger.info(
+        f"Capturing logs from {len(init_container_names)} init containers: {init_container_names}"
+    )
+
+    for container_name in init_container_names:
+        log_file = artifact_dir / "artifacts" / f"{pod_name}-init-{container_name}.log"
+        shell.run(
+            f"oc logs {pod_name} -n {namespace} -c {container_name}",
+            stdout_dest=log_file,
+            check=False,
+        )
+        logger.debug(f"Captured init container logs for '{container_name}' to {log_file}")
+
+
 def run(
     repo_name: str,
     commit: str,
@@ -185,12 +241,8 @@ def wait_for_build_completion(args, ctx):
             stdout_dest=args.artifact_dir / "artifacts" / f"{ctx.buildrun_name}-final-status.yaml",
         )
 
-        # Get build logs for debugging
-        shell.run(
-            f"oc logs {ctx.buildrun_name} -n {args.namespace}",
-            stdout_dest=args.artifact_dir / "artifacts" / f"{ctx.buildrun_name}-build.log",
-            check=False,
-        )
+        # Capture logs from all containers in the build pod
+        _capture_all_container_logs(ctx.buildrun_name, args.namespace, args.artifact_dir)
 
         if status == "false":
             raise RuntimeError(f"Build {ctx.buildrun_name} failed")
@@ -221,12 +273,8 @@ def capture_build_artifacts(args, ctx):
             check=False,
         )
 
-        # Get pod logs for git clone step (if available)
-        shell.run(
-            f"oc logs {build_run_name} -n {args.namespace} -c step-source-default",
-            stdout_dest=args.artifact_dir / "artifacts" / f"{build_run_name}-source-clone.log",
-            check=False,
-        )
+        # Capture logs from all containers in the build pod
+        _capture_all_container_logs(build_run_name, args.namespace, args.artifact_dir)
     else:
         logger.warning("No BuildRun name available")
 

--- a/projects/cluster/toolbox/rebuild_image/main.py
+++ b/projects/cluster/toolbox/rebuild_image/main.py
@@ -39,6 +39,62 @@ def setup_clean_logger(name: str):
 logger = setup_clean_logger("TOOLBOX")
 
 
+def _capture_all_container_logs(pod_name: str, namespace: str, artifact_dir):
+    """
+    Capture logs from all containers in a pod
+
+    Args:
+        pod_name: Name of the pod
+        namespace: Kubernetes namespace
+        artifact_dir: Directory to save log files
+    """
+    # Get list of all containers in the pod
+    result = shell.run(
+        f"oc get pod {pod_name} -n {namespace} -o jsonpath='{{.spec.containers[*].name}}'",
+        check=False,
+    )
+
+    if not result.success or not result.stdout.strip():
+        logger.warning(f"Could not get container list for pod {pod_name}")
+        return
+
+    container_names = result.stdout.strip().split()
+    logger.info(f"Capturing logs from {len(container_names)} containers: {container_names}")
+
+    # Capture logs for each container
+    for container_name in container_names:
+        log_file = artifact_dir / "artifacts" / f"{pod_name}-{container_name}.log"
+        shell.run(
+            f"oc logs {pod_name} -n {namespace} -c {container_name}",
+            stdout_dest=log_file,
+            check=False,
+        )
+        logger.debug(f"Captured logs for container '{container_name}' to {log_file}")
+
+    # Also capture logs from init containers if any
+    result = shell.run(
+        f"oc get pod {pod_name} -n {namespace} -o jsonpath='{{.spec.initContainers[*].name}}'",
+        check=False,
+    )
+
+    if not result.success or not result.stdout.strip():
+        return
+
+    init_container_names = result.stdout.strip().split()
+    logger.info(
+        f"Capturing logs from {len(init_container_names)} init containers: {init_container_names}"
+    )
+
+    for container_name in init_container_names:
+        log_file = artifact_dir / "artifacts" / f"{pod_name}-init-{container_name}.log"
+        shell.run(
+            f"oc logs {pod_name} -n {namespace} -c {container_name}",
+            stdout_dest=log_file,
+            check=False,
+        )
+        logger.debug(f"Captured init container logs for '{container_name}' to {log_file}")
+
+
 def run(
     build_name: str,
     *,
@@ -150,12 +206,8 @@ def wait_for_completion(args, ctx):
             stdout_dest=args.artifact_dir / "artifacts" / f"{ctx.buildrun_name}-final-status.yaml",
         )
 
-        # Get build logs for debugging
-        shell.run(
-            f"oc logs {ctx.buildrun_name} -n {args.namespace}",
-            stdout_dest=args.artifact_dir / "artifacts" / f"{ctx.buildrun_name}-build.log",
-            check=False,
-        )
+        # Capture logs from all containers in the build pod
+        _capture_all_container_logs(ctx.buildrun_name, args.namespace, args.artifact_dir)
 
         if status == "false":
             # Get failure reason

--- a/projects/core/ci_entrypoint/run_ci.py
+++ b/projects/core/ci_entrypoint/run_ci.py
@@ -159,6 +159,8 @@ def prepare():
     if os.isatty(sys.stdin.fileno()):
         # not working very well from a TTY ...
         logger.info("Running from a TTY, not enabling the dual output")
+    elif (Path(os.environ["ARTIFACT_DIR"]) / "run.log").exists():
+        logger.info("run.log file already exists, not enabling the dual output")
     else:
         # Set up dual output as early as possible
         prepare_ci.setup_dual_output()

--- a/projects/core/ci_entrypoint/run_ci.py
+++ b/projects/core/ci_entrypoint/run_ci.py
@@ -422,7 +422,8 @@ def execute_project_operation(
         sys.exit(1)
 
     # Prepare command - don't pass operation as it's just the script name
-    cmd = [sys.executable, str(ci_script)] + click_args
+
+    cmd = [sys.executable, str(ci_script)] + list(args)
 
     if verbose or dry_run:
         click.echo("\n🔧 Execution Details:")

--- a/projects/core/ci_entrypoint/run_ci.py
+++ b/projects/core/ci_entrypoint/run_ci.py
@@ -54,10 +54,7 @@ def signal_handler_sigint(sig, frame):
     print("\n🚫 Received SIGINT (Ctrl+C) - Interrupting CI operation...")
 
     # Emergency cleanup of dual output
-    try:
-        prepare_ci.shutdown_dual_output()
-    except Exception:
-        pass  # Don't let cleanup errors prevent signal handling
+    prepare_ci.shutdown_dual_output()
 
     sys.exit(130)  # Standard exit code for SIGINT
 
@@ -67,10 +64,7 @@ def signal_handler_sigterm(sig, frame):
     print("\n🛑 Received SIGTERM - Terminating CI operation...")
 
     # Emergency cleanup of dual output
-    try:
-        prepare_ci.shutdown_dual_output()
-    except Exception:
-        pass  # Don't let cleanup errors prevent signal handling
+    prepare_ci.shutdown_dual_output()
 
     sys.exit(143)  # Standard exit code for SIGTERM
 

--- a/projects/core/ci_entrypoint/run_ci.py
+++ b/projects/core/ci_entrypoint/run_ci.py
@@ -399,7 +399,7 @@ def execute_project_operation(
     # Find CI script
     ci_script = find_ci_script(project_dir, operation)
     if not ci_script:
-        script_path = project_dir / "orchestration" / f"{operation}.py"
+        script_path = project_dir.relative_to(FORGE_HOME) / "orchestration" / f"{operation}.py"
 
         if script_path.exists():
             click.echo(
@@ -413,14 +413,13 @@ def execute_project_operation(
         else:
             click.echo(
                 click.style(
-                    f"❌ ERROR: No CI script found for project '{project}' operation '{operation}'.",
+                    f"❌ ERROR: No CI script '{script_path}' found for project '{project}' operation '{operation}'.",
                     fg="red",
                 ),
                 err=True,
             )
             click.echo(f"🔍 Expected: {script_path}")
         sys.exit(1)
-
 
     # Prepare command - don't pass operation as it's just the script name
     cmd = [sys.executable, str(ci_script)] + click_args

--- a/projects/core/ci_entrypoint/run_ci.py
+++ b/projects/core/ci_entrypoint/run_ci.py
@@ -421,8 +421,6 @@ def execute_project_operation(
             click.echo(f"🔍 Expected: {script_path}")
         sys.exit(1)
 
-    # Convert underscores to hyphens in args for Click compatibility
-    click_args = [arg.replace("_", "-") for arg in args]
 
     # Prepare command - don't pass operation as it's just the script name
     cmd = [sys.executable, str(ci_script)] + click_args
@@ -432,9 +430,6 @@ def execute_project_operation(
         click.echo(f"   Command: {' '.join(cmd)}")
         click.echo(f"   Working Directory: {Path.cwd()}")
         click.echo(f"   Script: {ci_script}")
-        if any("_" in arg for arg in args):
-            converted_args = [f"'{arg}' -> '{arg.replace('_', '-')}'" for arg in args if "_" in arg]
-            click.echo(f"   Note: Converted underscores to hyphens: {', '.join(converted_args)}")
 
     if dry_run:
         click.echo("\n🧪 DRY RUN: Would execute the above command")

--- a/projects/foreign_testing/orchestration/ci.py
+++ b/projects/foreign_testing/orchestration/ci.py
@@ -30,7 +30,8 @@ def main(ctx):
 def submit(ctx):
     """Launch a foreign test."""
     project_path = foreign_testing.prepare()
-
+    if not project_path.exists():
+        raise ValueError(f"Received a project path that doesn't exist: {project_path}")
     return foreign_testing.submit(project_path)
 
 

--- a/projects/foreign_testing/orchestration/cli.py
+++ b/projects/foreign_testing/orchestration/cli.py
@@ -4,6 +4,7 @@ Foreign Testing Project CLI Operations
 """
 
 import logging
+import pathlib
 import types
 
 import click
@@ -23,12 +24,17 @@ def main(ctx):
 
 
 @main.command()
+@click.option(
+    "--project-path",
+    type=click.Path(exists=True, file_okay=False, path_type=pathlib.Path),
+    help="Path to the project source directory",
+)
 @click.pass_context
 @safe_cli_command
-def submit(ctx):
+def submit(ctx, project_path):
     """Launch a foreign test."""
 
-    return foreign_testing.submit()
+    return foreign_testing.submit(project_path=project_path)
 
 
 if __name__ == "__main__":

--- a/projects/foreign_testing/orchestration/config.yaml
+++ b/projects/foreign_testing/orchestration/config.yaml
@@ -4,3 +4,8 @@ foreign_testing:
   openshift-psap/fournos:
     project_mappings:
       fournos_deploy: tests/forge/deploy
+    launch:
+      project: fournos_deploy
+      operation: ci
+      args:
+      - deploy

--- a/projects/foreign_testing/orchestration/foreign_testing.py
+++ b/projects/foreign_testing/orchestration/foreign_testing.py
@@ -15,16 +15,14 @@ def init():
     config.init(pathlib.Path(__file__).parent)
 
 
-def prepare():
-    foreign_repo_id = os.environ.get("PSAP_FORGE_FOREIGN_TESTING")
-    repo_owner = os.environ.get("REPO_OWNER")
-    repo_name = os.environ.get("REPO_NAME")
-    pull_pull_sha = os.environ.get("PULL_PULL_SHA")
-
+def get_project_config(foreign_repo_id=None):
     if not foreign_repo_id:
-        raise ValueError(
-            "PSAP_FORGE_FOREIGN_TESTING must be set (and point to `foreign_testing.$NAME` field)"
-        )
+        foreign_repo_id = os.environ.get("PSAP_FORGE_FOREIGN_TESTING")
+
+        if not foreign_repo_id:
+            raise ValueError(
+                "PSAP_FORGE_FOREIGN_TESTING must be set (and point to `foreign_testing.$NAME` field)"
+            )
 
     foreign_repo_configs = config.project.get_config("foreign_testing")
     foreign_repo_config = foreign_repo_configs.get(foreign_repo_id, None)
@@ -32,6 +30,16 @@ def prepare():
         raise ValueError(
             f"PSAP_FORGE_FOREIGN_TESTING must point to `foreign_testing.{foreign_repo_id}` field"
         )
+
+    return foreign_repo_config
+
+
+def prepare():
+    foreign_repo_config = get_project_config()
+
+    repo_owner = os.environ.get("REPO_OWNER")
+    repo_name = os.environ.get("REPO_NAME")
+    pull_pull_sha = os.environ.get("PULL_PULL_SHA")
 
     repo_dest = env.FORGE_HOME / "foreign_testing" / repo_name
     run.run(f'git clone "https://github.com/{repo_owner}/{repo_name}" "{repo_dest}"')
@@ -67,19 +75,24 @@ def submit(project_path=None):
         project_path: Path to the project source directory (will be passed as --project-source)
     """
     # Build the command arguments
-    args = ["deploy"]
+    foreign_repo_config = get_project_config()
 
+    project = foreign_repo_config["launch"]["project"]
+    operation = foreign_repo_config["launch"]["operation"]
+    config_args = foreign_repo_config["launch"]["args"]
+
+    launch_args = list(config_args)
 
     if project_path:
         if not project_path.exists():
             raise ValueError(f"Received a project path that doesn't exist: {project_path}")
-        args = [*["--project-source", str(project_path)], *args]
-        logger.info(f"Submitting deployment with args: {args}")
+        launch_args = [*["--project-source", str(project_path)], *launch_args]
+        logger.info(f"Submitting deployment with args: {launch_args}")
 
     run_ci.execute_project_operation(
-        "fournos_deploy",
-        "ci",
-        args,
+        project,
+        operation,
+        launch_args,
         do_prepare_ci=False,
         verbose=True,
     )

--- a/projects/foreign_testing/orchestration/foreign_testing.py
+++ b/projects/foreign_testing/orchestration/foreign_testing.py
@@ -69,7 +69,10 @@ def submit(project_path=None):
     # Build the command arguments
     args = ["deploy"]
 
+
     if project_path:
+        if not project_path.exists():
+            raise ValueError(f"Received a project path that doesn't exist: {project_path}")
         args = [*["--project-source", str(project_path)], *args]
         logger.info(f"Submitting deployment with args: {args}")
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI `submit` gains optional --project-path to specify a project location.
  * Added configurable launch settings for foreign testing (project/operation/args).

* **Bug Fixes**
  * Build artifact capture now saves separate logs per container and init-container.
  * Submission now validates that the provided project path exists and errors if missing.

* **Behavior Changes**
  * Command-line args are passed through unchanged; signal/dual-output shutdown and CI script error reporting adjusted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->