### PR TITLE
fix: pipeline-full test step runs preflight instead of test

### DIFF
--- a/fournos/gitops/base/workflows/pipeline-full.yaml
+++ b/fournos/gitops/base/workflows/pipeline-full.yaml
@@ -92,7 +92,7 @@ spec:
         - name: kubeconfig-secret
           value: "$(params.kubeconfig-secret)"
         - name: job-step
-          value: preflight
+          value: test
         - name: job-step-name
           value: 02__test
 


### PR DESCRIPTION
The 02-test task had job-step: preflight (copy-paste from the preflight task above) instead of job-step: test, causing the pipeline to run preflight twice and skip the actual test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the pipeline’s testing stage so it now runs the intended test step instead of reusing the preflight step value.
  * Improved consistency in the automated workflow, reducing the chance of unexpected behavior during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->