### PR TITLE
fix: remove aws.credentials from mlflow vault definition

### DIFF
--- a/vaults/psap-forge-mlflow-export.yaml
+++ b/vaults/psap-forge-mlflow-export.yaml
@@ -23,12 +23,3 @@ content:
   password:
     description: |
       the mlflow password, so that the CI engine can censor it in the logs
-
-  aws.credentials:
-    description: |
-       the AWS credential file:
-    sample: |
-      [default]
-      aws_access_key_id = "..."
-      aws_secret_access_key = "..."
-      region = "..."


### PR DESCRIPTION
## Summary
- Remove `aws.credentials` content block from `vaults/psap-forge-mlflow-export.yaml`
- The cluster secret `vault-psap-forge-mlflow-export` does not contain this key, causing vault validation to fail and Fournos pipelines to abort at the prepare step

## Test plan
- [x] Submitted FournosJob `rhaiis-mlflow-full-zmptm` with this SHA — prepare step now passes vault validation
- [ ] Verify full pipeline completes (test + export-artifacts)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an exposed AWS credential entry from the vault configuration, reducing the risk of sensitive information being shared.
  * Preserved the existing MLFlow secret settings and related connection fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->