### PR TITLE
mcp_gateway: add preflight phase, rename labels, and support nightly builds

### DIFF
--- a/projects/agentic_tools/ci_base.py
+++ b/projects/agentic_tools/ci_base.py
@@ -198,7 +198,7 @@ def _register_phase_command(
     """Register a lazily-imported phase function as a click command."""
 
     @click.pass_context
-    @ci_lib.safe_ci_command
+    @ci_lib.safe_ci_entrypoint
     @functools.wraps(_import_function)
     def command(ctx, _spec=spec):
         fn = _import_function(_spec.func)

--- a/projects/agentic_tools/mcp/__init__.py
+++ b/projects/agentic_tools/mcp/__init__.py
@@ -2,7 +2,7 @@
 MCP Server Testing Toolbox
 
 Shared infrastructure for:
-- Deploying mock MCP servers on Kubernetes (batch scale-out)
+- Deploying mock MCP servers on Kubernetes (batch deployment)
 - Deploying tokenizer-accurate MCP servers (deterministic tool responses)
 - MCP protocol client for load testing (JSON-RPC over HTTP)
 

--- a/projects/agentic_tools/mcp/toolbox/deploy_mock_servers/main.py
+++ b/projects/agentic_tools/mcp/toolbox/deploy_mock_servers/main.py
@@ -48,9 +48,8 @@ def run(
 @task
 def generate_and_apply_manifests(args, ctx):
     """Generate YAML manifests for all servers and apply them."""
-    merged_labels = {"forge.openshift.io/component": "mock-mcp"}
-    if args.labels:
-        merged_labels.update(args.labels)
+    merged_labels = dict(args.labels) if args.labels else {}
+    merged_labels["forge.openshift.io/component"] = "mock-mcp"
 
     ctx.names = [f"{args.name_prefix}-{i}" for i in range(1, args.count + 1)]
 

--- a/projects/agentic_tools/mcp/toolbox/deploy_mock_servers/main.py
+++ b/projects/agentic_tools/mcp/toolbox/deploy_mock_servers/main.py
@@ -1,7 +1,7 @@
 """
 Deploy MCP-compatible mock servers on Kubernetes.
 
-Supports both single-server (count=1) and scale-out (count>1) scenarios
+Supports both single-server (count=1) and multi-server (count>1) scenarios
 using programmatic manifest generation. Each server gets a unique name
 (e.g. mock-server-1 .. mock-server-N), its own Service, and configurable
 tool count.
@@ -24,7 +24,7 @@ from projects.core.dsl.utils.k8s import oc
 
 logger = logging.getLogger(__name__)
 
-SCALE_OUT_LABEL = "experiment=scale-out"
+MOCK_MCP_LABEL = "forge.openshift.io/component=mock-mcp"
 
 
 @entrypoint
@@ -48,7 +48,7 @@ def run(
 @task
 def generate_and_apply_manifests(args, ctx):
     """Generate YAML manifests for all servers and apply them."""
-    merged_labels = {"experiment": "scale-out"}
+    merged_labels = {"forge.openshift.io/component": "mock-mcp"}
     if args.labels:
         merged_labels.update(args.labels)
 
@@ -92,7 +92,7 @@ def wait_for_rollout(args, ctx):
         "-n",
         args.namespace,
         "-l",
-        SCALE_OUT_LABEL,
+        MOCK_MCP_LABEL,
         "-o",
         "jsonpath={.items[?(@.status.readyReplicas==1)].metadata.name}",
         check=False,
@@ -120,7 +120,7 @@ def capture_artifacts(args, ctx):
         "-n",
         args.namespace,
         "-l",
-        SCALE_OUT_LABEL,
+        MOCK_MCP_LABEL,
         "-o",
         "yaml",
     )
@@ -131,7 +131,7 @@ def capture_artifacts(args, ctx):
         "-n",
         args.namespace,
         "-l",
-        SCALE_OUT_LABEL,
+        MOCK_MCP_LABEL,
         "-o",
         "wide",
     )
@@ -148,21 +148,21 @@ def capture_artifacts(args, ctx):
 
 
 def cleanup_servers(*, namespace: str) -> None:
-    """Delete all scale-out mock server deployments and services by label."""
-    logger.info("Cleaning up scale-out servers (label=%s)...", SCALE_OUT_LABEL)
+    """Delete all mock MCP server deployments and services by label."""
+    logger.info("Cleaning up mock MCP servers (label=%s)...", MOCK_MCP_LABEL)
     oc(
         "delete",
         "deployment,service",
         "-n",
         namespace,
         "-l",
-        SCALE_OUT_LABEL,
+        MOCK_MCP_LABEL,
         "--wait=false",
         "--ignore-not-found=true",
         check=False,
     )
     _wait_for_deletion(namespace=namespace, resource="deployment", timeout_seconds=120)
-    logger.info("Scale-out server cleanup complete")
+    logger.info("Mock MCP server cleanup complete")
 
 
 def restart_servers(
@@ -191,7 +191,7 @@ def restart_servers(
 
 
 def _wait_for_deletion(*, namespace: str, resource: str, timeout_seconds: int = 120) -> None:
-    """Wait until no resources with the scale-out label remain."""
+    """Wait until no resources with the mock-mcp label remain."""
     deadline = time.time() + timeout_seconds
     while time.time() < deadline:
         result = oc(
@@ -200,7 +200,7 @@ def _wait_for_deletion(*, namespace: str, resource: str, timeout_seconds: int = 
             "-n",
             namespace,
             "-l",
-            SCALE_OUT_LABEL,
+            MOCK_MCP_LABEL,
             "--no-headers",
             check=False,
         )

--- a/projects/caliper/engine/file_export/mlflow_backend.py
+++ b/projects/caliper/engine/file_export/mlflow_backend.py
@@ -473,10 +473,12 @@ def log_multi_run_artifacts(
     upload_workers: int = 10,
     run_metadata: dict[str, Any] | None = None,
     workspace: str | None = None,
+    child_run_names: dict[Path, str] | None = None,
 ) -> tuple[str, dict[str, Any] | None]:
     """Create a parent MLflow run with all artifacts and nested child runs per test directory.
 
     All artifacts are uploaded to both the parent run and each child run.
+    If ``child_run_names`` is provided, those names are used instead of ``run_dir.name``.
     """
     try:
         import mlflow
@@ -548,7 +550,11 @@ def log_multi_run_artifacts(
                 logger.info("Parent run: %s", parent_url)
 
             for run_dir in sorted(run_dirs):
-                child_name = run_dir.name
+                child_name = (
+                    child_run_names.get(run_dir, run_dir.name)
+                    if child_run_names
+                    else run_dir.name
+                )
 
                 with mlflow.start_run(run_name=child_name, nested=True):
                     child_rid = mlflow.active_run().info.run_id

--- a/projects/caliper/engine/file_export/mlflow_backend.py
+++ b/projects/caliper/engine/file_export/mlflow_backend.py
@@ -523,6 +523,7 @@ def log_multi_run_artifacts(
             )
 
         parent_meta: dict[str, Any] | None = None
+        child_runs_meta: list[dict[str, Any]] = []
         client = mlflow.tracking.MlflowClient()
 
         start_kw: dict[str, Any] = {}
@@ -595,7 +596,17 @@ def log_multi_run_artifacts(
                     if child_url:
                         logger.info("  Child run %s: %s", child_name, child_url)
 
+                    child_entry: dict[str, Any] = {
+                        "run_id": child_rid,
+                        "run_name": child_name,
+                    }
+                    if child_url:
+                        child_entry["run_url"] = child_url
+                    child_runs_meta.append(child_entry)
+
             parent_meta = _capture_mlflow_run_metadata(tu, workspace=workspace)
+            if child_runs_meta:
+                parent_meta["child_runs"] = child_runs_meta
 
         if verbose:
             logger.info("MLflow multi-run upload finished (%s)", mlflow.get_tracking_uri())

--- a/projects/caliper/engine/file_export/mlflow_backend.py
+++ b/projects/caliper/engine/file_export/mlflow_backend.py
@@ -477,7 +477,9 @@ def log_multi_run_artifacts(
 ) -> tuple[str, dict[str, Any] | None]:
     """Create a parent MLflow run with all artifacts and nested child runs per test directory.
 
-    All artifacts are uploaded to both the parent run and each child run.
+    The parent run receives every artifact.  Each child run receives only the
+    files that live under its own ``run_dir`` subtree, so artifacts are never
+    duplicated across children.
     If ``child_run_names`` is provided, those names are used instead of ``run_dir.name``.
     """
     try:
@@ -554,6 +556,11 @@ def log_multi_run_artifacts(
                     child_run_names.get(run_dir, run_dir.name) if child_run_names else run_dir.name
                 )
 
+                resolved_run_dir = run_dir.resolve()
+                child_files = [
+                    p for p in file_paths if p.resolve().is_relative_to(resolved_run_dir)
+                ]
+
                 with mlflow.start_run(run_name=child_name, nested=True):
                     child_rid = mlflow.active_run().info.run_id
 
@@ -571,12 +578,19 @@ def log_multi_run_artifacts(
                     _upload_mlflow_files_parallel(
                         client=client,
                         run_id=child_rid,
-                        file_paths=file_paths,
+                        file_paths=child_files,
                         artifact_root=artifact_root,
                         upload_workers=upload_workers,
                         verbose=verbose,
                     )
 
+                    if verbose:
+                        logger.info(
+                            "  Child run %s: %d artifact(s) (of %d total)",
+                            child_name,
+                            len(child_files),
+                            len(file_paths),
+                        )
                     child_url, _ = _mlflow_ui_links(tu, eid, child_rid, workspace=workspace)
                     if child_url:
                         logger.info("  Child run %s: %s", child_name, child_url)

--- a/projects/caliper/engine/file_export/mlflow_backend.py
+++ b/projects/caliper/engine/file_export/mlflow_backend.py
@@ -551,9 +551,7 @@ def log_multi_run_artifacts(
 
             for run_dir in sorted(run_dirs):
                 child_name = (
-                    child_run_names.get(run_dir, run_dir.name)
-                    if child_run_names
-                    else run_dir.name
+                    child_run_names.get(run_dir, run_dir.name) if child_run_names else run_dir.name
                 )
 
                 with mlflow.start_run(run_name=child_name, nested=True):

--- a/projects/caliper/orchestration/export.py
+++ b/projects/caliper/orchestration/export.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import copy
 import logging
+import os
+import re
 from pathlib import Path
 from typing import Any
 
@@ -28,6 +30,115 @@ from projects.core.library import env
 from projects.core.library import vault as vault_lib
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Run naming helpers
+# ---------------------------------------------------------------------------
+
+_TIMESTAMP_RE = re.compile(r"(\d{8}-\d{6})")
+_DIR_INDEX_RE = re.compile(r"^(\d+__)")
+
+
+def _extract_timestamp_from_fjob() -> str:
+    """Extract YYYYMMDD-HHMMSS timestamp from FJOB_NAME env var."""
+    fjob = os.environ.get("FJOB_NAME", "")
+    m = _TIMESTAMP_RE.search(fjob)
+    return m.group(1) if m else ""
+
+
+def _read_test_labels(run_dir: Path) -> dict[str, str]:
+    """Read labels from __test_labels__.yaml in a run directory."""
+    marker = run_dir / "__test_labels__.yaml"
+    if not marker.is_file():
+        return {}
+    try:
+        data = yaml.safe_load(marker.read_text(encoding="utf-8"))
+        return data.get("labels", {}) if isinstance(data, dict) else {}
+    except (OSError, yaml.YAMLError):
+        return {}
+
+
+def _format_run_name(template: str, labels: dict[str, str], *, prefix: str, timestamp: str) -> str:
+    """Format a run name template using labels plus computed fields (prefix, timestamp)."""
+    fields = {**labels, "prefix": prefix, "timestamp": timestamp}
+    try:
+        return template.format_map(fields)
+    except (KeyError, ValueError) as e:
+        logger.warning("Run naming template error (%s), falling back to raw template", e)
+        return template
+
+
+def format_child_run_name(
+    run_dir: Path,
+    *,
+    template: str,
+    prefix: str,
+    timestamp: str,
+) -> str:
+    """Build a child run name: preserve the NNN__ index prefix, apply the template for the rest."""
+    dir_name = run_dir.name
+    m = _DIR_INDEX_RE.match(dir_name)
+    num_prefix = m.group(1) if m else ""
+    labels = _read_test_labels(run_dir)
+    formatted = _format_run_name(template, labels, prefix=prefix, timestamp=timestamp)
+    return f"{num_prefix}{formatted}"
+
+
+def resolve_run_names(
+    run_dirs: list[Path],
+    mlflow_config_data: dict[str, Any] | None,
+    *,
+    fallback_run_name: str | None = None,
+) -> dict[str, str | None | dict[Path, str]]:
+    """Resolve parent and child run names from ``run_naming`` config + test labels.
+
+    Returns a dict with keys:
+        parent_run_name: str | None
+        single_run_name: str | None
+        child_run_names: dict[Path, str] (mapping run_dir -> formatted name)
+    """
+    naming_cfg = (mlflow_config_data or {}).get("run_naming")
+    if not naming_cfg or not isinstance(naming_cfg, dict):
+        return {
+            "parent_run_name": fallback_run_name,
+            "single_run_name": None,
+            "child_run_names": {},
+        }
+
+    prefix = naming_cfg.get("prefix", "")
+    timestamp = _extract_timestamp_from_fjob()
+    single_tpl = naming_cfg.get("single_run")
+    parent_tpl = naming_cfg.get("parent_run")
+    child_tpl = naming_cfg.get("child_run")
+
+    result: dict[str, Any] = {
+        "parent_run_name": fallback_run_name,
+        "single_run_name": None,
+        "child_run_names": {},
+    }
+
+    if len(run_dirs) == 1 and single_tpl:
+        labels = _read_test_labels(run_dirs[0])
+        result["single_run_name"] = _format_run_name(
+            single_tpl, labels, prefix=prefix, timestamp=timestamp
+        )
+
+    if len(run_dirs) > 1 and parent_tpl:
+        labels = _read_test_labels(run_dirs[0])
+        result["parent_run_name"] = _format_run_name(
+            parent_tpl, labels, prefix=prefix, timestamp=timestamp
+        )
+
+    if child_tpl:
+        child_names: dict[Path, str] = {}
+        for rd in run_dirs:
+            child_names[rd] = format_child_run_name(
+                rd, template=child_tpl, prefix=prefix, timestamp=timestamp
+            )
+        result["child_run_names"] = child_names
+
+    return result
 
 
 def run_from_orchestration_config(
@@ -93,6 +204,11 @@ def run_from_orchestration_config(
 
     run_dirs = _discover_run_dirs(from_path)
 
+    # Resolve descriptive run names from labels + run_naming config
+    naming = resolve_run_names(
+        run_dirs, mlflow_config_data, fallback_run_name=export_cfg.mlflow_run_name
+    )
+
     if len(run_dirs) > 1:
         if export_cfg.dry_run:
             logger.info(
@@ -107,12 +223,18 @@ def run_from_orchestration_config(
                 mlflow_secrets_path=mlflow_secrets_path,
                 mlflow_config_data=mlflow_config_data,
                 run_dirs=run_dirs,
+                resolved_parent_name=naming.get("parent_run_name"),
+                child_run_names=naming.get("child_run_names") or {},
             )
     else:
+        effective_name = (
+            naming.get("single_run_name") if len(run_dirs) == 1 else None
+        ) or export_cfg.mlflow_run_name
+
         mlflow_kwargs: dict[str, Any] = {
             "mlflow_experiment": export_cfg.mlflow_experiment,
             "mlflow_run_id": export_cfg.mlflow_run_id,
-            "mlflow_run_name": export_cfg.mlflow_run_name,
+            "mlflow_run_name": effective_name,
             "mlflow_secrets_path": mlflow_secrets_path,
         }
         if mlflow_config_data is not None:
@@ -165,6 +287,8 @@ def _run_multi_run_export(
     mlflow_secrets_path: Path,
     mlflow_config_data: dict[str, Any] | None,
     run_dirs: list[Path],
+    resolved_parent_name: str | None = None,
+    child_run_names: dict[Path, str] | None = None,
 ) -> int:
     """Export as parent + nested child MLflow runs."""
     import sys
@@ -208,7 +332,7 @@ def _run_multi_run_export(
 
     tracking_uri = merged_ml.get("tracking_uri")
     experiment = merged_ml.get("experiment")
-    run_name = merged_ml.get("run_name")
+    run_name = resolved_parent_name or merged_ml.get("run_name")
     workspace = merged_ml.get("workspace")
     meta = project_metadata_fields(merged_ml)
     run_metadata = meta if meta else None
@@ -241,6 +365,7 @@ def _run_multi_run_export(
             upload_workers=export_cfg.upload_workers,
             run_metadata=run_metadata,
             workspace=workspace,
+            child_run_names=child_run_names or None,
         )
         results = [
             FileExportBackendResult(

--- a/projects/caliper/orchestration/export.py
+++ b/projects/caliper/orchestration/export.py
@@ -54,7 +54,8 @@ def _read_test_labels(run_dir: Path) -> dict[str, str]:
         return {}
     try:
         data = yaml.safe_load(marker.read_text(encoding="utf-8"))
-        return data.get("labels", {}) if isinstance(data, dict) else {}
+        labels = data.get("labels", {}) if isinstance(data, dict) else {}
+        return labels if isinstance(labels, dict) else {}
     except (OSError, yaml.YAMLError):
         return {}
 

--- a/projects/caliper/tests/test_multi_run_export.py
+++ b/projects/caliper/tests/test_multi_run_export.py
@@ -466,6 +466,60 @@ class TestMultiRunMlflowLogging:
         assert tag_dict.get("forge.multi_run") == "true"
         assert tag_dict.get("forge.child_count") == "2"
 
+    def test_child_run_metadata_in_status(self, artifact_tree: Path, mock_mlflow):
+        """Returned metadata should include child_runs with run_id and run_name."""
+        from projects.caliper.engine.file_export.mlflow_backend import (
+            log_multi_run_artifacts,
+        )
+
+        run_dirs = _discover_run_dirs(artifact_tree)
+
+        child_run_ids = iter(["child-id-1", "child-id-2"])
+
+        def _active_run_side_effect():
+            mock = MagicMock()
+            mock.info.run_id = next(child_run_ids, "fallback-id")
+            return mock
+
+        mock_mlflow.active_run.side_effect = _active_run_side_effect
+
+        mock_client = mock_mlflow.tracking.MlflowClient.return_value
+        mock_get_run = MagicMock()
+        mock_get_run.info.run_name = "test-parent"
+        mock_get_run.data.tags = {}
+        mock_client.get_run.return_value = mock_get_run
+
+        mock_exp = MagicMock()
+        mock_exp.name = "test-experiment"
+        mock_client.get_experiment.return_value = mock_exp
+
+        _, meta = log_multi_run_artifacts(
+            all_artifact_paths=[],
+            artifact_root=artifact_tree,
+            run_dirs=run_dirs,
+            metrics_file=METRICS_FILE,
+            parameters_file=PARAMETERS_FILE,
+            tracking_uri="http://test-mlflow:5000",
+            experiment="test-experiment",
+            parent_run_name="test-parent",
+        )
+
+        assert meta is not None
+        assert "child_runs" in meta
+
+        child_runs = meta["child_runs"]
+        assert len(child_runs) == 2
+
+        child_names = sorted(c["run_name"] for c in child_runs)
+        assert child_names == ["mcp-smoke-s1-u16-gateway", "mcp-smoke-s1-u64-gateway"]
+
+        child_ids = {c["run_id"] for c in child_runs}
+        assert child_ids == {"child-id-1", "child-id-2"}
+
+        for child in child_runs:
+            assert "run_id" in child
+            assert "run_name" in child
+
 
 # ---------------------------------------------------------------------------
 # Test: workspace propagation

--- a/projects/caliper/tests/test_multi_run_export.py
+++ b/projects/caliper/tests/test_multi_run_export.py
@@ -418,9 +418,7 @@ class TestMultiRunMlflowLogging:
         child_a_artifacts = [c for c in log_artifact_calls if c.args[0] == "child-run-a"]
         child_b_artifacts = [c for c in log_artifact_calls if c.args[0] == "child-run-b"]
 
-        assert len(parent_artifacts) == len(all_files), (
-            "Parent run should receive all artifacts"
-        )
+        assert len(parent_artifacts) == len(all_files), "Parent run should receive all artifacts"
 
         run_a = sorted(run_dirs)[0]
         run_b = sorted(run_dirs)[1]

--- a/projects/caliper/tests/test_multi_run_export.py
+++ b/projects/caliper/tests/test_multi_run_export.py
@@ -381,6 +381,71 @@ class TestMultiRunMlflowLogging:
 
         mock_mlflow.set_experiment.assert_called_once_with("my-experiment")
 
+    def test_child_runs_only_get_own_artifacts(self, artifact_tree: Path, mock_mlflow):
+        """Each child run should only receive artifacts from its own directory subtree."""
+        from projects.caliper.engine.file_export.mlflow_backend import (
+            log_multi_run_artifacts,
+        )
+
+        run_dirs = _discover_run_dirs(artifact_tree)
+        all_files = [p for p in artifact_tree.rglob("*") if p.is_file()]
+
+        child_run_ids = iter(["child-run-a", "child-run-b"])
+        original_active = mock_mlflow.active_run
+
+        def _active_run_side_effect():
+            mock = MagicMock()
+            mock.info.run_id = next(child_run_ids, "fallback-id")
+            return mock
+
+        mock_mlflow.active_run.side_effect = _active_run_side_effect
+        mock_client = mock_mlflow.tracking.MlflowClient.return_value
+
+        log_multi_run_artifacts(
+            all_artifact_paths=all_files,
+            artifact_root=artifact_tree,
+            run_dirs=run_dirs,
+            metrics_file=METRICS_FILE,
+            parameters_file=PARAMETERS_FILE,
+            tracking_uri="http://test-mlflow:5000",
+            experiment="test-experiment",
+            parent_run_name="test-parent",
+        )
+
+        log_artifact_calls = mock_client.log_artifact.call_args_list
+
+        parent_artifacts = [c for c in log_artifact_calls if c.args[0] == "parent-run-id"]
+        child_a_artifacts = [c for c in log_artifact_calls if c.args[0] == "child-run-a"]
+        child_b_artifacts = [c for c in log_artifact_calls if c.args[0] == "child-run-b"]
+
+        assert len(parent_artifacts) == len(all_files), (
+            "Parent run should receive all artifacts"
+        )
+
+        run_a = sorted(run_dirs)[0]
+        run_b = sorted(run_dirs)[1]
+        run_a_file_count = sum(1 for p in all_files if p.resolve().is_relative_to(run_a.resolve()))
+        run_b_file_count = sum(1 for p in all_files if p.resolve().is_relative_to(run_b.resolve()))
+
+        assert len(child_a_artifacts) == run_a_file_count, (
+            f"Child A should only get {run_a_file_count} files from {run_a.name}, "
+            f"got {len(child_a_artifacts)}"
+        )
+        assert len(child_b_artifacts) == run_b_file_count, (
+            f"Child B should only get {run_b_file_count} files from {run_b.name}, "
+            f"got {len(child_b_artifacts)}"
+        )
+
+        assert len(child_a_artifacts) < len(parent_artifacts), (
+            "Child runs should have fewer artifacts than parent"
+        )
+        assert len(child_b_artifacts) < len(parent_artifacts), (
+            "Child runs should have fewer artifacts than parent"
+        )
+
+        mock_mlflow.active_run.side_effect = None
+        mock_mlflow.active_run.return_value = original_active.return_value
+
     def test_sets_forge_tags_on_parent(self, artifact_tree: Path, mock_mlflow):
         from projects.caliper.engine.file_export.mlflow_backend import (
             log_multi_run_artifacts,

--- a/projects/core/ci_entrypoint/prepare_ci.py
+++ b/projects/core/ci_entrypoint/prepare_ci.py
@@ -644,7 +644,12 @@ def generate_duration_and_timing_file(start_time: float | None, artifact_path: P
 
 
 def record_test_start_time(start_time: float | None = None):
-    """Record test start time to test_duration.yaml file.
+    """Record test start time to test_start.yaml file.
+
+    Writes to test_start.yaml (not test_duration.yaml) so the wait mechanism
+    in wait_for_step_completion() — which polls for test_duration.yaml — is not
+    triggered prematurely. test_duration.yaml is only created at step completion
+    by generate_duration_and_timing_file().
 
     Args:
         start_time: Unix timestamp when execution started. If None, uses current time.
@@ -659,13 +664,12 @@ def record_test_start_time(start_time: float | None = None):
         metadata_dir = artifact_path / CI_METADATA_DIRNAME
         metadata_dir.mkdir(parents=True, exist_ok=True)
 
-        timing_file = metadata_dir / "test_duration.yaml"
+        timing_file = metadata_dir / "test_start.yaml"
 
         # Use provided start_time or current time
         start_timestamp = start_time if start_time is not None else time.time()
         logger.info(f"Recording start time: {start_timestamp}")
 
-        # Use same format as final timing function
         timing_data = {
             "start_time": {
                 "timestamp": start_timestamp,

--- a/projects/mcp_gateway/orchestration/ci.py
+++ b/projects/mcp_gateway/orchestration/ci.py
@@ -14,6 +14,10 @@ main = CIApp(
             func="projects.mcp_gateway.orchestration.prepare_phase:run",
             help="Prepare phase - Install platform at MCP_GATEWAY_VERSION.",
         ),
+        "preflight": PhaseSpec(
+            func="projects.mcp_gateway.orchestration.preflight_phase:run",
+            help="Preflight check phase - Validate cluster readiness before testing.",
+        ),
         "test": PhaseSpec(
             func="projects.mcp_gateway.orchestration.test_phase:run",
             help="Test phase - Execute load tests across the experiment matrix.",

--- a/projects/mcp_gateway/orchestration/config.yaml
+++ b/projects/mcp_gateway/orchestration/config.yaml
@@ -53,10 +53,15 @@ caliper:
         config:
           run_name:
           experiment: mcp-gateway-cpt
-          workspace: ashtarkb
+          workspace: mcp-gw-cpt
           description: >
             MCP Gateway performance test results
           source_script: mcp_gateway project
           tags: {}
           parameters: {}
           metrics: {}
+          run_naming:
+            prefix: "forge-mcp-gateway"
+            single_run: "{prefix}-s{num_servers}-u{users}-v{mcp_gateway_version}-{timestamp}"
+            parent_run: "{prefix}-{preset}-{mcp_gateway_version}-{timestamp}"
+            child_run: "{prefix}-s{num_servers}-u{users}-v{mcp_gateway_version}-{timestamp}"

--- a/projects/mcp_gateway/orchestration/preflight_phase.py
+++ b/projects/mcp_gateway/orchestration/preflight_phase.py
@@ -22,7 +22,6 @@ import os
 import re
 
 from projects.agentic_tools.mcp.toolbox.deploy_mock_servers import main as deploy_mock_servers
-from projects.agentic_tools.mcp.toolbox.deploy_mock_servers.main import MOCK_MCP_LABEL
 from projects.core.dsl.utils.k8s import oc, oc_get_json, oc_resource_exists
 from projects.core.library import config
 from projects.core.orchestration.utils.k8s import ensure_namespace
@@ -71,6 +70,9 @@ def run() -> int:
         except PreflightError as exc:
             logger.error("  FAIL: %s: %s", name, exc)
             failed.append((name, str(exc)))
+        except Exception as exc:
+            logger.error("  FAIL: %s (unexpected): %s", name, exc)
+            failed.append((name, f"unexpected error: {exc}"))
 
     logger.info("")
     logger.info("=" * 60)
@@ -260,31 +262,55 @@ def check_gateway_connectivity() -> None:
 
 
 def _cleanup_probe(*, namespace: str, api_group: str) -> None:
-    """Remove all probe resources created by the connectivity check."""
-    deploy_mock_servers.cleanup_servers(namespace=namespace)
+    """Remove only the probe resources created by the connectivity check.
 
-    for resource_type in (
-        f"mcpserverregistrations.{api_group}",
-        "httproute",
-    ):
+    Deletes by known resource names derived from _PREFLIGHT_NAME_PREFIX
+    rather than the broad MOCK_MCP_LABEL selector, to avoid accidentally
+    removing test-phase resources sharing the same label.
+    """
+    probe_name = f"{_PREFLIGHT_NAME_PREFIX}-1"
+
+    for resource_type in ("deployment", "service"):
         oc(
             "delete",
             resource_type,
+            probe_name,
             "-n",
             namespace,
-            "-l",
-            MOCK_MCP_LABEL,
             "--ignore-not-found=true",
             "--wait=false",
             check=False,
         )
+
+    for resource_type in (f"mcpserverregistrations.{api_group}",):
+        oc(
+            "delete",
+            resource_type,
+            probe_name,
+            "-n",
+            namespace,
+            "--ignore-not-found=true",
+            "--wait=false",
+            check=False,
+        )
+
+    oc(
+        "delete",
+        "httproute",
+        f"{probe_name}-route",
+        "-n",
+        namespace,
+        "--ignore-not-found=true",
+        "--wait=false",
+        check=False,
+    )
+
     oc(
         "delete",
         "destinationrule",
+        f"{probe_name}-mtls-disable",
         "-n",
         "istio-system",
-        "-l",
-        MOCK_MCP_LABEL,
         "--ignore-not-found=true",
         "--wait=false",
         check=False,

--- a/projects/mcp_gateway/orchestration/preflight_phase.py
+++ b/projects/mcp_gateway/orchestration/preflight_phase.py
@@ -1,0 +1,312 @@
+"""
+Preflight checks for MCP Gateway performance tests.
+
+Validates that the cluster is ready for testing after the prepare phase:
+1. Required CRDs are installed
+2. MCP Gateway deployment is running in mcp-system
+3. MCPGatewayExtension CR exists and is reconciled
+4. Test namespace exists
+5. Deployed version matches the requested version
+6. End-to-end connectivity: deploy a probe server, verify gateway
+   recognition via MCPServerRegistration Ready condition, then clean up
+
+Usage:
+    python -m projects.mcp_gateway.orchestration.ci preflight
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+
+from projects.agentic_tools.mcp.toolbox.deploy_mock_servers import main as deploy_mock_servers
+from projects.agentic_tools.mcp.toolbox.deploy_mock_servers.main import MOCK_MCP_LABEL
+from projects.core.dsl.utils.k8s import oc, oc_get_json, oc_resource_exists
+from projects.core.library import config
+from projects.core.orchestration.utils.k8s import ensure_namespace
+from projects.mcp_gateway.orchestration.runtime_config import cfg
+from projects.mcp_gateway.toolbox.apply_infrastructure import main as apply_infra
+
+logger = logging.getLogger(__name__)
+
+_PREFLIGHT_NAME_PREFIX = "preflight-probe"
+
+
+class PreflightError(RuntimeError):
+    """A preflight check failed."""
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def run() -> int:
+    """Execute all preflight checks. Returns 0 on success, 1 on failure."""
+    checks = [
+        ("Required CRDs present", check_crds_present),
+        ("MCP Gateway deployment running", check_gateway_deployment),
+        ("MCPGatewayExtension reconciled", check_extension_reconciled),
+        ("Test namespace exists", check_test_namespace),
+        ("Deployed version matches requested", check_version_match),
+        ("Gateway connectivity (probe)", check_gateway_connectivity),
+    ]
+
+    passed: list[str] = []
+    failed: list[tuple[str, str]] = []
+
+    logger.info("=" * 60)
+    logger.info("MCP Gateway Preflight Checks")
+    logger.info("=" * 60)
+
+    for name, check_fn in checks:
+        logger.info("")
+        logger.info("--- %s ---", name)
+        try:
+            check_fn()
+            logger.info("  PASS: %s", name)
+            passed.append(name)
+        except PreflightError as exc:
+            logger.error("  FAIL: %s: %s", name, exc)
+            failed.append((name, str(exc)))
+
+    logger.info("")
+    logger.info("=" * 60)
+    logger.info("Preflight summary: %d passed, %d failed", len(passed), len(failed))
+
+    if failed:
+        for name, msg in failed:
+            logger.error("  FAIL  %s: %s", name, msg)
+        return 1
+
+    logger.info("All preflight checks passed")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Individual checks
+# ---------------------------------------------------------------------------
+
+
+def check_crds_present() -> None:
+    """Verify that the MCP Gateway CRDs are installed on the cluster."""
+    api_group = cfg.get_api_group()
+    required_crds = [
+        f"mcpserverregistrations.{api_group}",
+        f"mcpgatewayextensions.{api_group}",
+    ]
+
+    missing = []
+    for crd in required_crds:
+        if not oc_resource_exists("crd", crd):
+            missing.append(crd)
+
+    if missing:
+        raise PreflightError(f"Missing CRDs: {', '.join(missing)}")
+
+    logger.info("  Found CRDs: %s", ", ".join(required_crds))
+
+
+def check_gateway_deployment() -> None:
+    """Verify that the mcp-gateway deployment exists and has ready replicas."""
+    namespace = "mcp-system"
+    deployment = oc_get_json(
+        "deployment",
+        name="mcp-gateway",
+        namespace=namespace,
+        ignore_not_found=True,
+    )
+    if not deployment:
+        raise PreflightError(
+            f"deployment/mcp-gateway not found in {namespace}. "
+            "Did the prepare phase complete successfully?"
+        )
+
+    available = deployment.get("status", {}).get("availableReplicas", 0)
+    if not available:
+        raise PreflightError(
+            f"deployment/mcp-gateway exists but has no ready replicas "
+            f"(availableReplicas={available})"
+        )
+
+    logger.info("  deployment/mcp-gateway: %d replica(s) available", available)
+
+
+def check_extension_reconciled() -> None:
+    """Verify that an MCPGatewayExtension CR exists and has been reconciled."""
+    api_group = cfg.get_api_group()
+    result = oc(
+        "get",
+        f"mcpgatewayextensions.{api_group}",
+        "-A",
+        "-o",
+        "json",
+        check=False,
+        log_stdout=False,
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        raise PreflightError("No MCPGatewayExtension resources found on the cluster")
+
+    data = json.loads(result.stdout)
+    items = data.get("items", [])
+    if not items:
+        raise PreflightError("No MCPGatewayExtension resources found on the cluster")
+
+    ext = items[0]
+    ext_name = ext["metadata"]["name"]
+    ext_ns = ext["metadata"].get("namespace", "?")
+    conditions = ext.get("status", {}).get("conditions", [])
+
+    ready = any(c.get("type") == "Ready" and c.get("status") == "True" for c in conditions)
+    if not ready:
+        condition_summary = "; ".join(f"{c.get('type')}={c.get('status')}" for c in conditions)
+        raise PreflightError(
+            f"MCPGatewayExtension {ext_ns}/{ext_name} is not Ready "
+            f"(conditions: {condition_summary or 'none'})"
+        )
+
+    logger.info("  MCPGatewayExtension %s/%s is Ready", ext_ns, ext_name)
+
+
+def check_test_namespace() -> None:
+    """Verify that the test namespace exists (or can be created)."""
+    namespace = cfg.get_namespace()
+    if oc_resource_exists("namespace", namespace):
+        logger.info("  Namespace %s exists", namespace)
+    else:
+        logger.info("  Namespace %s does not exist, creating it", namespace)
+        ensure_namespace(
+            namespace,
+            labels={
+                "app.kubernetes.io/managed-by": "forge",
+                "forge.openshift.io/project": "mcp_gateway",
+            },
+        )
+        logger.info("  Namespace %s created", namespace)
+
+
+def check_version_match() -> None:
+    """Verify that the deployed MCP Gateway version matches what was requested."""
+    requested = config.project.get_config(
+        "infrastructure.mcp_gateway_version", None, print=False, warn=False
+    ) or os.environ.get("MCP_GATEWAY_VERSION")
+
+    if not requested:
+        logger.info("  No explicit version requested, skipping version match check")
+        return
+
+    deployed = cfg.get_deployed_version()
+    requested_normalized = _normalize_version(requested)
+    deployed_normalized = _normalize_version(deployed)
+
+    if requested_normalized != deployed_normalized:
+        raise PreflightError(
+            f"Version mismatch: requested '{requested}' (normalized: "
+            f"'{requested_normalized}') but deployed '{deployed}' (normalized: "
+            f"'{deployed_normalized}'). The prepare phase may have installed "
+            f"the wrong version."
+        )
+
+    logger.info("  Version match: requested=%s, deployed=%s", requested, deployed)
+
+
+def check_gateway_connectivity() -> None:
+    """End-to-end connectivity probe.
+
+    Deploys a single mock server into the test namespace using the existing
+    deploy_mock_servers toolbox, creates gateway infrastructure (HTTPRoute +
+    MCPServerRegistration) using the apply_infrastructure toolbox, waits for
+    the registration to become Ready (proving the gateway recognized it),
+    then tears everything down via the existing cleanup functions.
+    """
+    namespace = cfg.get_namespace()
+    api_group = cfg.get_api_group()
+    mock_image = _get_mock_server_image()
+
+    logger.info("  Deploying probe server in %s ...", namespace)
+
+    try:
+        deploy_mock_servers.run(
+            namespace=namespace,
+            count=1,
+            image=mock_image,
+            name_prefix=_PREFLIGHT_NAME_PREFIX,
+            tools_per_server=1,
+            labels={"forge.openshift.io/purpose": "preflight"},
+        )
+
+        apply_infra.run(
+            namespace=namespace,
+            count=1,
+            name_prefix=_PREFLIGHT_NAME_PREFIX,
+            api_group=api_group,
+        )
+
+        logger.info("  Gateway recognized the probe server")
+    except Exception as exc:
+        raise PreflightError(f"Connectivity probe failed: {exc}") from exc
+    finally:
+        logger.info("  Cleaning up probe resources ...")
+        _cleanup_probe(namespace=namespace, api_group=api_group)
+
+    logger.info("  Connectivity probe passed")
+
+
+# ---------------------------------------------------------------------------
+# Cleanup helper
+# ---------------------------------------------------------------------------
+
+
+def _cleanup_probe(*, namespace: str, api_group: str) -> None:
+    """Remove all probe resources created by the connectivity check."""
+    deploy_mock_servers.cleanup_servers(namespace=namespace)
+
+    for resource_type in (
+        f"mcpserverregistrations.{api_group}",
+        "httproute",
+    ):
+        oc(
+            "delete",
+            resource_type,
+            "-n",
+            namespace,
+            "-l",
+            MOCK_MCP_LABEL,
+            "--ignore-not-found=true",
+            "--wait=false",
+            check=False,
+        )
+    oc(
+        "delete",
+        "destinationrule",
+        "-n",
+        "istio-system",
+        "-l",
+        MOCK_MCP_LABEL,
+        "--ignore-not-found=true",
+        "--wait=false",
+        check=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Utility helpers
+# ---------------------------------------------------------------------------
+
+
+def _normalize_version(version: str) -> str:
+    """Normalize a version string for comparison (strip leading 'v', whitespace)."""
+    v = version.strip().lstrip("v")
+    match = re.match(r"(\d+\.\d+\.\d+)", v)
+    return match.group(1) if match else v
+
+
+def _get_mock_server_image() -> str:
+    """Resolve the mock server container image from config."""
+    try:
+        mock_cfg = cfg.get_mock_server_config()
+        return mock_cfg.get("image", "quay.io/rh-ee-aharush/perf-mock-server:latest")
+    except Exception:
+        return "quay.io/rh-ee-aharush/perf-mock-server:latest"

--- a/projects/mcp_gateway/orchestration/preflight_phase.py
+++ b/projects/mcp_gateway/orchestration/preflight_phase.py
@@ -297,8 +297,13 @@ def _cleanup_probe(*, namespace: str, api_group: str) -> None:
 
 
 def _normalize_version(version: str) -> str:
-    """Normalize a version string for comparison (strip leading 'v', whitespace)."""
+    """Normalize a version string for comparison.
+
+    Strips whitespace, leading ``v``, and the ``sha-`` prefix that ghcr.io
+    image tags use (e.g. ``sha-7ce4c58…`` → ``7ce4c58…``).
+    """
     v = version.strip().lstrip("v")
+    v = re.sub(r"^sha-", "", v)
     match = re.match(r"(\d+\.\d+\.\d+)", v)
     return match.group(1) if match else v
 

--- a/projects/mcp_gateway/orchestration/prepare_phase.py
+++ b/projects/mcp_gateway/orchestration/prepare_phase.py
@@ -5,14 +5,22 @@ Prepare phase for MCP Gateway performance tests.
 2. Install the MCP Gateway platform at the version specified by MCP_GATEWAY_VERSION
 3. Ensure test namespace exists
 
+Supports two modes:
+- Release mode: MCP_GATEWAY_VERSION=0.7.0 (semver tag)
+- Nightly mode: MCP_GATEWAY_VERSION=<40-char commit SHA> (uses pre-built images from ghcr.io)
+
 Usage:
     MCP_GATEWAY_VERSION=0.7.0 python -m projects.mcp_gateway.orchestration.ci prepare
+    MCP_GATEWAY_VERSION=<SHA> python -m projects.mcp_gateway.orchestration.ci prepare
 """
 
 from __future__ import annotations
 
 import logging
 import os
+import re
+import subprocess
+from pathlib import Path
 
 from projects.core.library import config
 from projects.core.orchestration.utils.k8s import ensure_namespace
@@ -21,6 +29,8 @@ from projects.mcp_gateway.toolbox.install_platform import main as install_platfo
 from projects.mcp_gateway.toolbox.platform_helpers import clone_platform_repo
 
 logger = logging.getLogger(__name__)
+
+_SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
 
 
 def run() -> int:
@@ -34,10 +44,12 @@ def run() -> int:
             "MCP_GATEWAY_VERSION environment variable."
         )
 
+    is_nightly = _is_commit_sha(version)
     namespace = cfg.get_namespace()
 
     logger.info("=== MCP Gateway Prepare Phase ===")
     logger.info("Version: %s", version)
+    logger.info("Mode: %s", "nightly (commit SHA)" if is_nightly else "release")
     logger.info("Namespace: %s", namespace)
 
     platform_cfg = cfg.get_platform_config()
@@ -54,6 +66,20 @@ def run() -> int:
         kustomize_base = clone_platform_repo(**clone_kwargs)
         platform_cfg["kustomize_base"] = str(kustomize_base)
 
+    if is_nightly:
+        image_tag = f"sha-{version}"
+        chart_path = _add_charts_to_sparse_checkout(platform_cfg["kustomize_base"])
+        if chart_path:
+            platform_cfg["mcp_gateway_instance"]["chart_path"] = str(chart_path)
+            platform_cfg["mcp_gateway_instance"]["image_tag"] = image_tag
+            logger.info("Nightly: using local chart at %s", chart_path)
+            logger.info("Nightly: image tag override = %s", image_tag)
+        else:
+            raise RuntimeError(
+                f"Failed to checkout charts/mcp-gateway from clone. "
+                f"Cannot install nightly build for commit {version}."
+            )
+
     install_platform_mod.run(platform_config=platform_cfg)
 
     ensure_namespace(
@@ -66,3 +92,32 @@ def run() -> int:
 
     logger.info("=== Prepare phase complete ===")
     return 0
+
+
+# --- Helper functions ---
+
+
+def _is_commit_sha(version: str) -> bool:
+    return bool(_SHA_PATTERN.match(version))
+
+
+def _add_charts_to_sparse_checkout(kustomize_base: str) -> Path | None:
+    """Add charts/mcp-gateway to the existing sparse checkout so we can helm install from source."""
+    repo_dir = Path(kustomize_base)
+    while repo_dir != repo_dir.parent:
+        if (repo_dir / ".git").exists():
+            break
+        repo_dir = repo_dir.parent
+    else:
+        return None
+
+    subprocess.run(
+        ["git", "sparse-checkout", "add", "charts/mcp-gateway"],
+        cwd=str(repo_dir),
+        check=True,
+        timeout=30,
+    )
+    chart_path = repo_dir / "charts" / "mcp-gateway"
+    if chart_path.is_dir():
+        return chart_path
+    return None

--- a/projects/mcp_gateway/orchestration/test_phase.py
+++ b/projects/mcp_gateway/orchestration/test_phase.py
@@ -11,6 +11,7 @@ post-processing.
 from __future__ import annotations
 
 import logging
+import re
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -18,11 +19,10 @@ from typing import Any
 from projects.agentic_tools.locust.toolbox.run_distributed import main as run_locust
 from projects.agentic_tools.locust.toolbox.run_distributed.main import LocustResults
 from projects.agentic_tools.mcp.toolbox.deploy_mock_servers import main as deploy_mock_servers
-from projects.agentic_tools.mcp.toolbox.deploy_mock_servers.main import MOCK_MCP_LABEL
 from projects.caliper.prometheus_metrics.capture import capture_metrics
 from projects.caliper.prometheus_metrics.config import MetricsCaptureConfig
 from projects.core.dsl.utils import write_json
-from projects.core.library import env
+from projects.core.library import config, env
 from projects.core.library.postprocess import run_and_postprocess, write_test_labels
 from projects.mcp_gateway.orchestration.runtime_config import cfg
 from projects.mcp_gateway.toolbox.apply_infrastructure import main as apply_infra
@@ -95,18 +95,26 @@ def do_test() -> int:
 
                 all_summaries.append(job_name)
 
-    write_json(
-        env.ARTIFACT_DIR / "test_summary.json",
-        {
-            "preset": preset,
-            "version": version,
-            "servers": servers,
-            "concurrency": concurrency,
-            "targets": targets,
-            "tools_per_server": tools_per_server,
-            "run_names": all_summaries,
-        },
+    summary: dict[str, Any] = {
+        "preset": preset,
+        "version": version,
+        "servers": servers,
+        "concurrency": concurrency,
+        "targets": targets,
+        "tools_per_server": tools_per_server,
+        "run_names": all_summaries,
+    }
+
+    configured_version = config.project.get_config(
+        "infrastructure.mcp_gateway_version", None, print=False, warn=False
     )
+    if configured_version and re.fullmatch(r"[0-9a-f]{40}", configured_version):
+        summary["nightly"] = {
+            "commit_sha": configured_version,
+            "image_tag": f"sha-{configured_version}",
+        }
+
+    write_json(env.ARTIFACT_DIR / "test_summary.json", summary)
 
     return 0
 
@@ -246,13 +254,14 @@ def _cleanup_servers(*, namespace: str, num_servers: int, mock_server: str) -> N
     deploy_mock_servers.cleanup_servers(namespace=namespace)
 
     api_group = cfg.get_api_group()
+    scale_out_label = "experiment=scale-out"
     run_oc(
         "delete",
         f"mcpserverregistrations.{api_group},httproute",
         "-n",
         namespace,
         "-l",
-        MOCK_MCP_LABEL,
+        scale_out_label,
         "--wait=false",
         "--ignore-not-found=true",
         check=False,
@@ -263,7 +272,7 @@ def _cleanup_servers(*, namespace: str, num_servers: int, mock_server: str) -> N
         "-n",
         "istio-system",
         "-l",
-        MOCK_MCP_LABEL,
+        scale_out_label,
         "--wait=false",
         "--ignore-not-found=true",
         check=False,

--- a/projects/mcp_gateway/orchestration/test_phase.py
+++ b/projects/mcp_gateway/orchestration/test_phase.py
@@ -11,6 +11,7 @@ post-processing.
 from __future__ import annotations
 
 import logging
+import os
 import re
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -107,7 +108,7 @@ def do_test() -> int:
 
     configured_version = config.project.get_config(
         "infrastructure.mcp_gateway_version", None, print=False, warn=False
-    )
+    ) or os.environ.get("MCP_GATEWAY_VERSION")
     if configured_version and re.fullmatch(r"[0-9a-f]{40}", configured_version):
         summary["nightly"] = {
             "commit_sha": configured_version,

--- a/projects/mcp_gateway/orchestration/test_phase.py
+++ b/projects/mcp_gateway/orchestration/test_phase.py
@@ -18,6 +18,7 @@ from typing import Any
 from projects.agentic_tools.locust.toolbox.run_distributed import main as run_locust
 from projects.agentic_tools.locust.toolbox.run_distributed.main import LocustResults
 from projects.agentic_tools.mcp.toolbox.deploy_mock_servers import main as deploy_mock_servers
+from projects.agentic_tools.mcp.toolbox.deploy_mock_servers.main import MOCK_MCP_LABEL
 from projects.caliper.prometheus_metrics.capture import capture_metrics
 from projects.caliper.prometheus_metrics.config import MetricsCaptureConfig
 from projects.core.dsl.utils import write_json
@@ -245,14 +246,13 @@ def _cleanup_servers(*, namespace: str, num_servers: int, mock_server: str) -> N
     deploy_mock_servers.cleanup_servers(namespace=namespace)
 
     api_group = cfg.get_api_group()
-    scale_out_label = "experiment=scale-out"
     run_oc(
         "delete",
         f"mcpserverregistrations.{api_group},httproute",
         "-n",
         namespace,
         "-l",
-        scale_out_label,
+        MOCK_MCP_LABEL,
         "--wait=false",
         "--ignore-not-found=true",
         check=False,
@@ -263,7 +263,7 @@ def _cleanup_servers(*, namespace: str, num_servers: int, mock_server: str) -> N
         "-n",
         "istio-system",
         "-l",
-        scale_out_label,
+        MOCK_MCP_LABEL,
         "--wait=false",
         "--ignore-not-found=true",
         check=False,

--- a/projects/mcp_gateway/toolbox/apply_infrastructure/main.py
+++ b/projects/mcp_gateway/toolbox/apply_infrastructure/main.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 import yaml
 
-from projects.agentic_tools.mcp.toolbox.deploy_mock_servers.main import SCALE_OUT_LABEL
+from projects.agentic_tools.mcp.toolbox.deploy_mock_servers.main import MOCK_MCP_LABEL
 from projects.core.dsl import always, entrypoint, execute_tasks, retry, task
 from projects.core.dsl.utils.k8s import oc
 
@@ -107,7 +107,7 @@ def capture_artifacts(args, ctx):
         "-n",
         args.namespace,
         "-l",
-        SCALE_OUT_LABEL,
+        MOCK_MCP_LABEL,
         "-o",
         "yaml",
     )
@@ -118,7 +118,7 @@ def capture_artifacts(args, ctx):
         "-n",
         args.namespace,
         "-l",
-        SCALE_OUT_LABEL,
+        MOCK_MCP_LABEL,
         "-o",
         "yaml",
     )
@@ -129,7 +129,7 @@ def capture_artifacts(args, ctx):
         "-n",
         "istio-system",
         "-l",
-        SCALE_OUT_LABEL,
+        MOCK_MCP_LABEL,
         "-o",
         "yaml",
     )
@@ -158,7 +158,7 @@ def _count_ready_registrations(*, namespace: str, api_group: str = DEFAULT_API_G
         "-n",
         namespace,
         "-l",
-        SCALE_OUT_LABEL,
+        MOCK_MCP_LABEL,
         "-o",
         'jsonpath={range .items[*]}{.status.conditions[?(@.type=="Ready")].status}{"\\n"}{end}',
         check=False,
@@ -180,7 +180,7 @@ def _generate_infrastructure_manifest(
 ) -> str:
     """Generate YAML manifest for HTTPRoute + DestinationRule + MCPServerRegistration."""
     labels = {
-        "experiment": "scale-out",
+        "forge.openshift.io/component": "mock-mcp",
         "forge.openshift.io/project": "mcp_gateway",
     }
 

--- a/projects/mcp_gateway/toolbox/install_platform/main.py
+++ b/projects/mcp_gateway/toolbox/install_platform/main.py
@@ -238,6 +238,10 @@ def install_mcp_gateway_instance(args, ctx):
     The MCPGatewayExtension is created in a separate step after the Gateway is
     programmed, to avoid a race condition where the controller deletes the CR
     because the Gateway isn't ready yet at first reconciliation.
+
+    Supports two install modes:
+    - Release: uses OCI chart ref + --version flag
+    - Nightly: uses local chart path from cloned repo + image tag overrides
     """
     step = find_step(ctx.steps, "mcp-gateway-instance")
     if not step:
@@ -245,9 +249,17 @@ def install_mcp_gateway_instance(args, ctx):
 
     _ensure_helm()
 
-    chart_ref = ctx.inst.get("chart_ref", "oci://ghcr.io/kuadrant/charts/mcp-gateway")
-    chart_version = ctx.inst.get("version")
-    version_flag = ["--version", chart_version] if chart_version else []
+    chart_path = ctx.inst.get("chart_path")
+    image_tag = ctx.inst.get("image_tag")
+
+    if chart_path:
+        chart_ref = chart_path
+        version_flag = []
+    else:
+        chart_ref = ctx.inst.get("chart_ref", "oci://ghcr.io/kuadrant/charts/mcp-gateway")
+        chart_version = ctx.inst.get("version")
+        version_flag = ["--version", chart_version] if chart_version else []
+
     ctx.mcp_host = _get_mcp_host()
 
     subprocess.run(
@@ -284,9 +296,14 @@ def install_mcp_gateway_instance(args, ctx):
         "mcpGatewayExtension.create=false",
     ]
 
+    if image_tag:
+        cmd += ["--set", f"image.tag={image_tag}", "--set", f"imageController.tag={image_tag}"]
+
     subprocess.run(cmd, check=True, timeout=120)
     ctx.gateway_installed = True
-    return f"MCP Gateway Helm release installed (host={ctx.mcp_host}, MCPGatewayExtension deferred)"
+
+    mode = "nightly" if chart_path else "release"
+    return f"MCP Gateway Helm release installed ({mode}, host={ctx.mcp_host}, MCPGatewayExtension deferred)"
 
 
 @retry(attempts=30, delay=10, backoff=1.0)


### PR DESCRIPTION
Add a preflight check phase for mcp_gateway that validates cluster readiness before testing: CRDs present, gateway deployment running, MCPGatewayExtension reconciled, test namespace exists, version match, and end-to-end connectivity probe.

Rename the resource label from experiment=scale-out to forge.openshift.io/component=mock-mcp across deploy_mock_servers, apply_infrastructure, test_phase, and preflight_phase for semantic consistency.

Add nightly mode for commit-to-commit performance tracking: This enables nightly performance testing against the upstream main branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **preflight** CI phase to validate MCP Gateway readiness before running tests.
  * Added **release vs nightly** MCP Gateway installation support, including commit-derived nightly image tags.
  * Improved Caliper/MLflow artifact export run naming via config/label-driven templates, including updated MCP Gateway workspace and parent/child naming.
* **Bug Fixes**
  * Standardized Kubernetes targeting for mock MCP Gateway resources with a consistent label across rollout, artifact capture, and cleanup.
  * Fixed multi-run MLflow exports so **child runs only upload their own artifacts**, and parent metadata now includes child run details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->