### PR TITLE
.github: workflows: image-push: remove GHA extraheader token from theimage

### DIFF
--- a/.github/workflows/image-push.yaml
+++ b/.github/workflows/image-push.yaml
@@ -12,6 +12,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Remove GitHub credentials from git config
+        run: |
+          # Remove the GitHub token from git config to prevent secret leakage in container
+          git config --unset-all http.https://github.com/.extraheader || true
+          # Reconfigure for anonymous access (public repo)
+          git remote set-url origin https://github.com/openshift-psap/forge
+
       - name: Determine tags
         id: tags
         run: |


### PR DESCRIPTION
(short life pull token, not a proper leak)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow configuration to enhance credential handling during image building and pushing processes. The workflow now removes authentication credentials from git configuration and uses public URLs for remote operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openshift-psap/forge/pull/58)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->