### PR TITLE
feat: Add config.d project configuration support

### DIFF
--- a/.github/workflows/test_toolbox_dsl.yml
+++ b/.github/workflows/test_toolbox_dsl.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           set -o errexit
           python -m pip install --upgrade pip
-          python -m pip install pytest pyyaml jinja2
+          python -m pip install pytest pyyaml jinja2 jsonpath_ng
 
       - name: Run projects/core/tests
         run: |

--- a/projects/core/library/config.py
+++ b/projects/core/library/config.py
@@ -335,12 +335,13 @@ class Config:
 def __get_config_path(orchestration_dir):
     config_file_src = orchestration_dir / "config.yaml"
     config_dir_src = orchestration_dir / "config.d"
+    config_chunk_files = _get_config_chunk_files(config_dir_src)
     config_path_final = pathlib.Path(env.ARTIFACT_DIR / "config.yaml")
 
-    if not config_file_src.exists() and not config_dir_src.exists():
+    if not config_file_src.exists() and not config_chunk_files:
         raise ValueError(
             f"Cannot find the source config file at {config_file_src} "
-            f"or config directory at {config_dir_src}"
+            f"or config YAML chunks under {config_dir_src}"
         )
 
     if config_path_final.exists():
@@ -350,9 +351,11 @@ def __get_config_path(orchestration_dir):
         f"Consolidating the configuration from {config_file_src} "
         f"and {config_dir_src} to the artifact dir ..."
     )
+    consolidated_config = _load_project_config(config_file_src, config_chunk_files)
+
     with open(config_path_final, "w") as config_f:
         yaml.safe_dump(
-            _load_project_config(orchestration_dir),
+            consolidated_config,
             config_f,
             indent=4,
             default_flow_style=False,
@@ -362,43 +365,35 @@ def __get_config_path(orchestration_dir):
     return config_path_final, config_file_src
 
 
-def _load_project_config(orchestration_dir):
-    config_file_src = orchestration_dir / "config.yaml"
-    config_dir_src = orchestration_dir / "config.d"
+def _get_config_chunk_files(config_dir_src):
+    if not config_dir_src.is_dir():
+        return []
 
+    return sorted(config_dir_src.glob("*.yaml"))
+
+
+def _load_project_config(config_file_src, config_chunk_files):
     config = {}
     if config_file_src.exists():
         with open(config_file_src) as config_f:
             config = yaml.safe_load(config_f) or {}
 
-    if not config_dir_src.exists():
+    if not config_chunk_files:
         return config
 
-    for chunk_file in sorted(config_dir_src.glob("*.yaml")):
+    for chunk_file in config_chunk_files:
         with open(chunk_file) as chunk_f:
             chunk_value = yaml.safe_load(chunk_f)
 
         key = chunk_file.stem
         if key in config:
-            config[key] = _merge_config_values(config[key], chunk_value)
-        else:
-            config[key] = chunk_value
+            raise ValueError(
+                f"Configuration section '{key}' is defined in both "
+                f"{config_file_src} and {chunk_file}"
+            )
+        config[key] = chunk_value
 
     return config
-
-
-def _merge_config_values(base_value, chunk_value):
-    if not isinstance(base_value, dict) or not isinstance(chunk_value, dict):
-        return copy.deepcopy(chunk_value)
-
-    merged = copy.deepcopy(base_value)
-    for key, value in chunk_value.items():
-        if key in merged:
-            merged[key] = _merge_config_values(merged[key], value)
-        else:
-            merged[key] = copy.deepcopy(value)
-
-    return merged
 
 
 REQUIRES_ANNOTATION_ARG_NAME = "_cfg"

--- a/projects/core/library/config.py
+++ b/projects/core/library/config.py
@@ -369,7 +369,7 @@ def _get_config_chunk_files(config_dir_src):
     if not config_dir_src.is_dir():
         return []
 
-    return sorted(config_dir_src.glob("*.yaml"))
+    return sorted([*config_dir_src.glob("*.yaml"), *config_dir_src.glob("*.yml")])
 
 
 def _load_project_config(config_file_src, config_chunk_files):

--- a/projects/core/library/config.py
+++ b/projects/core/library/config.py
@@ -5,7 +5,6 @@ import logging
 import os
 import pathlib
 import re
-import shutil
 import types
 
 import jsonpath_ng
@@ -335,18 +334,71 @@ class Config:
 
 def __get_config_path(orchestration_dir):
     config_file_src = orchestration_dir / "config.yaml"
+    config_dir_src = orchestration_dir / "config.d"
     config_path_final = pathlib.Path(env.ARTIFACT_DIR / "config.yaml")
 
-    if not config_file_src.exists():
-        raise ValueError(f"Cannot find the source config file at {config_file_src}")
+    if not config_file_src.exists() and not config_dir_src.exists():
+        raise ValueError(
+            f"Cannot find the source config file at {config_file_src} "
+            f"or config directory at {config_dir_src}"
+        )
 
     if config_path_final.exists():
         config_path_final.unlink()
 
-    logger.info(f"Copying the configuration from {config_file_src} to the artifact dir ...")
-    shutil.copyfile(config_file_src, config_path_final)
+    logger.info(
+        f"Consolidating the configuration from {config_file_src} "
+        f"and {config_dir_src} to the artifact dir ..."
+    )
+    with open(config_path_final, "w") as config_f:
+        yaml.safe_dump(
+            _load_project_config(orchestration_dir),
+            config_f,
+            indent=4,
+            default_flow_style=False,
+            sort_keys=False,
+        )
 
     return config_path_final, config_file_src
+
+
+def _load_project_config(orchestration_dir):
+    config_file_src = orchestration_dir / "config.yaml"
+    config_dir_src = orchestration_dir / "config.d"
+
+    config = {}
+    if config_file_src.exists():
+        with open(config_file_src) as config_f:
+            config = yaml.safe_load(config_f) or {}
+
+    if not config_dir_src.exists():
+        return config
+
+    for chunk_file in sorted(config_dir_src.glob("*.yaml")):
+        with open(chunk_file) as chunk_f:
+            chunk_value = yaml.safe_load(chunk_f)
+
+        key = chunk_file.stem
+        if key in config:
+            config[key] = _merge_config_values(config[key], chunk_value)
+        else:
+            config[key] = chunk_value
+
+    return config
+
+
+def _merge_config_values(base_value, chunk_value):
+    if not isinstance(base_value, dict) or not isinstance(chunk_value, dict):
+        return copy.deepcopy(chunk_value)
+
+    merged = copy.deepcopy(base_value)
+    for key, value in chunk_value.items():
+        if key in merged:
+            merged[key] = _merge_config_values(merged[key], value)
+        else:
+            merged[key] = copy.deepcopy(value)
+
+    return merged
 
 
 REQUIRES_ANNOTATION_ARG_NAME = "_cfg"

--- a/projects/core/tests/test_library_config.py
+++ b/projects/core/tests/test_library_config.py
@@ -26,18 +26,14 @@ def test_init_consolidates_config_chunks_into_top_level_sections(tmp_path: Path)
     _write_yaml(
         orchestration_dir / "config.yaml",
         {
-            "runtime": {
-                "keep": "from-base",
-                "nested": {"base_value": 1},
-            },
             "shared": {"source": "config-file"},
         },
     )
     _write_yaml(
         orchestration_dir / "config.d" / "runtime.yaml",
         {
-            "nested": {"chunk_value": 2},
             "override": "from-chunk",
+            "nested": {"chunk_value": 2},
         },
     )
     _write_yaml(
@@ -47,15 +43,18 @@ def test_init_consolidates_config_chunks_into_top_level_sections(tmp_path: Path)
 
     core_config.init(orchestration_dir)
 
-    assert core_config.project.get_config("runtime.keep", print=False) == "from-base"
     assert core_config.project.get_config("runtime.override", print=False) == "from-chunk"
-    assert core_config.project.get_config("runtime.nested.base_value", print=False) == 1
     assert core_config.project.get_config("runtime.nested.chunk_value", print=False) == 2
     assert core_config.project.get_config("platform.name", print=False) == "rhoai"
+    assert core_config.project.get_config("shared.source", print=False) == "config-file"
 
     consolidated = yaml.safe_load((env.ARTIFACT_DIR / "config.yaml").read_text())
-    assert consolidated["runtime"]["nested"] == {"base_value": 1, "chunk_value": 2}
+    assert consolidated["runtime"] == {
+        "override": "from-chunk",
+        "nested": {"chunk_value": 2},
+    }
     assert consolidated["platform"] == {"name": "rhoai", "channel": "stable"}
+    assert consolidated["shared"] == {"source": "config-file"}
 
 
 def test_init_supports_projects_defined_only_with_config_d(tmp_path: Path) -> None:
@@ -77,3 +76,39 @@ def test_init_supports_projects_defined_only_with_config_d(tmp_path: Path) -> No
     consolidated = yaml.safe_load((env.ARTIFACT_DIR / "config.yaml").read_text())
     assert consolidated["runtime"]["default_preset"] == "smoke"
     assert consolidated["platform"]["namespace"] == "test-ns"
+
+
+def test_init_rejects_empty_config_d_when_config_yaml_is_missing(tmp_path: Path) -> None:
+    orchestration_dir = tmp_path / "orchestration"
+    (orchestration_dir / "config.d").mkdir(parents=True)
+
+    with pytest.raises(ValueError, match="config YAML chunks"):
+        core_config.init(orchestration_dir)
+
+
+def test_init_rejects_overlapping_sections_between_config_and_config_d(
+    tmp_path: Path,
+) -> None:
+    orchestration_dir = tmp_path / "orchestration"
+    _write_yaml(
+        orchestration_dir / "config.yaml",
+        {"runtime": {"keep": "from-base"}},
+    )
+    _write_yaml(
+        orchestration_dir / "config.d" / "runtime.yaml",
+        {"override": "from-chunk"},
+    )
+
+    with pytest.raises(ValueError, match="defined in both"):
+        core_config.init(orchestration_dir)
+
+
+def test_init_ignores_yml_config_chunks(tmp_path: Path) -> None:
+    orchestration_dir = tmp_path / "orchestration"
+    _write_yaml(
+        orchestration_dir / "config.d" / "runtime.yml",
+        {"default_preset": "smoke"},
+    )
+
+    with pytest.raises(ValueError, match="config YAML chunks"):
+        core_config.init(orchestration_dir)

--- a/projects/core/tests/test_library_config.py
+++ b/projects/core/tests/test_library_config.py
@@ -103,12 +103,13 @@ def test_init_rejects_overlapping_sections_between_config_and_config_d(
         core_config.init(orchestration_dir)
 
 
-def test_init_ignores_yml_config_chunks(tmp_path: Path) -> None:
+def test_init_supports_yml_config_chunks(tmp_path: Path) -> None:
     orchestration_dir = tmp_path / "orchestration"
     _write_yaml(
         orchestration_dir / "config.d" / "runtime.yml",
         {"default_preset": "smoke"},
     )
 
-    with pytest.raises(ValueError, match="config YAML chunks"):
-        core_config.init(orchestration_dir)
+    core_config.init(orchestration_dir)
+
+    assert core_config.project.get_config("runtime.default_preset", print=False) == "smoke"

--- a/projects/core/tests/test_library_config.py
+++ b/projects/core/tests/test_library_config.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+import projects.core.library.config as core_config
+import projects.core.library.env as env
+
+
+@pytest.fixture(autouse=True)
+def _reset_project_config():
+    core_config.project = None
+    yield
+    core_config.project = None
+
+
+def _write_yaml(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+
+def test_init_consolidates_config_chunks_into_top_level_sections(tmp_path: Path) -> None:
+    orchestration_dir = tmp_path / "orchestration"
+    _write_yaml(
+        orchestration_dir / "config.yaml",
+        {
+            "runtime": {
+                "keep": "from-base",
+                "nested": {"base_value": 1},
+            },
+            "shared": {"source": "config-file"},
+        },
+    )
+    _write_yaml(
+        orchestration_dir / "config.d" / "runtime.yaml",
+        {
+            "nested": {"chunk_value": 2},
+            "override": "from-chunk",
+        },
+    )
+    _write_yaml(
+        orchestration_dir / "config.d" / "platform.yaml",
+        {"name": "rhoai", "channel": "stable"},
+    )
+
+    core_config.init(orchestration_dir)
+
+    assert core_config.project.get_config("runtime.keep", print=False) == "from-base"
+    assert core_config.project.get_config("runtime.override", print=False) == "from-chunk"
+    assert core_config.project.get_config("runtime.nested.base_value", print=False) == 1
+    assert core_config.project.get_config("runtime.nested.chunk_value", print=False) == 2
+    assert core_config.project.get_config("platform.name", print=False) == "rhoai"
+
+    consolidated = yaml.safe_load((env.ARTIFACT_DIR / "config.yaml").read_text())
+    assert consolidated["runtime"]["nested"] == {"base_value": 1, "chunk_value": 2}
+    assert consolidated["platform"] == {"name": "rhoai", "channel": "stable"}
+
+
+def test_init_supports_projects_defined_only_with_config_d(tmp_path: Path) -> None:
+    orchestration_dir = tmp_path / "orchestration"
+    _write_yaml(
+        orchestration_dir / "config.d" / "runtime.yaml",
+        {"default_preset": "smoke"},
+    )
+    _write_yaml(
+        orchestration_dir / "config.d" / "platform.yaml",
+        {"namespace": "test-ns"},
+    )
+
+    core_config.init(orchestration_dir)
+
+    assert core_config.project.get_config("runtime.default_preset", print=False) == "smoke"
+    assert core_config.project.get_config("platform.namespace", print=False) == "test-ns"
+
+    consolidated = yaml.safe_load((env.ARTIFACT_DIR / "config.yaml").read_text())
+    assert consolidated["runtime"]["default_preset"] == "smoke"
+    assert consolidated["platform"]["namespace"] == "test-ns"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configuration now supports modular config fragments in a config.d directory that are merged into a single emitted configuration, with fragments treated as top-level sections.

* **Bug Fixes / Validation**
  * Initialization now requires either a base config or at least one valid fragment, rejects overlapping top-level sections, and ignores non-.yaml fragments.

* **Tests**
  * Added tests validating merging behavior, missing-source validation, conflict rejection, and .yaml-only fragment handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->