### PR TITLE
fix: add post-cleanup and make pre-cleanup no-op in rhaiis CI

### DIFF
--- a/projects/rhaiis/orchestration/ci.py
+++ b/projects/rhaiis/orchestration/ci.py
@@ -73,7 +73,15 @@ def test(ctx):
 @click.pass_context
 @ci_lib.safe_ci_command
 def pre_cleanup(ctx):
-    """Cleanup phase - Clean up resources and finalize."""
+    """Pre-cleanup phase - no-op to avoid cleaning up running resources."""
+    return 0
+
+
+@main.command()
+@click.pass_context
+@ci_lib.safe_ci_command
+def post_cleanup(ctx):
+    """Post-cleanup phase - Clean up resources after test."""
     return prepare_rhaiis.cleanup()
 
 


### PR DESCRIPTION
## Summary
- Add missing `post-cleanup` command to rhaiis CI — pipeline was failing because the command didn't exist
- Make `pre-cleanup` a no-op to avoid cleaning up resources from concurrent runs

## Test plan
- [x] Full pipeline `rhaiis-mlflow-full-wsm5p` succeeded on fournos-fg cluster
- [x] All 5 tasks passed: pre-cleanup, prepare, test, post-cleanup, export-artifacts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated post-test cleanup step to run after test execution.

* **Behavior Changes**
  * The earlier cleanup step now performs no cleanup and returns immediately.
  * Cleanup is now handled exclusively after the test phase for more reliable results.

* **Documentation**
  * Updated CLI help text to reflect the new responsibilities of each cleanup step.

* **Tests**
  * Verified end-to-end: pipeline passed all stages successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->