### PR TITLE
pyproject.toml: add the `caliper` dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "ansible", "fire",
     "pyjwt",
     "jsonpath_ng",
+    "pydantic>=2.0",
 ]
 
 [project.optional-dependencies]
@@ -47,6 +48,11 @@ dev = [
 docs = [
     "sphinx>=7.1.0",
     "sphinx-rtd-theme>=1.3.0",
+]
+caliper = [
+    "opensearch-py>=2.4.0",
+    "boto3>=1.28.0",
+    "mlflow>=2.10.0",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
I need to merge that to have a working image

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum Pydantic requirement to version 2.0 or higher.

* **New Features**
  * Added optional extras group for enhanced OpenSearch, AWS, and experiment tracking capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->