### PR TITLE
[fournos_launcher] Add the ability to abort the fjob

### DIFF
--- a/projects/core/ci_entrypoint/run_ci.py
+++ b/projects/core/ci_entrypoint/run_ci.py
@@ -48,10 +48,21 @@ FORGE_HOME = Path(__file__).resolve().parent.parent.parent.parent
 
 EXTRA_PACKAGES = []
 
+# Global reference to child process for signal forwarding
+_child_process = None
+
 
 def signal_handler_sigint(sig, frame):
     """Handle SIGINT (Ctrl+C) gracefully."""
-    print("\n🚫 Received SIGINT (Ctrl+C) - Interrupting CI operation...")
+    logger.info("🚫 Received SIGINT (Ctrl+C) - Interrupting CI operation...")
+
+    # Forward signal to child process first
+    if _child_process and _child_process.poll() is None:  # Child is still running
+        logger.info("📡 Forwarding SIGINT to child process...")
+        try:
+            _child_process.send_signal(signal.SIGINT)
+        except (OSError, ProcessLookupError):
+            pass  # Child may have already terminated
 
     # Emergency cleanup of dual output
     prepare_ci.shutdown_dual_output()
@@ -61,7 +72,15 @@ def signal_handler_sigint(sig, frame):
 
 def signal_handler_sigterm(sig, frame):
     """Handle SIGTERM gracefully."""
-    print("\n🛑 Received SIGTERM - Terminating CI operation...")
+    logger.info("🛑 Received SIGTERM - Terminating CI operation...")
+
+    # Forward signal to child process first
+    if _child_process and _child_process.poll() is None:  # Child is still running
+        logger.info("📡 Forwarding SIGTERM to child process...")
+        try:
+            _child_process.send_signal(signal.SIGTERM)
+        except (OSError, ProcessLookupError):
+            pass  # Child may have already terminated
 
     # Emergency cleanup of dual output
     prepare_ci.shutdown_dual_output()
@@ -148,9 +167,6 @@ def install_extra_packages(packages):
 
 def prepare():
     setup_logging()
-
-    # Set up signal handlers for graceful interruption
-    setup_signal_handlers()
 
     # Install click package using uv (as non-root user)
     install_extra_packages(EXTRA_PACKAGES)
@@ -443,13 +459,27 @@ def execute_project_operation(
         # Track start time for duration calculation
         start_time = time.time()
 
-        result = subprocess.run(
+        # Set up signal handlers for graceful interruption (safe to call multiple times)
+        setup_signal_handlers()
+
+        # Use Popen to get access to process object for signal forwarding
+        global _child_process
+        _child_process = subprocess.Popen(
             cmd,
-            check=False,  # Don't raise exception on non-zero exit
             stdin=None,  # Inherit stdin for pdb/debugging
             stdout=None,  # Inherit stdout for pdb/debugging
             stderr=None,  # Inherit stderr for pdb/debugging
         )
+
+        # Wait for process to complete
+        result_code = _child_process.wait()
+
+        # Create result object similar to subprocess.run()
+        class Result:
+            def __init__(self, returncode):
+                self.returncode = returncode
+
+        result = Result(result_code)
         click.echo()
         click.echo(
             f"▶️  Execution of {project} {operation} {' '.join(args)} returned {result.returncode}"

--- a/projects/core/dsl/runtime.py
+++ b/projects/core/dsl/runtime.py
@@ -105,6 +105,7 @@ def execute_tasks(function_args: dict = None):
             # Generate metadata files
             _generate_execution_metadata(function_args, caller_frame, meta_dir)
             _generate_restart_script(function_args, caller_frame, meta_dir)
+            _generate_env_file(meta_dir)
 
             # Execute tasks only from the calling file
             script_manager = get_script_manager()
@@ -334,6 +335,17 @@ def _generate_execution_metadata(function_args: dict, caller_frame, meta_dir):
         yaml.dump(metadata, f, default_flow_style=False, sort_keys=False)
 
     logger.debug(f"Generated execution metadata: {metadata_file}")
+
+
+def _generate_env_file(meta_dir):
+    """Generate a file with environment variables as key/value pairs"""
+    env_file = meta_dir / "env.txt"
+
+    with open(env_file, "w") as f:
+        for key, value in sorted(os.environ.items()):
+            f.write(f"{key}={value}\n")
+
+    logger.debug(f"Generated environment file: {env_file}")
 
 
 def _setup_execution_logging(artifact_dir):

--- a/projects/core/library/env.py
+++ b/projects/core/library/env.py
@@ -3,6 +3,7 @@ import pathlib
 import time
 
 ARTIFACT_DIR = None
+BASE_ARTIFACT_DIR = None  # Immutable copy of the initial ARTIFACT_DIR
 FORGE_HOME = pathlib.Path(__file__).parents[3]
 
 
@@ -11,8 +12,16 @@ def _set_artifact_dir(value):
     ARTIFACT_DIR = value
 
 
-def init(daily_artifact_dir=False):
+def reset_artifact_dir():
+    """Reset ARTIFACT_DIR to its original BASE_ARTIFACT_DIR value."""
     global ARTIFACT_DIR
+    if BASE_ARTIFACT_DIR is not None:
+        ARTIFACT_DIR = BASE_ARTIFACT_DIR
+        os.environ["ARTIFACT_DIR"] = str(BASE_ARTIFACT_DIR)
+
+
+def init(daily_artifact_dir=False):
+    global ARTIFACT_DIR, BASE_ARTIFACT_DIR
     if "ARTIFACT_DIR" in os.environ:
         artifact_dir = pathlib.Path(os.environ["ARTIFACT_DIR"])
 
@@ -25,6 +34,12 @@ def init(daily_artifact_dir=False):
         os.environ["ARTIFACT_DIR"] = str(artifact_dir)
 
     artifact_dir.mkdir(parents=True, exist_ok=True)
+
+    # Set BASE_ARTIFACT_DIR to the initial value (immutable)
+    if BASE_ARTIFACT_DIR is None:
+        BASE_ARTIFACT_DIR = artifact_dir
+        # Also expose it as an environment variable
+        os.environ["FORGE_BASE_ARTIFACT_DIR"] = str(BASE_ARTIFACT_DIR)
 
     _set_artifact_dir(artifact_dir)
 

--- a/projects/core/library/env.py
+++ b/projects/core/library/env.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import pathlib
 import time
@@ -22,6 +23,14 @@ def reset_artifact_dir():
 
 def init(daily_artifact_dir=False):
     global ARTIFACT_DIR, BASE_ARTIFACT_DIR
+
+    # Configure global logging to show INFO level messages
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(levelname)s: %(message)s",
+        force=True,  # Override any existing basicConfig
+    )
+
     if "ARTIFACT_DIR" in os.environ:
         artifact_dir = pathlib.Path(os.environ["ARTIFACT_DIR"])
 

--- a/projects/fournos_launcher/orchestration/ci.py
+++ b/projects/fournos_launcher/orchestration/ci.py
@@ -10,6 +10,7 @@ import types
 
 import click
 
+from projects.core.ci_entrypoint.prepare_ci import CI_METADATA_DIRNAME
 from projects.core.library import ci as ci_lib
 from projects.core.library import config, env
 from projects.fournos_launcher.orchestration import submit as submit_mod
@@ -24,7 +25,7 @@ def _set_job_owner_from_pull_request():
 
     Checks for pull_request.json file and extracts user.login to set as fournos.job.owner
     """
-    pull_request_file = env.ARTIFACT_DIR / "000__ci_metadata" / "pull_request.json"
+    pull_request_file = env.ARTIFACT_DIR / CI_METADATA_DIRNAME / "pull_request.json"
 
     # Guard: Check if file exists
     if not pull_request_file.exists():

--- a/projects/fournos_launcher/orchestration/ci.py
+++ b/projects/fournos_launcher/orchestration/ci.py
@@ -13,8 +13,8 @@ import click
 from projects.core.ci_entrypoint.prepare_ci import CI_METADATA_DIRNAME
 from projects.core.library import ci as ci_lib
 from projects.core.library import config, env
+from projects.fournos_launcher.orchestration import job_management, utils
 from projects.fournos_launcher.orchestration import submit as submit_mod
-from projects.fournos_launcher.orchestration import utils
 
 logger = logging.getLogger(__name__)
 
@@ -62,6 +62,12 @@ def main(ctx):
 
     # Set job owner from pull request metadata if available
     _set_job_owner_from_pull_request()
+
+    # Set CI job label for tracking and cancellation
+    ci_label = job_management.generate_ci_job_label()
+    if ci_label:
+        config.project.set_config("fournos.job.ci_label", ci_label)
+        logger.info(f"Set CI job label: {ci_label}")
 
 
 @main.command()

--- a/projects/fournos_launcher/orchestration/cli.py
+++ b/projects/fournos_launcher/orchestration/cli.py
@@ -11,6 +11,7 @@ import click
 
 from projects.core.library import config
 from projects.core.library.cli import safe_cli_command
+from projects.fournos_launcher.orchestration import job_management
 from projects.fournos_launcher.orchestration import submit as submit_mod
 
 logger = logging.getLogger(__name__)
@@ -90,6 +91,15 @@ def submit(ctx, cluster, project, args, namespace, override, commit):
         logger.info(f"Using commit SHA {commit}")
 
     return submit_mod.submit_job()
+
+
+@main.command()
+@click.pass_context
+@safe_cli_command
+def shutdown_jobs(ctx):
+    """Shutdown any running FournosJobs for this CI run."""
+    job_management.shutdown_fjobs_on_interrupt()
+    return 0
 
 
 if __name__ == "__main__":

--- a/projects/fournos_launcher/orchestration/config.yaml
+++ b/projects/fournos_launcher/orchestration/config.yaml
@@ -21,7 +21,10 @@ fournos:
     owner: "FORGE/fournos-launcher" # updated to the PR owner if available
     display_name: null # will be set to the job project/args if null
     pipeline_name: forge-test-only
+    ci_label: null # will be generated from the CI job UID
     env:
       OPENSHIFT_CI_job: [JOB_TYPE, JOB_NAME, JOB_SPEC, OPENSHIFT_CI, JOB_NAME_SAFE, BUILD_ID]
       OPENSHIFT_CI_git_pr: [PULL_PULL_SHA, PULL_NUMBER, PULL_BASE_REF, REPO_NAME, REPO_OWNER, PULL_BASE_SHA, JOB_NAME, PULL_TITLE, PULL_REFS, PULL_HEAD_REF]
     extra_env: {}
+  on_abort:
+    shutdown_value: Stop  # Value to set for spec.shutdown when aborting jobs (Stop or Terminate)

--- a/projects/fournos_launcher/orchestration/job_management.py
+++ b/projects/fournos_launcher/orchestration/job_management.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""
+FOURNOS job management utilities
+
+Functions for labeling, tracking, and shutting down FournosJobs
+"""
+
+import logging
+import os
+
+from projects.core.library import config
+
+logger = logging.getLogger(__name__)
+
+
+def generate_ci_job_label():
+    """
+    Generate a unique label for CI job based on PR and build information.
+
+    Returns a label in format: pr{PULL_NUMBER}_b{BUILD_ID}
+    If environment variables are not available, returns None.
+    """
+    pull_number = os.environ.get("PULL_NUMBER")
+    build_id = os.environ.get("BUILD_ID")
+
+    if pull_number and build_id:
+        return f"pr{pull_number}_b{build_id}"
+    elif pull_number:
+        # Fallback to just PR number if BUILD_ID is not available
+        return f"pr{pull_number}"
+
+    logger.warning("Unable to generate CI job label - PULL_NUMBER or BUILD_ID not available")
+    return None
+
+
+def shutdown_running_fjobs():
+    """
+    Gracefully shutdown all running FournosJobs that match the current CI run.
+
+    This function uses the shutdown_fjobs toolbox to find and shutdown jobs.
+    """
+    ci_label = generate_ci_job_label()
+    if not ci_label:
+        logger.warning("Cannot shutdown fjobs - no CI label available")
+        return
+
+    # Get namespace from config, fallback to default
+    namespace = config.project.get_config("fournos.namespace")
+
+    # Get shutdown value from config
+    shutdown_value = config.project.get_config("fournos.on_abort.shutdown_value")
+
+    logger.info(f"Shutting down FournosJobs with CI label '{ci_label}' in namespace '{namespace}'")
+
+    try:
+        # Use the shutdown_fjobs toolbox for the actual shutdown work
+        from projects.fournos_launcher.toolbox.shutdown_fjobs.main import run as shutdown_toolbox
+
+        result = shutdown_toolbox(
+            namespace=namespace,
+            ci_label=ci_label,
+            job_name=None,
+            all_jobs=False,
+            shutdown_value=shutdown_value,
+        )
+
+        logger.info("Shutdown operation completed via toolbox")
+        return result
+
+    except Exception as e:
+        logger.error(f"Exception while shutting down FournosJobs: {e}")
+
+
+def shutdown_fjobs_on_interrupt():
+    """
+    Entry point for shutting down FournosJobs when the process is interrupted.
+    This function should be called by signal handlers.
+    """
+    try:
+        logger.info("🚫 Process interrupted - shutting down running FournosJobs...")
+        shutdown_running_fjobs()
+    except Exception as e:
+        logger.error(f"Failed to shutdown FournosJobs: {e}")

--- a/projects/fournos_launcher/orchestration/submit.py
+++ b/projects/fournos_launcher/orchestration/submit.py
@@ -96,8 +96,15 @@ def submit_job():
     config.project.set_config("fournos.job.display_name", display_name)
     logger.info(f"Set job display name: {display_name}")
 
+    # Validate required configuration before job submission
+    cluster_name = config.project.get_config("cluster.name")
+    if not cluster_name:
+        raise ValueError(
+            "cluster.name must be configured in config.yaml - cannot submit job without target cluster"
+        )
+
     submit_and_wait(
-        cluster_name=config.project.get_config("cluster.name"),
+        cluster_name=cluster_name,
         project=config.project.get_config("ci_job.project"),
         args=config.project.get_config("ci_job.args"),
         variables_overrides=overrides,

--- a/projects/fournos_launcher/orchestration/submit.py
+++ b/projects/fournos_launcher/orchestration/submit.py
@@ -1,13 +1,48 @@
 import logging
 import os
 import pathlib
+import signal
 
 from projects.core.library import config, env, run, vault
+from projects.fournos_launcher.orchestration import job_management
 from projects.fournos_launcher.toolbox.submit_and_wait.main import (
     run as submit_and_wait,
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _signal_handler_sigint(sig, frame):
+    """Handle SIGINT (Ctrl+C) for FOURNOS launcher."""
+    print("\n🚫 FOURNOS launcher received SIGINT - shutting down jobs...")
+    env.reset_artifact_dir()
+    job_management.shutdown_fjobs_on_interrupt()
+    # Don't call sys.exit here - let the original handler handle it
+
+
+def _signal_handler_sigterm(sig, frame):
+    """Handle SIGTERM for FOURNOS launcher."""
+    print("\n🛑 FOURNOS launcher received SIGTERM - shutting down jobs...")
+    env.reset_artifact_dir()
+    job_management.shutdown_fjobs_on_interrupt()
+    # Don't call sys.exit here - let the original handler handle it
+
+
+def _setup_signal_handlers():
+    """Set up signal handlers for FOURNOS job shutdown."""
+    try:
+        # Store original handlers
+        original_sigint = signal.signal(signal.SIGINT, _signal_handler_sigint)
+        original_sigterm = signal.signal(signal.SIGTERM, _signal_handler_sigterm)
+
+        logger.debug("FOURNOS signal handlers installed")
+
+        # Store references so we can restore them if needed
+        _setup_signal_handlers._original_sigint = original_sigint
+        _setup_signal_handlers._original_sigterm = original_sigterm
+
+    except Exception as e:
+        logger.warning(f"Failed to set up FOURNOS signal handlers: {e}")
 
 
 def init():
@@ -31,6 +66,9 @@ def prepare_env():
 
 
 def submit_job():
+    # Set up signal handlers for graceful job shutdown on interruption
+    _setup_signal_handlers()
+
     overrides = {}
     overrides.update(config.project.get_config("overrides"))
     overrides.update(config.project.get_config("extra_overrides"))
@@ -69,6 +107,7 @@ def submit_job():
         pipeline_name=config.project.get_config("fournos.job.pipeline_name"),
         env=env_dict,
         status_dest=env.ARTIFACT_DIR,
+        ci_label=config.project.get_config("fournos.job.ci_label"),
     )
 
     return 0

--- a/projects/fournos_launcher/toolbox/shutdown_fjobs/README.md
+++ b/projects/fournos_launcher/toolbox/shutdown_fjobs/README.md
@@ -1,0 +1,74 @@
+# FournosJob Shutdown Toolbox
+
+This toolbox provides graceful shutdown functionality for FournosJobs by setting `spec.shutdown=Stop`.
+
+## Features
+
+- **Graceful Shutdown**: Uses `spec.shutdown=Stop` for clean job termination
+- **Flexible Targeting**: Shutdown jobs by CI label, specific job name, or all jobs
+- **Auto-detection**: Automatically generates CI labels from environment variables
+- **Safety Checks**: Validation and confirmation for dangerous operations
+- **Status Capture**: Saves job status after shutdown for debugging
+
+## Usage
+
+### Basic Usage (Auto-detect CI label)
+
+```bash
+# Shutdown jobs for current CI run (uses PULL_NUMBER and BUILD_ID from env)
+./main.py
+```
+
+### Advanced Usage
+
+```bash
+# Shutdown jobs for specific CI run
+./main.py --ci-label pr123_b456
+
+# Shutdown specific job
+./main.py --job-name forge-llm-d-20241203-143022
+
+# Shutdown ALL jobs in namespace (use with caution!)
+./main.py --all-jobs
+
+# Use different namespace
+./main.py --namespace my-fournos-jobs
+```
+
+## How It Works
+
+1. **Target Selection**: Identifies which FournosJobs to shutdown based on provided criteria
+2. **Validation**: Ensures valid inputs and confirms dangerous operations
+3. **Graceful Shutdown**: Sets `spec.shutdown=Stop` for each target job
+4. **Status Capture**: Saves final job status to artifacts directory for review
+
+## Signal Handler Integration
+
+The FOURNOS launcher automatically sets up signal handlers that call this shutdown functionality when the process is interrupted:
+
+- **SIGINT (Ctrl+C)**: Triggers graceful shutdown of current CI run's jobs
+- **SIGTERM**: Triggers graceful shutdown of current CI run's jobs
+
+## Environment Variables
+
+- `PULL_NUMBER`: Used to generate CI label (format: `pr{PULL_NUMBER}`)
+- `BUILD_ID`: Combined with PULL_NUMBER (format: `pr{PULL_NUMBER}_b{BUILD_ID}`)
+
+## Output
+
+The toolbox creates artifacts in the `artifacts/` directory:
+- `{job-name}-shutdown-status.yaml`: Final status of each shutdown job
+
+## Safety Features
+
+- **Input validation**: Prevents invalid parameter combinations
+- **Confirmation logging**: Shows which jobs will be shutdown before proceeding
+- **Error handling**: Continues shutdown process even if individual jobs fail
+- **Status reporting**: Provides summary of successful vs failed shutdowns
+
+## Comparison: shutdown vs aborted
+
+- **`spec.shutdown=Stop`**: Graceful shutdown - allows jobs to clean up properly
+- **`spec.aborted=true`**: Immediate cancellation - forces jobs to stop abruptly
+
+This toolbox uses the graceful shutdown approach for better resource cleanup.

--- a/projects/fournos_launcher/toolbox/shutdown_fjobs/main.py
+++ b/projects/fournos_launcher/toolbox/shutdown_fjobs/main.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+
+"""
+FOURNOS job shutdown toolbox using DSL
+
+Gracefully shutdown FournosJobs by setting spec.shutdown=Stop
+"""
+
+import logging
+import shlex
+
+from projects.core.dsl import (
+    execute_tasks,
+    shell,
+    task,
+    toolbox,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def run(
+    namespace: str = "psap-automation",
+    ci_label: str = None,
+    job_name: str = None,
+    all_jobs: bool = False,
+    shutdown_value: str = "Stop",
+):
+    """
+    Shutdown FournosJobs by setting spec.shutdown to a configurable value
+
+    Args:
+        namespace: Kubernetes namespace where FournosJobs are located (default: "psap-automation")
+        ci_label: CI run label to filter jobs (e.g., "pr123_b456"). If not provided, will try to generate from env vars.
+        job_name: Specific job name to shutdown (takes precedence over ci_label)
+        all_jobs: Shutdown all FournosJobs in the namespace (dangerous - use with caution)
+        shutdown_value: Value to set for spec.shutdown (default: "Stop")
+
+    Examples:
+        # Shutdown jobs for current CI run (auto-detect from env vars):
+        run()
+
+        # Shutdown jobs for specific CI run:
+        run(ci_label="pr123_b456")
+
+        # Shutdown specific job:
+        run(job_name="forge-llm-d-20241203-143022")
+
+        # Shutdown all jobs in namespace (use with caution):
+        run(all_jobs=True)
+
+        # Shutdown with custom shutdown value:
+        run(ci_label="pr123_b456", shutdown_value="Terminate")
+    """
+    # Execute all registered tasks in order
+    return execute_tasks(locals())
+
+
+@task
+def validate_inputs(args, ctx):
+    """Validate input parameters"""
+
+    if not args.namespace:
+        raise ValueError("namespace is required")
+
+    # Check that we have some way to identify which jobs to shutdown
+    if not any([args.ci_label, args.job_name, args.all_jobs]):
+        raise ValueError("Must specify one of: ci_label, job_name, or all_jobs=True. ")
+
+    if args.all_jobs and (args.ci_label or args.job_name):
+        raise ValueError("Cannot use all_jobs=True together with ci_label or job_name")
+
+    SHUTDOWN_VALUES = ("Stop", "Terminate")
+    if args.shutdown_value not in SHUTDOWN_VALUES:
+        raise ValueError(
+            f"Shutdown value ({args.shutdown_value}) not in the allowed values ({', '.join(SHUTDOWN_VALUES)})"
+        )
+
+    return "Inputs validated"
+
+
+@task
+def ensure_oc(args, ctx):
+    """Ensure oc is available and connected"""
+
+    shell.run("which oc || (echo 'oc not found in PATH' && exit 1)")
+    shell.run("oc whoami")
+
+
+@task
+def find_target_jobs(args, ctx):
+    """Find FournosJobs to shutdown"""
+
+    if args.job_name:
+        # Shutdown specific job
+        ctx.target_selector = f"metadata.name={args.job_name}"
+        ctx.description = f"job '{args.job_name}'"
+
+    elif args.ci_label:
+        # Shutdown jobs with CI label
+        ctx.target_selector = f"ci-run={args.ci_label}"
+        ctx.description = f"jobs with CI label '{args.ci_label}'"
+
+    elif args.all_jobs:
+        # Shutdown all jobs (no selector)
+        ctx.target_selector = ""
+        ctx.description = "ALL jobs in namespace (dangerous!)"
+
+    # Get list of matching jobs
+    if ctx.target_selector and not ctx.target_selector.startswith("metadata.name="):
+        # Use label selector
+        cmd = f'oc get fournosjobs -n {args.namespace} -l "{ctx.target_selector}" -o jsonpath="{{.items[*].metadata.name}}"'
+    elif ctx.target_selector.startswith("metadata.name="):
+        # Specific job name
+        job_name = ctx.target_selector.replace("metadata.name=", "")
+        cmd = f'oc get fournosjobs -n {args.namespace} {job_name} -o jsonpath="{{.metadata.name}}"'
+    else:
+        # All jobs
+        cmd = f'oc get fournosjobs -n {args.namespace} -o jsonpath="{{.items[*].metadata.name}}"'
+
+    result = shell.run(cmd, check=False)
+
+    if not result.success:
+        if "not found" in result.stderr.lower():
+            ctx.job_names = []
+            return f"No FournosJobs found for {ctx.description}"
+        else:
+            raise RuntimeError(f"Failed to list FournosJobs: {result.stderr}")
+
+    job_names = result.stdout.strip().split() if result.stdout.strip() else []
+    ctx.job_names = job_names
+
+    if not job_names:
+        return f"No FournosJobs found for {ctx.description}"
+
+    return f"Found {len(job_names)} FournosJobs to shutdown: {', '.join(job_names)}"
+
+
+@task
+def confirm_shutdown(args, ctx):
+    """Confirm shutdown operation"""
+
+    if not ctx.job_names:
+        return "No jobs to shutdown - skipping confirmation"
+
+    if args.all_jobs:
+        logger.warning("⚠️  WARNING: You are about to shutdown ALL FournosJobs in the namespace!")
+        logger.warning(f"   Namespace: {args.namespace}")
+        logger.warning(f"   Jobs to shutdown: {', '.join(ctx.job_names)}")
+
+    logger.info(f"Will shutdown {len(ctx.job_names)} FournosJob(s): {', '.join(ctx.job_names)}")
+    logger.info(f"Method: Set spec.shutdown={args.shutdown_value} for shutdown")
+
+    return f"Ready to shutdown {len(ctx.job_names)} job(s)"
+
+
+@task
+def shutdown_jobs(args, ctx):
+    """Shutdown the FournosJobs by setting spec.shutdown to the configured value"""
+
+    if not ctx.job_names:
+        return "No jobs to shutdown"
+
+    successful_shutdowns = []
+    failed_shutdowns = []
+
+    for job_name in ctx.job_names:
+        try:
+            logger.info(f"Shutting down FournosJob: {job_name}")
+
+            # Set spec.shutdown to the configured value
+            patch_cmd = [
+                "oc",
+                "patch",
+                "fournosjob",
+                job_name,
+                "-n",
+                args.namespace,
+                "--type=merge",
+                "--patch",
+                f'{{"spec":{{"shutdown":"{args.shutdown_value}"}}}}',
+            ]
+
+            result = shell.run(shlex.join(patch_cmd), check=False)
+
+            if result.success:
+                successful_shutdowns.append(job_name)
+                logger.info(f"✅ Successfully shutdown FournosJob: {job_name}")
+            else:
+                failed_shutdowns.append(job_name)
+                logger.error(f"❌ Failed to shutdown FournosJob {job_name}: {result.stderr}")
+
+        except Exception as e:
+            failed_shutdowns.append(job_name)
+            logger.error(f"❌ Exception while shutting down FournosJob {job_name}: {e}")
+
+    # Summary
+    total_jobs = len(ctx.job_names)
+    success_count = len(successful_shutdowns)
+    fail_count = len(failed_shutdowns)
+
+    if fail_count > 0:
+        logger.warning(
+            f"Shutdown summary: {success_count}/{total_jobs} successful, {fail_count} failed"
+        )
+        logger.warning(f"Failed jobs: {', '.join(failed_shutdowns)}")
+    else:
+        logger.info(f"Shutdown summary: {success_count}/{total_jobs} successful")
+
+    return f"Shutdown complete: {success_count} successful, {fail_count} failed"
+
+
+@task
+def capture_final_status(args, ctx):
+    """Capture final status of shutdown jobs"""
+
+    if not ctx.job_names:
+        return "No jobs to capture status for"
+
+    # Create artifacts directory
+    shell.mkdir("artifacts")
+
+    for job_name in ctx.job_names:
+        # Get job status after shutdown
+        shell.run(
+            f"oc get fournosjob {job_name} -n {args.namespace} -o yaml",
+            stdout_dest=args.artifact_dir / "artifacts" / f"{job_name}-shutdown-status.yaml",
+            check=False,
+        )
+
+    return f"Captured status for {len(ctx.job_names)} jobs in artifacts/ directory"
+
+
+# Create the main function using the toolbox library
+main = toolbox.create_toolbox_main(run)
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/fournos_launcher/toolbox/submit_and_wait/main.py
+++ b/projects/fournos_launcher/toolbox/submit_and_wait/main.py
@@ -36,6 +36,7 @@ def run(
     pipeline_name: str = "",
     env: dict = None,
     status_dest=None,
+    ci_label: str = None,
 ):
     """
     Submit a FOURNOS job and wait for completion
@@ -52,6 +53,7 @@ def run(
         pipeline_name: Name of the pipeline to execute (default: empty)
         env: Dictionary of environment variables to set (default: empty dict)
         status_dest: Directory to save status information and pod logs (default: {artifact_dir}/artifacts)
+        ci_label: CI run label for tracking and cancellation (default: None)
 
     Examples:
         # Called by entrypoint with config values:
@@ -173,7 +175,6 @@ def wait_for_job_completion(args, ctx):
     status_result = shell.run(
         f'oc get fournosjob {ctx.final_job_name} -n {args.namespace} -o jsonpath="{{.status.phase}}"',
         check=False,
-        log_stdout=False,
     )
 
     if not status_result.success:
@@ -189,6 +190,21 @@ def wait_for_job_completion(args, ctx):
 
     status = status_result.stdout.strip()
 
+    # Check if shutdown has been requested
+    shutdown_result = shell.run(
+        f'oc get fournosjob {ctx.final_job_name} -n {args.namespace} -o jsonpath="{{.spec.shutdown}}"',
+        check=False,
+    )
+
+    if shutdown_result.success and shutdown_result.stdout.strip():
+        shutdown_value = shutdown_result.stdout.strip()
+        logger.warning(
+            f"Job {ctx.final_job_name} has spec.shutdown={shutdown_value} - aborting wait"
+        )
+        raise RuntimeError(
+            f"Job {ctx.final_job_name} shutdown requested: spec.shutdown={shutdown_value}"
+        )
+
     if status in ["Succeeded"]:
         return f"Job {ctx.final_job_name} completed successfully"
 
@@ -197,7 +213,6 @@ def wait_for_job_completion(args, ctx):
         failure_result = shell.run(
             f'oc get fournosjob {ctx.final_job_name} -n {args.namespace} -o jsonpath="{{.status.message}}"',
             check=False,
-            log_stdout=False,
         )
         failure_msg = failure_result.stdout.strip() if failure_result.success else "Unknown failure"
         raise RuntimeError(f"Job {ctx.final_job_name} failed: {failure_msg}")  # Abort on failure
@@ -213,6 +228,10 @@ def wait_for_job_completion(args, ctx):
 @task
 def capture_final_job_status(args, ctx):
     """Capture final job status and details"""
+    # Guard: Check if job name was generated (might not exist if early validation failed)
+    if not hasattr(ctx, "final_job_name"):
+        return "No job name available - skipping status capture"
+
     # Get full job details
     shell.run(
         f"oc get fournosjob {ctx.final_job_name} -n {args.namespace} -o yaml",
@@ -228,6 +247,10 @@ def capture_final_job_status(args, ctx):
 def capture_pod_information(args, ctx):
     """Capture pod status and logs for the FOURNOS job"""
 
+    # Guard: Check if job name was generated (might not exist if early validation failed)
+    if not hasattr(ctx, "final_job_name"):
+        return "No job name available - skipping pod information capture"
+
     # List all pods with the FOURNOS job label
     label_selector = f"fournos.dev/job-name={ctx.final_job_name}"
 
@@ -242,7 +265,6 @@ def capture_pod_information(args, ctx):
     pod_list_result = shell.run(
         f'oc get pods -l {label_selector} -n {args.namespace} -o jsonpath="{{.items[*].metadata.name}}"',
         check=False,
-        log_stdout=False,
     )
 
     if not (pod_list_result.success and pod_list_result.stdout.strip()):
@@ -269,11 +291,25 @@ def capture_pod_information(args, ctx):
 def cleanup_job(args, ctx):
     """Clean up the job object"""
 
+    # Guard: Check if job name was generated (might not exist if early validation failed)
+    if not hasattr(ctx, "final_job_name"):
+        return "No job name available - skipping job cleanup"
+
+    # Check if shutdown has been requested - if so, preserve the job to let it export its artifacts
+    shutdown_result = shell.run(
+        f'oc get fournosjob {ctx.final_job_name} -n {args.namespace} -o jsonpath="{{.spec.shutdown}}"',
+        check=False,
+    )
+
+    if shutdown_result.success and shutdown_result.stdout.strip():
+        shutdown_value = shutdown_result.stdout.strip()
+        return f"Job has spec.shutdown={shutdown_value} - preserving it to let it export its artifacts, skipping deletion"
+
     shell.run(
         f"oc delete fournosjob {ctx.final_job_name} -n {args.namespace} --ignore-not-found",
     )
 
-    return "No manifest file to clean up"
+    return "Job cleanup completed"
 
 
 # Create the main function using the toolbox library

--- a/projects/fournos_launcher/toolbox/submit_and_wait/templates/job.yaml.j2
+++ b/projects/fournos_launcher/toolbox/submit_and_wait/templates/job.yaml.j2
@@ -3,6 +3,10 @@ kind: FournosJob
 metadata:
   name: {{ ctx.final_job_name }}
   namespace: {{ args.namespace }}
+  {% if args.ci_label -%}
+  labels:
+    ci-run: {{ args.ci_label }}
+  {%- endif %}
 spec:
   owner: {{ args.owner }}
   displayName: {{ args.display_name }}

--- a/projects/skeleton/orchestration/config.yaml
+++ b/projects/skeleton/orchestration/config.yaml
@@ -10,3 +10,5 @@ skeleton:
     max_requests: 30
   extra_properties: {} # for the preset to give any extra property
   deep_testing: false
+  test:
+    duration_seconds: 30  # Default test duration in seconds

--- a/projects/skeleton/orchestration/presets.d/extended_test.yaml
+++ b/projects/skeleton/orchestration/presets.d/extended_test.yaml
@@ -1,0 +1,2 @@
+skeleton.test.duration_seconds: 300  # Run test for 5 minutes
+skeleton.collect_cluster_info: true      # Enable cluster info gathering for extended tests

--- a/projects/skeleton/orchestration/presets.d/presets.yaml
+++ b/projects/skeleton/orchestration/presets.d/presets.yaml
@@ -7,3 +7,9 @@ side_testing:
   skeleton.extra_properties:
     load_shape: round
     request_type: text_completions
+
+quick_test:
+  skeleton.test.duration_seconds: 10  # Quick 10 second test
+
+long_test:
+  skeleton.test.duration_seconds: 600  # Long 10 minute test

--- a/projects/skeleton/orchestration/test_skeleton.py
+++ b/projects/skeleton/orchestration/test_skeleton.py
@@ -1,5 +1,6 @@
 import logging
 import pathlib
+import time
 
 import yaml
 
@@ -18,6 +19,10 @@ def init(strict_vault_validation=True):
 
 def test():
     logger.info("=== Skeleton Project Test Phase ===")
+
+    # Get test duration configuration
+    test_duration = config.project.get_config("skeleton.test.duration_seconds")
+    logger.info(f"Test duration: {test_duration} seconds")
 
     if config.project.get_config("skeleton.deep_testing"):
         logger.warning("Running the (fake) deep testing ...")
@@ -41,6 +46,29 @@ def test():
     )
     logger.info("")
     logger.info(f"Fake test configuration:\n{yaml_cfg}")
+
+    # Run timed test loop
+    start_time = time.time()
+    test_iteration = 0
+
+    logger.info(f"Starting {test_duration}s test loop...")
+
+    while time.time() - start_time < test_duration:
+        test_iteration += 1
+        elapsed = time.time() - start_time
+        remaining = test_duration - elapsed
+
+        logger.info(
+            f"Test iteration {test_iteration} - Elapsed: {elapsed:.1f}s, Remaining: {remaining:.1f}s"
+        )
+
+        # Simulate some test work with explicit waiting message
+        wait_time = min(30.0, remaining)
+        logger.info(f"⏳ Waiting {wait_time:.1f}s before next iteration...")
+        time.sleep(wait_time)
+
+    elapsed_total = time.time() - start_time
+    logger.info(f"✅ Completed {test_iteration} test iterations in {elapsed_total:.1f}s")
 
     if not config.project.get_config("skeleton.collect_cluster_info"):
         logger.warning("⚠️ Cluster information gathering not enabled. Returning early.")

--- a/projects/skeleton/orchestration/test_skeleton.py
+++ b/projects/skeleton/orchestration/test_skeleton.py
@@ -1,5 +1,6 @@
 import logging
 import pathlib
+import signal
 import time
 
 import yaml
@@ -8,6 +9,28 @@ from projects.core.library import config, env, run, vault
 from projects.skeleton.toolbox.cluster_info.main import run as cluster_info
 
 logger = logging.getLogger(__name__)
+
+
+def _signal_handler_sigint(sig, frame):
+    """Sample SIGINT signal handler for skeleton project."""
+    env.reset_artifact_dir()
+    # Sample handler - does nothing else
+
+
+def _signal_handler_sigterm(sig, frame):
+    """Sample SIGTERM signal handler for skeleton project."""
+    env.reset_artifact_dir()
+    # Sample handler - does nothing else
+
+
+def _setup_sample_signal_handlers():
+    """Set up sample signal handlers for demonstration."""
+    try:
+        signal.signal(signal.SIGINT, _signal_handler_sigint)
+        signal.signal(signal.SIGTERM, _signal_handler_sigterm)
+        logger.debug("Sample signal handlers installed")
+    except Exception as e:
+        logger.warning(f"Failed to set up sample signal handlers: {e}")
 
 
 def init(strict_vault_validation=True):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Graceful job shutdown on SIGINT/SIGTERM with a new shutdown tool and CLI command
  * New CLI command to trigger job shutdowns for the current CI run
  * Jobs can be labeled with CI run identifiers for tracking and targeted shutdown
  * Job submissions now propagate CI labels and validate cluster name
* **Configuration**
  * Added config keys for CI job label and abort-time shutdown mode
* **Documentation**
  * Added shutdown toolbox README and usage examples
* **Tests**
  * Test duration made configurable with quick/long presets
<!-- end of auto-generated comment: release notes by coderabbit.ai -->