### PR TITLE
fix: more time for fournos jobs 

### DIFF
--- a/projects/fournos_launcher/toolbox/submit_and_wait/main.py
+++ b/projects/fournos_launcher/toolbox/submit_and_wait/main.py
@@ -181,7 +181,7 @@ def submit_fournos_job(args, ctx):
     return f"Successfully submitted FOURNOS job: {ctx.final_job_name}"
 
 
-@retry(attempts=120, delay=10, backoff=1.0)
+@retry(attempts=360, delay=10, backoff=1.0)
 @task
 def wait_for_job_completion(args, ctx):
     """Wait for FOURNOS job to complete"""


### PR DESCRIPTION
before fix : the submit_and_wait for fournos was running for tests that are working for 20 min max, and after that were crashing.
after fix : jobs are allowed to run for 1 hour max. consider later to increase for even more if needed.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job status polling resilience by allowing longer waits before timing out, reducing the chance of jobs being marked incomplete too early.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->