### PR TITLE
feat: pluggable per-project Slack notifications with KPI comparison

### DIFF
--- a/projects/agentic_tools/ci_base.py
+++ b/projects/agentic_tools/ci_base.py
@@ -150,6 +150,28 @@ class CIApp:
     def _get_vaults_for_key(self, key: str) -> list[str]:
         return config.project.get_config(f"vaults.{key}", [])
 
+    def _resolve_notification_provider(self):
+        """Auto-discover notification provider from config.
+
+        Reads ``notifications.slack.provider_module`` (a fully-qualified
+        class path like ``projects.foo.notifications.MyProvider``) and
+        instantiates it.  Returns None if not configured.
+        """
+        provider_path = config.project.get_config(
+            "notifications.slack.provider_module", None, print=False, warn=False
+        )
+        if not provider_path:
+            return None
+
+        try:
+            module_path, class_name = provider_path.rsplit(".", 1)
+            mod = importlib.import_module(module_path)
+            provider_cls = getattr(mod, class_name)
+            return provider_cls()
+        except Exception as e:
+            logger.warning("Failed to resolve notification provider '%s': %s", provider_path, e)
+            return None
+
     # ------------------------------------------------------------------
     # Build
     # ------------------------------------------------------------------
@@ -170,6 +192,8 @@ class CIApp:
                 return
 
             app.init_vaults(ctx.invoked_subcommand)
+
+            ctx.obj.notification_provider = app._resolve_notification_provider()
 
         main.help = self.description
 

--- a/projects/core/library/export.py
+++ b/projects/core/library/export.py
@@ -87,11 +87,12 @@ def _update_fjob_export_status(status: dict):
             os.environ["KUBECONFIG"] = original_kubeconfig
 
 
-def send_notification(status: dict[str, Any]) -> None:
+def send_notification(status: dict[str, Any], notification_provider=None) -> None:
     """Send job completion notifications based on caliper export status.
 
     Args:
         status: Caliper export status object containing backend results and metadata
+        notification_provider: Optional per-project SlackNotificationProvider instance
     """
     # Extract notification parameters from status object
     project = _extract_project_from_status(status)
@@ -135,6 +136,28 @@ def send_notification(status: dict[str, Any]) -> None:
             logger.warning("GitHub notification sending failed")
     except Exception as e:
         logger.warning(f"Failed to send GitHub notification: {e}")
+
+    # Per-project Slack notification via provider
+    if notification_provider:
+        try:
+            from projects.core.notifications.provider import NotificationContext
+
+            artifact_dir = Path(env.ARTIFACT_DIR) if env.ARTIFACT_DIR else None
+            context = NotificationContext(
+                status=status,
+                finish_reason=str(finish_reason),
+                project_name=project or "unknown",
+                pr_number=os.environ.get("PULL_NUMBER"),
+                job_type=os.environ.get("JOB_TYPE"),
+                artifact_dir=artifact_dir,
+            )
+            ok = notification_provider.notify(context)
+            if ok:
+                logger.info("Successfully sent per-project Slack notification")
+            else:
+                logger.warning("Per-project Slack notification failed")
+        except Exception as e:
+            logger.warning(f"Failed to send per-project Slack notification: {e}")
 
 
 def _get_project_and_args(project: str) -> tuple[str, str]:
@@ -497,6 +520,8 @@ def run_caliper_orchestration_export(*, artifact_directory: Path | None):
 def caliper_export_entrypoint(_ctx, artifact_directory: Path | None):
     """Export the file artifacts."""
 
+    notification_provider = getattr(getattr(_ctx, "obj", None), "notification_provider", None)
+
     status = None
     try:
         status = run_caliper_orchestration_export(artifact_directory=artifact_directory)
@@ -515,7 +540,7 @@ def caliper_export_entrypoint(_ctx, artifact_directory: Path | None):
         # Send completion notifications regardless of success/failure
         if status:
             try:
-                send_notification(status)
+                send_notification(status, notification_provider=notification_provider)
             except Exception as e:
                 logger.warning(f"Failed to send notifications: {e}")
                 # Don't fail the entire job if notifications fail

--- a/projects/core/notifications/helpers.py
+++ b/projects/core/notifications/helpers.py
@@ -1,0 +1,211 @@
+"""
+Shared helpers for per-project Slack notification providers.
+
+These utilities are framework-wide and can be used by any project's
+notification provider to resolve test artifacts, read timing data,
+extract labels, find KPIs, and build comparison tables.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+import yaml
+
+from projects.core.notifications.provider import NotificationContext
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Artifact root resolution
+# ---------------------------------------------------------------------------
+
+
+def get_test_artifacts_root(context: NotificationContext) -> Path | None:
+    """Resolve the root directory containing actual test results.
+
+    During CI, each phase gets its own artifact subdir (via NextArtifactDir).
+    The export phase's ARTIFACT_DIR doesn't contain the test results.
+    We use the framework's BASE_ARTIFACT_DIR which is the immutable root
+    set at init time, before any phase subdirectories are created.
+    """
+    from projects.core.library import env
+
+    if env.BASE_ARTIFACT_DIR:
+        return Path(env.BASE_ARTIFACT_DIR)
+
+    base_env = os.environ.get("FORGE_BASE_ARTIFACT_DIR")
+    if base_env:
+        p = Path(base_env)
+        if p.exists():
+            return p
+
+    return context.artifact_dir
+
+
+# ---------------------------------------------------------------------------
+# Timing
+# ---------------------------------------------------------------------------
+
+
+def read_test_duration(context: NotificationContext) -> str:
+    """Read formatted duration from 000__ci_metadata/test_duration.yaml."""
+    root = get_test_artifacts_root(context)
+    if not root:
+        return ""
+
+    timing_file = root / "000__ci_metadata" / "test_duration.yaml"
+    if not timing_file.exists():
+        candidates = list(root.glob("**/000__ci_metadata/test_duration.yaml"))
+        if not candidates:
+            return ""
+        timing_file = candidates[0]
+
+    try:
+        with open(timing_file) as f:
+            data = yaml.safe_load(f) or {}
+        return data.get("duration", {}).get("formatted", "")
+    except Exception:
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# Test labels
+# ---------------------------------------------------------------------------
+
+
+def get_label_value(artifact_root: Path | None, key: str) -> str | None:
+    """Extract a value from __test_labels__.yaml in the artifact tree.
+
+    The labels file format is: {"version": "1", "labels": {"key": "value", ...}}
+    """
+    if not artifact_root:
+        return None
+
+    labels_file = artifact_root / "__test_labels__.yaml"
+    if not labels_file.exists():
+        labels_glob = list(artifact_root.glob("**/__test_labels__.yaml"))
+        if not labels_glob:
+            return None
+        labels_file = labels_glob[0]
+
+    try:
+        with open(labels_file) as f:
+            data = yaml.safe_load(f) or {}
+        labels = data.get("labels", data)
+        val = labels.get(key, "")
+        return str(val) if val else None
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# KPI file discovery
+# ---------------------------------------------------------------------------
+
+
+def find_kpis_jsonl(artifact_dir: Path) -> Path | None:
+    """Find kpis.jsonl in artifact directory tree."""
+    direct = artifact_dir / "kpis.jsonl"
+    if direct.exists():
+        return direct
+
+    for f in artifact_dir.glob("**/kpis.jsonl"):
+        return f
+    return None
+
+
+# ---------------------------------------------------------------------------
+# MLflow URL extraction
+# ---------------------------------------------------------------------------
+
+
+def extract_mlflow_url(context: NotificationContext) -> str | None:
+    """Extract MLflow run URL from caliper export status dict."""
+    if not isinstance(context.status, dict):
+        return None
+    backends = context.status.get("caliper_artifacts_export", {}).get("backends", {})
+    mlflow_info = backends.get("mlflow", {})
+    return mlflow_info.get("run_url") or mlflow_info.get("experiment_url")
+
+
+# ---------------------------------------------------------------------------
+# KPI comparison table formatting
+# ---------------------------------------------------------------------------
+
+
+def build_comparison_table(
+    current: dict[str, float],
+    previous: dict[str, float],
+    prev_run_name: str,
+    kpi_definitions: list[tuple[str, str, str]],
+) -> str:
+    """Format a Slack-friendly KPI comparison table.
+
+    Args:
+        current: Current run's KPI values keyed by kpi_id.
+        previous: Previous run's KPI values keyed by kpi_id.
+        prev_run_name: Display name of the previous run.
+        kpi_definitions: List of (kpi_id, display_name, unit) tuples.
+    """
+    lines = [f"*KPI comparison* (vs `{prev_run_name}`):", "```"]
+
+    header = f"{'KPI':<16}| {'Previous':>10} | {'Current':>10} | {'Delta':>8}"
+    lines.append(header)
+    lines.append("-" * len(header))
+
+    for kpi_id, display_name, unit in kpi_definitions:
+        cur_val = current.get(kpi_id)
+        prev_val = previous.get(kpi_id)
+
+        if cur_val is None:
+            continue
+
+        cur_str = format_kpi_value(cur_val, unit)
+        prev_str = format_kpi_value(prev_val, unit) if prev_val is not None else "n/a"
+        delta_str = format_kpi_delta(cur_val, prev_val) if prev_val is not None else "n/a"
+
+        lines.append(f"{display_name:<16}| {prev_str:>10} | {cur_str:>10} | {delta_str:>8}")
+
+    lines.append("```")
+    return "\n".join(lines)
+
+
+def build_current_kpis_list(
+    current: dict[str, float],
+    kpi_definitions: list[tuple[str, str, str]],
+) -> str:
+    """Format current KPIs as a simple bullet list (no comparison available)."""
+    lines = ["*Current KPIs*:"]
+    for kpi_id, display_name, unit in kpi_definitions:
+        val = current.get(kpi_id)
+        if val is None:
+            continue
+        lines.append(f"  \u2022 {display_name}: `{format_kpi_value(val, unit)}`")
+
+    return "\n".join(lines) if len(lines) > 1 else ""
+
+
+def format_kpi_value(value: float | None, unit: str) -> str:
+    """Format a single KPI value with its unit."""
+    if value is None:
+        return "n/a"
+    if unit == "%":
+        return f"{value * 100:.2f}%"
+    if unit == "ms":
+        return f"{value:.1f} ms"
+    if unit == "req/s":
+        return f"{value:.0f}"
+    return f"{value:.2f}"
+
+
+def format_kpi_delta(current: float, previous: float) -> str:
+    """Format the percentage delta between two KPI values."""
+    if previous == 0:
+        return "n/a"
+    pct = ((current - previous) / abs(previous)) * 100
+    sign = "+" if pct >= 0 else ""
+    return f"{sign}{pct:.1f}%"

--- a/projects/core/notifications/helpers.py
+++ b/projects/core/notifications/helpers.py
@@ -27,21 +27,36 @@ logger = logging.getLogger(__name__)
 def get_test_artifacts_root(context: NotificationContext) -> Path | None:
     """Resolve the root directory containing actual test results.
 
-    During CI, each phase gets its own artifact subdir (via NextArtifactDir).
-    The export phase's ARTIFACT_DIR doesn't contain the test results.
-    We use the framework's BASE_ARTIFACT_DIR which is the immutable root
-    set at init time, before any phase subdirectories are created.
-    """
-    from projects.core.library import env
+    In Fournos pipelines, each step (prepare, test, export) runs as a
+    separate container with its own ARTIFACT_DIR. The export step's
+    BASE_ARTIFACT_DIR is its own subdir, NOT the overall root.
 
-    if env.BASE_ARTIFACT_DIR:
-        return Path(env.BASE_ARTIFACT_DIR)
+    The correct root is ``caliper.export.from`` which is set by the
+    export entrypoint to the shared workspace containing all steps.
+    """
+    try:
+        from projects.core.library import config
+
+        export_from = config.project.get_config(
+            "caliper.export.from", None, print=False, warn=False
+        )
+        if export_from:
+            p = Path(export_from)
+            if p.exists():
+                return p
+    except Exception:
+        pass
 
     base_env = os.environ.get("FORGE_BASE_ARTIFACT_DIR")
     if base_env:
         p = Path(base_env)
         if p.exists():
             return p
+
+    if context.artifact_dir:
+        parent = context.artifact_dir.parent
+        if parent.exists() and any(parent.glob("*/__test_labels__.yaml")):
+            return parent
 
     return context.artifact_dir
 

--- a/projects/core/notifications/provider.py
+++ b/projects/core/notifications/provider.py
@@ -19,10 +19,7 @@ import projects.core.notifications.slack.api as slack_api
 logger = logging.getLogger(__name__)
 
 DEFAULT_SLACK_TOKEN_FILE = "topsail-bot.slack-token"
-DEFAULT_SECRET_ENV_KEYS = (
-    "PSAP_FORGE_NOTIFICATIONS_SECRET_PATH",
-    "PSAP_FORGE_JUMP_CI_SECRET_PATH",
-)
+DEFAULT_SECRET_ENV_KEYS = ("PSAP_FORGE_NOTIFICATIONS_SECRET_PATH",)
 
 
 @dataclass

--- a/projects/core/notifications/provider.py
+++ b/projects/core/notifications/provider.py
@@ -15,11 +15,9 @@ from pathlib import Path
 from typing import Any
 
 import projects.core.notifications.slack.api as slack_api
+from projects.core.library import vault
 
 logger = logging.getLogger(__name__)
-
-DEFAULT_SLACK_TOKEN_FILE = "topsail-bot.slack-token"
-DEFAULT_SECRET_ENV_KEYS = ("PSAP_FORGE_NOTIFICATIONS_SECRET_PATH",)
 
 
 @dataclass
@@ -51,19 +49,19 @@ class SlackNotificationProvider(ABC):
 
         Override this only if your project needs a different bot token.
         """
-        for env_key in DEFAULT_SECRET_ENV_KEYS:
-            path = os.environ.get(env_key)
-            if not path:
-                continue
-            secret_dir = Path(path)
-            if not secret_dir.exists():
-                continue
-            token_file = secret_dir / DEFAULT_SLACK_TOKEN_FILE
-            if token_file.exists():
-                return token_file.read_text().strip()
+        try:
+            token_path = vault.get_vault_content_path(
+                "psap-forge-notifications", "topsail-bot.slack-token"
+            )
+        except RuntimeError:
+            logger.warning("Vault not initialized, cannot resolve Slack token")
+            return None
 
-        logger.warning("Slack token not found via %s", DEFAULT_SECRET_ENV_KEYS)
-        return None
+        if not token_path or not token_path.exists():
+            logger.warning("Slack token not found in psap-forge-notifications vault")
+            return None
+
+        return token_path.read_text().strip()
 
     @abstractmethod
     def get_channel_id(self) -> str:

--- a/projects/core/notifications/provider.py
+++ b/projects/core/notifications/provider.py
@@ -116,9 +116,7 @@ class SlackNotificationProvider(ABC):
             logger.error("Provider %s: failed to init Slack client", type(self).__name__)
             return False
 
-        channel_msg_ts, _ = slack_api.search_channel_message(
-            client, anchor, channel_id=channel_id
-        )
+        channel_msg_ts, _ = slack_api.search_channel_message(client, anchor, channel_id=channel_id)
 
         if not channel_msg_ts:
             channel_message = f"🧵 {anchor}"

--- a/projects/core/notifications/provider.py
+++ b/projects/core/notifications/provider.py
@@ -1,0 +1,141 @@
+"""
+Per-project Slack notification provider interface.
+
+Projects that want custom Slack notifications subclass
+SlackNotificationProvider and pass it to CIApp.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import projects.core.notifications.slack.api as slack_api
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SLACK_TOKEN_FILE = "topsail-bot.slack-token"
+DEFAULT_SECRET_ENV_KEYS = (
+    "PSAP_FORGE_NOTIFICATIONS_SECRET_PATH",
+    "PSAP_FORGE_JUMP_CI_SECRET_PATH",
+)
+
+
+@dataclass
+class NotificationContext:
+    """Context passed to a notification provider when a notification fires."""
+
+    status: dict[str, Any]
+    finish_reason: str
+    project_name: str
+    pr_number: str | None = None
+    job_type: str | None = None
+    artifact_dir: Path | None = None
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+class SlackNotificationProvider(ABC):
+    """Abstract base for per-project Slack notification providers.
+
+    Subclass this and implement the abstract methods to give a FORGE
+    project its own Slack channel and message format.
+
+    Token resolution uses the standard forge vault (topsail-bot.slack-token
+    from psap-forge-notifications). Override ``get_slack_token()`` only if
+    you need a different token.
+    """
+
+    def get_slack_token(self) -> str | None:
+        """Resolve the Slack token from the standard forge notifications vault.
+
+        Override this only if your project needs a different bot token.
+        """
+        for env_key in DEFAULT_SECRET_ENV_KEYS:
+            path = os.environ.get(env_key)
+            if not path:
+                continue
+            secret_dir = Path(path)
+            if not secret_dir.exists():
+                continue
+            token_file = secret_dir / DEFAULT_SLACK_TOKEN_FILE
+            if token_file.exists():
+                return token_file.read_text().strip()
+
+        logger.warning("Slack token not found via %s", DEFAULT_SECRET_ENV_KEYS)
+        return None
+
+    @abstractmethod
+    def get_channel_id(self) -> str:
+        """Return the Slack channel ID to post to."""
+
+    @abstractmethod
+    def format_message(self, context: NotificationContext) -> str:
+        """Format the Slack message body."""
+
+    def get_thread_anchor(self, context: NotificationContext) -> str:
+        """Return the thread anchor text for grouping messages in a thread."""
+        if context.pr_number:
+            return f"Thread for {context.project_name} PR #{context.pr_number}"
+        if context.job_type == "periodic":
+            job_name = os.environ.get("JOB_NAME_SAFE", context.project_name)
+            return f"Thread for {context.project_name} periodic `{job_name}`"
+        return f"Thread for {context.project_name} run"
+
+    def should_notify(self, context: NotificationContext) -> bool:
+        """Return True if notification should be sent. Default: always notify."""
+        return True
+
+    # ------------------------------------------------------------------
+    # Dispatch (not meant to be overridden in most cases)
+    # ------------------------------------------------------------------
+
+    def notify(self, context: NotificationContext, *, dry_run: bool = False) -> bool:
+        """Execute the full notification flow.
+
+        Returns True on success, False on failure.
+        """
+        if not self.should_notify(context):
+            logger.info("Provider %s: should_notify returned False, skipping", type(self).__name__)
+            return True
+
+        token = self.get_slack_token()
+        if not token:
+            logger.warning("Provider %s: no Slack token available", type(self).__name__)
+            return False
+
+        channel_id = self.get_channel_id()
+        message = self.format_message(context)
+        anchor = self.get_thread_anchor(context)
+
+        client = slack_api.init_client(token)
+        if not client:
+            logger.error("Provider %s: failed to init Slack client", type(self).__name__)
+            return False
+
+        channel_msg_ts, _ = slack_api.search_channel_message(
+            client, anchor, channel_id=channel_id
+        )
+
+        if not channel_msg_ts:
+            channel_message = f"🧵 {anchor}"
+            if dry_run:
+                logger.info("Would post channel message: %s", channel_message)
+            else:
+                channel_msg_ts, ok = slack_api.send_message(
+                    client, message=channel_message, channel_id=channel_id
+                )
+                if not ok:
+                    return False
+
+        if dry_run:
+            logger.info("Would post thread message:\n%s", message)
+            return True
+
+        _, ok = slack_api.send_message(
+            client, message=message, main_ts=channel_msg_ts, channel_id=channel_id
+        )
+        return ok

--- a/projects/core/notifications/provider.py
+++ b/projects/core/notifications/provider.py
@@ -104,6 +104,11 @@ class SlackNotificationProvider(ABC):
 
         channel_id = self.get_channel_id()
         message = self.format_message(context)
+
+        if context.extra.get("_skip_notification"):
+            logger.info("Provider %s: _skip_notification set, skipping", type(self).__name__)
+            return True
+
         anchor = self.get_thread_anchor(context)
 
         client = slack_api.init_client(token)

--- a/projects/core/notifications/slack/api.py
+++ b/projects/core/notifications/slack/api.py
@@ -10,9 +10,12 @@ CHANNEL_ID = "C07NS5TAKPA"
 MAX_CALLS = 10
 
 
-def search_channel_message(client, message_anchor: str, not_before=None):
+def search_channel_message(client, message_anchor: str, not_before=None, channel_id=None):
     """Searches for a message matching the pattern.
     Returns thread ts if successful."""
+    if channel_id is None:
+        channel_id = CHANNEL_ID
+
     has_more = True
     history = []
     cursor = None
@@ -23,7 +26,7 @@ def search_channel_message(client, message_anchor: str, not_before=None):
 
         try:
             result = client.conversations_history(
-                channel=CHANNEL_ID,
+                channel=channel_id,
                 limit=20,  # default 100
                 oldest=not_before,
                 cursor=cursor,
@@ -52,11 +55,14 @@ def search_channel_message(client, message_anchor: str, not_before=None):
     return None, None
 
 
-def send_message(client, message: str, main_ts: str = None):
+def send_message(client, message: str, main_ts: str = None, channel_id=None):
     """Sends a message. Optionally to a thread."""
+    if channel_id is None:
+        channel_id = CHANNEL_ID
+
     try:
         result = client.chat_postMessage(
-            channel=CHANNEL_ID,
+            channel=channel_id,
             text=message,
             thread_ts=main_ts,
         )

--- a/projects/mcp_gateway/orchestration/config.yaml
+++ b/projects/mcp_gateway/orchestration/config.yaml
@@ -6,6 +6,11 @@ vaults:
   prepare: []
   test: []
 
+notifications:
+  slack:
+    channel_id: C0BEBS6929L
+    provider_module: projects.mcp_gateway.orchestration.notifications.MCPGatewaySlackProvider
+
 metrics:
   enabled: true
   namespaces:

--- a/projects/mcp_gateway/orchestration/notifications.py
+++ b/projects/mcp_gateway/orchestration/notifications.py
@@ -37,6 +37,14 @@ TARGET_KPIS = [
     ("mcp_gw_failure_rate", "Failure rate", "%"),
 ]
 
+# Mapping from kpis.jsonl IDs to MLflow metrics.json keys (logged via mlflow.log_metric)
+_KPI_TO_MLFLOW_METRIC = {
+    "mcp_gw_requests_per_second": "requests_per_second",
+    "mcp_gw_p95_ms": "p95_ms",
+    "mcp_gw_p99_ms": "p99_ms",
+    "mcp_gw_failure_rate": "failure_rate",
+}
+
 
 class MCPGatewaySlackProvider(SlackNotificationProvider):
     """Slack notification provider for the mcp_gateway project."""
@@ -243,7 +251,15 @@ def _load_previous_kpis_from_mlflow() -> tuple[dict[str, float], str]:
 
             previous_run = runs[1]
             run_name = getattr(previous_run.info, "run_name", "") or previous_run.info.run_id[:8]
-            metrics = previous_run.data.metrics or {}
+            raw_metrics = previous_run.data.metrics or {}
+
+            # Translate MLflow metric keys to kpi_id format
+            mlflow_to_kpi = {v: k for k, v in _KPI_TO_MLFLOW_METRIC.items()}
+            metrics = {}
+            for mlflow_key, value in raw_metrics.items():
+                kpi_id = mlflow_to_kpi.get(mlflow_key)
+                if kpi_id:
+                    metrics[kpi_id] = value
 
             return metrics, run_name
 

--- a/projects/mcp_gateway/orchestration/notifications.py
+++ b/projects/mcp_gateway/orchestration/notifications.py
@@ -117,55 +117,6 @@ class MCPGatewaySlackProvider(SlackNotificationProvider):
 
         return "Thread for mcp_gateway run"
 
-    def notify(self, context: NotificationContext, *, dry_run: bool = False) -> bool:
-        """Override to skip notification for duplicate version/SHA runs."""
-        if not self.should_notify(context):
-            logger.info("Provider %s: should_notify returned False, skipping", type(self).__name__)
-            return True
-
-        token = self.get_slack_token()
-        if not token:
-            logger.warning("Provider %s: no Slack token available", type(self).__name__)
-            return False
-
-        channel_id = self.get_channel_id()
-        message = self.format_message(context)
-
-        if context.extra.get("_skip_notification"):
-            logger.info("Skipping notification: duplicate version/SHA already notified")
-            return True
-
-        anchor = self.get_thread_anchor(context)
-
-        import projects.core.notifications.slack.api as slack_api
-
-        client = slack_api.init_client(token)
-        if not client:
-            logger.error("Provider %s: failed to init Slack client", type(self).__name__)
-            return False
-
-        channel_msg_ts, _ = slack_api.search_channel_message(client, anchor, channel_id=channel_id)
-
-        if not channel_msg_ts:
-            channel_message = f"\U0001f9f5 {anchor}"
-            if dry_run:
-                logger.info("Would post channel message: %s", channel_message)
-            else:
-                channel_msg_ts, ok = slack_api.send_message(
-                    client, message=channel_message, channel_id=channel_id
-                )
-                if not ok:
-                    return False
-
-        if dry_run:
-            logger.info("Would post thread message:\n%s", message)
-            return True
-
-        _, ok = slack_api.send_message(
-            client, message=message, main_ts=channel_msg_ts, channel_id=channel_id
-        )
-        return ok
-
 
 # ---------------------------------------------------------------------------
 # Message sections (MCP Gateway specific)
@@ -198,7 +149,13 @@ def _format_kpi_table(context: NotificationContext) -> str:
     if not current_kpis:
         return ""
 
-    previous_kpis, previous_run_name, skip = _load_previous_kpis_from_mlflow()
+    # Extract current run_id from export status to avoid race with parallel jobs
+    current_run_id = None
+    if isinstance(context.status, dict):
+        backends = context.status.get("caliper_artifacts_export", {}).get("backends", {})
+        current_run_id = backends.get("mlflow", {}).get("run_id")
+
+    previous_kpis, previous_run_name, skip = _load_previous_kpis_from_mlflow(current_run_id)
 
     if skip:
         context.extra["_skip_notification"] = True
@@ -273,8 +230,14 @@ def _load_current_kpis(context: NotificationContext) -> dict[str, float]:
     return kpis
 
 
-def _load_previous_kpis_from_mlflow() -> tuple[dict[str, float], str, bool]:
+def _load_previous_kpis_from_mlflow(
+    current_run_id: str | None = None,
+) -> tuple[dict[str, float], str, bool]:
     """Query MLflow for the previous matching run's metrics.
+
+    Args:
+        current_run_id: MLflow run ID of this notification's run. When provided
+            the current run is located by ID (avoids races with parallel jobs).
 
     Matching rules:
     - Same load config (e.g. s150-u500)
@@ -335,7 +298,21 @@ def _load_previous_kpis_from_mlflow() -> tuple[dict[str, float], str, bool]:
                 logger.info("No previous MLflow run found for comparison")
                 return {}, "", False
 
-            current_run = runs[0]
+            # Locate the current run explicitly by ID when available
+            current_run = None
+            if current_run_id:
+                for run in runs:
+                    if run.info.run_id == current_run_id:
+                        current_run = run
+                        break
+                if current_run is None:
+                    logger.info(
+                        "Current run_id '%s' not found in recent runs, falling back to runs[0]",
+                        current_run_id,
+                    )
+            if current_run is None:
+                current_run = runs[0]
+
             current_name = getattr(current_run.info, "run_name", "") or current_run.info.run_id[:8]
             current_parsed = _parse_run_name(current_name)
             current_preset = (current_run.data.params or {}).get("preset", "")
@@ -346,7 +323,9 @@ def _load_previous_kpis_from_mlflow() -> tuple[dict[str, float], str, bool]:
 
             # Find previous run matching: same config, same type, same preset
             previous_run = None
-            for run in runs[1:]:
+            for run in runs:
+                if run.info.run_id == current_run.info.run_id:
+                    continue
                 candidate_name = getattr(run.info, "run_name", "") or run.info.run_id[:8]
                 candidate_parsed = _parse_run_name(candidate_name)
                 if not candidate_parsed:

--- a/projects/mcp_gateway/orchestration/notifications.py
+++ b/projects/mcp_gateway/orchestration/notifications.py
@@ -234,7 +234,10 @@ def _load_previous_kpis_from_mlflow() -> tuple[dict[str, float], str]:
             "caliper.export.backend.mlflow.secrets.vault.name", None, print=False, warn=False
         )
         vault_secret = config.project.get_config(
-            "caliper.export.backend.mlflow.secrets.vault.mlflow_secret", None, print=False, warn=False
+            "caliper.export.backend.mlflow.secrets.vault.mlflow_secret",
+            None,
+            print=False,
+            warn=False,
         )
         experiment_name = config.project.get_config(
             "caliper.export.backend.mlflow.config.experiment", None, print=False, warn=False

--- a/projects/mcp_gateway/orchestration/notifications.py
+++ b/projects/mcp_gateway/orchestration/notifications.py
@@ -15,6 +15,7 @@ import json
 import logging
 import os
 from pathlib import Path
+
 import yaml
 
 from projects.core.library import config

--- a/projects/mcp_gateway/orchestration/notifications.py
+++ b/projects/mcp_gateway/orchestration/notifications.py
@@ -47,7 +47,7 @@ class MCPGatewaySlackProvider(SlackNotificationProvider):
         header = _format_header(context)
         metadata = _format_metadata(context)
         kpi_table = _format_kpi_table(context)
-        links = _format_standard_links()
+        links = _format_standard_links(context)
         failure_info = _format_failure_info(context)
 
         parts = [header, metadata, kpi_table, links, failure_info]
@@ -74,9 +74,29 @@ class MCPGatewaySlackProvider(SlackNotificationProvider):
 
 def _format_header(context: NotificationContext) -> str:
     status_icon = ":done-circle-check:" if context.finish_reason == "success" else ":no-red-circle:"
-    duration = context.status.get("duration", "")
+    duration = _read_test_duration(context)
     duration_str = f" after {duration}" if duration else ""
     return f"{status_icon} *mcp_gateway test finished{duration_str}* {status_icon}"
+
+
+def _read_test_duration(context: NotificationContext) -> str:
+    """Read duration from 000__ci_metadata/test_duration.yaml."""
+    if not context.artifact_dir:
+        return ""
+
+    timing_file = context.artifact_dir / "000__ci_metadata" / "test_duration.yaml"
+    if not timing_file.exists():
+        candidates = list(context.artifact_dir.glob("**/000__ci_metadata/test_duration.yaml"))
+        if not candidates:
+            return ""
+        timing_file = candidates[0]
+
+    try:
+        with open(timing_file) as f:
+            data = yaml.safe_load(f) or {}
+        return data.get("duration", {}).get("formatted", "")
+    except Exception:
+        return ""
 
 
 def _format_metadata(context: NotificationContext) -> str:
@@ -105,20 +125,33 @@ def _format_kpi_table(context: NotificationContext) -> str:
         return _build_current_only(current_kpis)
 
 
-def _format_standard_links() -> str:
+def _format_standard_links(context: NotificationContext) -> str:
     """Generate artifact links reusing the core notification link builder."""
-    try:
-        def get_link(name, path, **kwargs):
-            return f"<{get_ocpci_link(path, **kwargs)}|{name}>"
+    lines = []
 
-        lines = [
-            f"\u2022 {get_link('Test results', '', is_dir=True)}",
-            f"\u2022 {get_link('Execution logs', 'run.log', is_raw_file=True)}",
-        ]
-        return "\n".join(lines)
+    try:
+        ci_link = get_ocpci_link("", is_dir=True)
+        if ci_link and "no_known_ci_engine" not in ci_link:
+            lines.append(f"\u2022 <{ci_link}|Test results>")
+            log_link = get_ocpci_link("run.log", is_raw_file=True)
+            lines.append(f"\u2022 <{log_link}|Execution logs>")
     except Exception as e:
-        logger.warning("Failed to generate artifact links: %s", e)
-        return ""
+        logger.debug("CI link generation unavailable: %s", e)
+
+    mlflow_url = _extract_mlflow_url(context)
+    if mlflow_url:
+        lines.append(f"\u2022 <{mlflow_url}|MLflow run>")
+
+    return "\n".join(lines) if lines else ""
+
+
+def _extract_mlflow_url(context: NotificationContext) -> str | None:
+    """Extract MLflow run URL from caliper export status."""
+    if not isinstance(context.status, dict):
+        return None
+    backends = context.status.get("caliper_artifacts_export", {}).get("backends", {})
+    mlflow_info = backends.get("mlflow", {})
+    return mlflow_info.get("run_url") or mlflow_info.get("experiment_url")
 
 
 def _format_failure_info(context: NotificationContext) -> str:
@@ -313,7 +346,10 @@ def _format_delta(current: float, previous: float, kpi_id: str) -> str:
 
 
 def _get_label_value(context: NotificationContext, key: str) -> str | None:
-    """Extract a value from test labels in artifact dir."""
+    """Extract a value from test labels in artifact dir.
+
+    The labels file format is: {"version": "1", "labels": {"key": "value", ...}}
+    """
     if not context.artifact_dir:
         return None
 
@@ -326,7 +362,9 @@ def _get_label_value(context: NotificationContext, key: str) -> str | None:
 
     try:
         with open(labels_file) as f:
-            labels = yaml.safe_load(f) or {}
-        return str(labels.get(key, "")) or None
+            data = yaml.safe_load(f) or {}
+        labels = data.get("labels", data)
+        val = labels.get(key, "")
+        return str(val) if val else None
     except Exception:
         return None

--- a/projects/mcp_gateway/orchestration/notifications.py
+++ b/projects/mcp_gateway/orchestration/notifications.py
@@ -2,8 +2,8 @@
 Per-project Slack notification provider for MCP Gateway.
 
 Sends structured performance summaries with KPI comparison against the
-previous MLflow run. Reuses artifact link generation from the core
-notification system.
+previous MLflow run. Reuses shared helpers from the core notification
+framework.
 
 Channel ID is read from the project's config.yaml at
 ``notifications.slack.channel_id``.
@@ -14,11 +14,17 @@ from __future__ import annotations
 import json
 import logging
 import os
-from pathlib import Path
-
-import yaml
 
 from projects.core.library import config
+from projects.core.notifications.helpers import (
+    build_comparison_table,
+    build_current_kpis_list,
+    extract_mlflow_url,
+    find_kpis_jsonl,
+    get_label_value,
+    get_test_artifacts_root,
+    read_test_duration,
+)
 from projects.core.notifications.provider import NotificationContext, SlackNotificationProvider
 from projects.core.notifications.send import get_ocpci_link
 
@@ -68,45 +74,26 @@ class MCPGatewaySlackProvider(SlackNotificationProvider):
 
 
 # ---------------------------------------------------------------------------
-# Message sections
+# Message sections (MCP Gateway specific)
 # ---------------------------------------------------------------------------
 
 
 def _format_header(context: NotificationContext) -> str:
     status_icon = ":done-circle-check:" if context.finish_reason == "success" else ":no-red-circle:"
-    duration = _read_test_duration(context)
+    duration = read_test_duration(context)
     duration_str = f" after {duration}" if duration else ""
     return f"{status_icon} *mcp_gateway test finished{duration_str}* {status_icon}"
-
-
-def _read_test_duration(context: NotificationContext) -> str:
-    """Read duration from 000__ci_metadata/test_duration.yaml."""
-    if not context.artifact_dir:
-        return ""
-
-    timing_file = context.artifact_dir / "000__ci_metadata" / "test_duration.yaml"
-    if not timing_file.exists():
-        candidates = list(context.artifact_dir.glob("**/000__ci_metadata/test_duration.yaml"))
-        if not candidates:
-            return ""
-        timing_file = candidates[0]
-
-    try:
-        with open(timing_file) as f:
-            data = yaml.safe_load(f) or {}
-        return data.get("duration", {}).get("formatted", "")
-    except Exception:
-        return ""
 
 
 def _format_metadata(context: NotificationContext) -> str:
     version = os.environ.get("MCP_GATEWAY_VERSION", "")
     preset = os.environ.get("MCP_GATEWAY_PRESET", "")
 
+    test_root = get_test_artifacts_root(context)
     if not version:
-        version = _get_label_value(context, "mcp_gateway_version") or "unknown"
+        version = get_label_value(test_root, "mcp_gateway_version") or "unknown"
     if not preset:
-        preset = _get_label_value(context, "preset") or "default"
+        preset = get_label_value(test_root, "preset") or "default"
 
     return f"*Version*: `{version}`  |  *Preset*: `{preset}`"
 
@@ -120,9 +107,9 @@ def _format_kpi_table(context: NotificationContext) -> str:
     previous_kpis, previous_run_name = _load_previous_kpis_from_mlflow()
 
     if previous_kpis:
-        return _build_comparison_table(current_kpis, previous_kpis, previous_run_name)
+        return build_comparison_table(current_kpis, previous_kpis, previous_run_name, TARGET_KPIS)
     else:
-        return _build_current_only(current_kpis)
+        return build_current_kpis_list(current_kpis, TARGET_KPIS)
 
 
 def _format_standard_links(context: NotificationContext) -> str:
@@ -138,20 +125,11 @@ def _format_standard_links(context: NotificationContext) -> str:
     except Exception as e:
         logger.debug("CI link generation unavailable: %s", e)
 
-    mlflow_url = _extract_mlflow_url(context)
+    mlflow_url = extract_mlflow_url(context)
     if mlflow_url:
         lines.append(f"\u2022 <{mlflow_url}|MLflow run>")
 
     return "\n".join(lines) if lines else ""
-
-
-def _extract_mlflow_url(context: NotificationContext) -> str | None:
-    """Extract MLflow run URL from caliper export status."""
-    if not isinstance(context.status, dict):
-        return None
-    backends = context.status.get("caliper_artifacts_export", {}).get("backends", {})
-    mlflow_info = backends.get("mlflow", {})
-    return mlflow_info.get("run_url") or mlflow_info.get("experiment_url")
 
 
 def _format_failure_info(context: NotificationContext) -> str:
@@ -177,16 +155,17 @@ def _format_failure_info(context: NotificationContext) -> str:
 
 
 # ---------------------------------------------------------------------------
-# KPI loading
+# KPI loading (MCP Gateway specific)
 # ---------------------------------------------------------------------------
 
 
 def _load_current_kpis(context: NotificationContext) -> dict[str, float]:
     """Read KPI values from kpis.jsonl in the artifact directory."""
-    if not context.artifact_dir:
+    test_root = get_test_artifacts_root(context)
+    if not test_root:
         return {}
 
-    kpis_file = _find_kpis_jsonl(context.artifact_dir)
+    kpis_file = find_kpis_jsonl(test_root)
     if not kpis_file:
         return {}
 
@@ -205,17 +184,6 @@ def _load_current_kpis(context: NotificationContext) -> dict[str, float]:
         logger.warning("Failed to read kpis.jsonl: %s", e)
 
     return kpis
-
-
-def _find_kpis_jsonl(artifact_dir: Path) -> Path | None:
-    """Find kpis.jsonl in artifact directory tree."""
-    direct = artifact_dir / "kpis.jsonl"
-    if direct.exists():
-        return direct
-
-    for f in artifact_dir.glob("**/kpis.jsonl"):
-        return f
-    return None
 
 
 def _load_previous_kpis_from_mlflow() -> tuple[dict[str, float], str]:
@@ -282,92 +250,3 @@ def _load_previous_kpis_from_mlflow() -> tuple[dict[str, float], str]:
     except Exception as e:
         logger.warning("MLflow comparison unavailable: %s", e)
         return {}, ""
-
-
-# ---------------------------------------------------------------------------
-# Formatting helpers
-# ---------------------------------------------------------------------------
-
-
-def _build_comparison_table(
-    current: dict[str, float], previous: dict[str, float], prev_run_name: str
-) -> str:
-    """Format a Slack-friendly comparison table."""
-    lines = [f"*KPI comparison* (vs `{prev_run_name}`):", "```"]
-
-    header = f"{'KPI':<16}| {'Previous':>10} | {'Current':>10} | {'Delta':>8}"
-    lines.append(header)
-    lines.append("-" * len(header))
-
-    for kpi_id, display_name, unit in TARGET_KPIS:
-        cur_val = current.get(kpi_id)
-        prev_val = previous.get(kpi_id)
-
-        if cur_val is None:
-            continue
-
-        cur_str = _format_value(cur_val, unit)
-        prev_str = _format_value(prev_val, unit) if prev_val is not None else "n/a"
-        delta_str = _format_delta(cur_val, prev_val, kpi_id) if prev_val is not None else "n/a"
-
-        lines.append(f"{display_name:<16}| {prev_str:>10} | {cur_str:>10} | {delta_str:>8}")
-
-    lines.append("```")
-    return "\n".join(lines)
-
-
-def _build_current_only(current: dict[str, float]) -> str:
-    """Format current KPIs as a simple list (no comparison available)."""
-    lines = ["*Current KPIs*:"]
-    for kpi_id, display_name, unit in TARGET_KPIS:
-        val = current.get(kpi_id)
-        if val is None:
-            continue
-        lines.append(f"  \u2022 {display_name}: `{_format_value(val, unit)}`")
-
-    return "\n".join(lines) if len(lines) > 1 else ""
-
-
-def _format_value(value: float | None, unit: str) -> str:
-    if value is None:
-        return "n/a"
-    if unit == "%":
-        return f"{value * 100:.2f}%"
-    if unit == "ms":
-        return f"{value:.1f} ms"
-    if unit == "req/s":
-        return f"{value:.0f}"
-    return f"{value:.2f}"
-
-
-def _format_delta(current: float, previous: float, kpi_id: str) -> str:
-    if previous == 0:
-        return "n/a"
-    pct = ((current - previous) / abs(previous)) * 100
-    sign = "+" if pct >= 0 else ""
-    return f"{sign}{pct:.1f}%"
-
-
-def _get_label_value(context: NotificationContext, key: str) -> str | None:
-    """Extract a value from test labels in artifact dir.
-
-    The labels file format is: {"version": "1", "labels": {"key": "value", ...}}
-    """
-    if not context.artifact_dir:
-        return None
-
-    labels_file = context.artifact_dir / "__test_labels__.yaml"
-    if not labels_file.exists():
-        labels_glob = list(context.artifact_dir.glob("**/__test_labels__.yaml"))
-        if not labels_glob:
-            return None
-        labels_file = labels_glob[0]
-
-    try:
-        with open(labels_file) as f:
-            data = yaml.safe_load(f) or {}
-        labels = data.get("labels", data)
-        val = labels.get(key, "")
-        return str(val) if val else None
-    except Exception:
-        return None

--- a/projects/mcp_gateway/orchestration/notifications.py
+++ b/projects/mcp_gateway/orchestration/notifications.py
@@ -15,8 +15,6 @@ import json
 import logging
 import os
 from pathlib import Path
-from typing import Any
-
 import yaml
 
 from projects.core.library import config

--- a/projects/mcp_gateway/orchestration/notifications.py
+++ b/projects/mcp_gateway/orchestration/notifications.py
@@ -1,0 +1,333 @@
+"""
+Per-project Slack notification provider for MCP Gateway.
+
+Sends structured performance summaries with KPI comparison against the
+previous MLflow run. Reuses artifact link generation from the core
+notification system.
+
+Channel ID is read from the project's config.yaml at
+``notifications.slack.channel_id``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from projects.core.library import config
+from projects.core.notifications.provider import NotificationContext, SlackNotificationProvider
+from projects.core.notifications.send import get_ocpci_link
+
+logger = logging.getLogger(__name__)
+
+TARGET_KPIS = [
+    ("mcp_gw_requests_per_second", "RPS", "req/s"),
+    ("mcp_gw_p95_ms", "P95 latency", "ms"),
+    ("mcp_gw_p99_ms", "P99 latency", "ms"),
+    ("mcp_gw_failure_rate", "Failure rate", "%"),
+]
+
+
+class MCPGatewaySlackProvider(SlackNotificationProvider):
+    """Slack notification provider for the mcp_gateway project."""
+
+    def get_channel_id(self) -> str:
+        channel_id = config.project.get_config(
+            "notifications.slack.channel_id", None, print=False, warn=False
+        )
+        if not channel_id:
+            raise ValueError("notifications.slack.channel_id must be set in config.yaml")
+        return channel_id
+
+    def format_message(self, context: NotificationContext) -> str:
+        header = _format_header(context)
+        metadata = _format_metadata(context)
+        kpi_table = _format_kpi_table(context)
+        links = _format_standard_links()
+        failure_info = _format_failure_info(context)
+
+        parts = [header, metadata, kpi_table, links, failure_info]
+        return "\n\n".join(filter(None, parts))
+
+    def get_thread_anchor(self, context: NotificationContext) -> str:
+        if context.pr_number:
+            return f"Thread for mcp_gateway PR #{context.pr_number}"
+
+        job_name = os.environ.get("FJOB_NAME") or os.environ.get("JOB_NAME_SAFE", "")
+        if job_name:
+            return f"Thread for mcp_gateway `{job_name}`"
+
+        return "Thread for mcp_gateway run"
+
+    def should_notify(self, context: NotificationContext) -> bool:
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Message sections
+# ---------------------------------------------------------------------------
+
+
+def _format_header(context: NotificationContext) -> str:
+    status_icon = ":done-circle-check:" if context.finish_reason == "success" else ":no-red-circle:"
+    duration = context.status.get("duration", "")
+    duration_str = f" after {duration}" if duration else ""
+    return f"{status_icon} *mcp_gateway test finished{duration_str}* {status_icon}"
+
+
+def _format_metadata(context: NotificationContext) -> str:
+    version = os.environ.get("MCP_GATEWAY_VERSION", "")
+    preset = os.environ.get("MCP_GATEWAY_PRESET", "")
+
+    if not version:
+        version = _get_label_value(context, "mcp_gateway_version") or "unknown"
+    if not preset:
+        preset = _get_label_value(context, "preset") or "default"
+
+    return f"*Version*: `{version}`  |  *Preset*: `{preset}`"
+
+
+def _format_kpi_table(context: NotificationContext) -> str:
+    """Build comparison table: current KPIs vs previous MLflow run."""
+    current_kpis = _load_current_kpis(context)
+    if not current_kpis:
+        return ""
+
+    previous_kpis, previous_run_name = _load_previous_kpis_from_mlflow()
+
+    if previous_kpis:
+        return _build_comparison_table(current_kpis, previous_kpis, previous_run_name)
+    else:
+        return _build_current_only(current_kpis)
+
+
+def _format_standard_links() -> str:
+    """Generate artifact links reusing the core notification link builder."""
+    try:
+        def get_link(name, path, **kwargs):
+            return f"<{get_ocpci_link(path, **kwargs)}|{name}>"
+
+        lines = [
+            f"\u2022 {get_link('Test results', '', is_dir=True)}",
+            f"\u2022 {get_link('Execution logs', 'run.log', is_raw_file=True)}",
+        ]
+        return "\n".join(lines)
+    except Exception as e:
+        logger.warning("Failed to generate artifact links: %s", e)
+        return ""
+
+
+def _format_failure_info(context: NotificationContext) -> str:
+    """Include structured failure details when test failed."""
+    if context.finish_reason == "success":
+        return ""
+    if not context.artifact_dir:
+        return ""
+
+    try:
+        from projects.core.notifications.send import _get_notification_content
+
+        def get_link(name, path, **kwargs):
+            return f"<{get_ocpci_link(path, **kwargs)}|{name}>"
+
+        def get_bold(text):
+            return f"*{text}*"
+
+        return _get_notification_content(context.artifact_dir, get_link, get_bold)
+    except Exception as e:
+        logger.warning("Failed to extract failure info: %s", e)
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# KPI loading
+# ---------------------------------------------------------------------------
+
+
+def _load_current_kpis(context: NotificationContext) -> dict[str, float]:
+    """Read KPI values from kpis.jsonl in the artifact directory."""
+    if not context.artifact_dir:
+        return {}
+
+    kpis_file = _find_kpis_jsonl(context.artifact_dir)
+    if not kpis_file:
+        return {}
+
+    kpis: dict[str, float] = {}
+    try:
+        with open(kpis_file) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                record = json.loads(line)
+                kpi_id = record.get("kpi_id", "")
+                if kpi_id in {k[0] for k in TARGET_KPIS}:
+                    kpis[kpi_id] = record.get("value", 0)
+    except Exception as e:
+        logger.warning("Failed to read kpis.jsonl: %s", e)
+
+    return kpis
+
+
+def _find_kpis_jsonl(artifact_dir: Path) -> Path | None:
+    """Find kpis.jsonl in artifact directory tree."""
+    direct = artifact_dir / "kpis.jsonl"
+    if direct.exists():
+        return direct
+
+    for f in artifact_dir.glob("**/kpis.jsonl"):
+        return f
+    return None
+
+
+def _load_previous_kpis_from_mlflow() -> tuple[dict[str, float], str]:
+    """Query MLflow for the most recent previous run's metrics.
+
+    Returns (metrics_dict, run_name) or ({}, "") if unavailable.
+    """
+    try:
+        from projects.caliper.engine.file_export.mlflow_secrets import (
+            load_mlflow_secrets_yaml,
+            mlflow_connection_env,
+        )
+        from projects.core.library import vault as vault_lib
+
+        vault_name = config.project.get_config(
+            "caliper.export.backend.mlflow.secrets.vault.name", None, print=False, warn=False
+        )
+        vault_secret = config.project.get_config(
+            "caliper.export.backend.mlflow.secrets.vault.mlflow_secret", None, print=False, warn=False
+        )
+        experiment_name = config.project.get_config(
+            "caliper.export.backend.mlflow.config.experiment", None, print=False, warn=False
+        )
+
+        if not all([vault_name, vault_secret, experiment_name]):
+            logger.info("MLflow config incomplete, skipping comparison")
+            return {}, ""
+
+        secrets_path = vault_lib.get_vault_content_path(vault_name, vault_secret)
+        if not secrets_path or not secrets_path.exists():
+            logger.info("MLflow secrets not available, skipping comparison")
+            return {}, ""
+
+        secrets = load_mlflow_secrets_yaml(secrets_path)
+
+        with mlflow_connection_env(secrets):
+            import mlflow
+
+            client = mlflow.tracking.MlflowClient()
+            exp = client.get_experiment_by_name(experiment_name)
+            if not exp:
+                logger.info("MLflow experiment '%s' not found", experiment_name)
+                return {}, ""
+
+            runs = client.search_runs(
+                experiment_ids=[exp.experiment_id],
+                order_by=["start_time DESC"],
+                max_results=2,
+            )
+
+            if len(runs) < 2:
+                logger.info("No previous MLflow run found for comparison")
+                return {}, ""
+
+            previous_run = runs[1]
+            run_name = getattr(previous_run.info, "run_name", "") or previous_run.info.run_id[:8]
+            metrics = previous_run.data.metrics or {}
+
+            return metrics, run_name
+
+    except Exception as e:
+        logger.warning("MLflow comparison unavailable: %s", e)
+        return {}, ""
+
+
+# ---------------------------------------------------------------------------
+# Formatting helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_comparison_table(
+    current: dict[str, float], previous: dict[str, float], prev_run_name: str
+) -> str:
+    """Format a Slack-friendly comparison table."""
+    lines = [f"*KPI comparison* (vs `{prev_run_name}`):", "```"]
+
+    header = f"{'KPI':<16}| {'Previous':>10} | {'Current':>10} | {'Delta':>8}"
+    lines.append(header)
+    lines.append("-" * len(header))
+
+    for kpi_id, display_name, unit in TARGET_KPIS:
+        cur_val = current.get(kpi_id)
+        prev_val = previous.get(kpi_id)
+
+        if cur_val is None:
+            continue
+
+        cur_str = _format_value(cur_val, unit)
+        prev_str = _format_value(prev_val, unit) if prev_val is not None else "n/a"
+        delta_str = _format_delta(cur_val, prev_val, kpi_id) if prev_val is not None else "n/a"
+
+        lines.append(f"{display_name:<16}| {prev_str:>10} | {cur_str:>10} | {delta_str:>8}")
+
+    lines.append("```")
+    return "\n".join(lines)
+
+
+def _build_current_only(current: dict[str, float]) -> str:
+    """Format current KPIs as a simple list (no comparison available)."""
+    lines = ["*Current KPIs*:"]
+    for kpi_id, display_name, unit in TARGET_KPIS:
+        val = current.get(kpi_id)
+        if val is None:
+            continue
+        lines.append(f"  \u2022 {display_name}: `{_format_value(val, unit)}`")
+
+    return "\n".join(lines) if len(lines) > 1 else ""
+
+
+def _format_value(value: float | None, unit: str) -> str:
+    if value is None:
+        return "n/a"
+    if unit == "%":
+        return f"{value * 100:.2f}%"
+    if unit == "ms":
+        return f"{value:.1f} ms"
+    if unit == "req/s":
+        return f"{value:.0f}"
+    return f"{value:.2f}"
+
+
+def _format_delta(current: float, previous: float, kpi_id: str) -> str:
+    if previous == 0:
+        return "n/a"
+    pct = ((current - previous) / abs(previous)) * 100
+    sign = "+" if pct >= 0 else ""
+    return f"{sign}{pct:.1f}%"
+
+
+def _get_label_value(context: NotificationContext, key: str) -> str | None:
+    """Extract a value from test labels in artifact dir."""
+    if not context.artifact_dir:
+        return None
+
+    labels_file = context.artifact_dir / "__test_labels__.yaml"
+    if not labels_file.exists():
+        labels_glob = list(context.artifact_dir.glob("**/__test_labels__.yaml"))
+        if not labels_glob:
+            return None
+        labels_file = labels_glob[0]
+
+    try:
+        with open(labels_file) as f:
+            labels = yaml.safe_load(f) or {}
+        return str(labels.get(key, "")) or None
+    except Exception:
+        return None

--- a/projects/mcp_gateway/orchestration/notifications.py
+++ b/projects/mcp_gateway/orchestration/notifications.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 
 from projects.core.library import config
 from projects.core.notifications.helpers import (
@@ -44,6 +45,45 @@ _KPI_TO_MLFLOW_METRIC = {
     "mcp_gw_p99_ms": "p99_ms",
     "mcp_gw_failure_rate": "failure_rate",
 }
+
+_RUN_NAME_PREFIX = "forge-mcp-gateway-"
+
+
+def _parse_run_name(run_name: str) -> dict | None:
+    """Parse a forge-mcp-gateway run name into components.
+
+    Expected formats:
+      forge-mcp-gateway-s150-u500-vsha-<hash>-YYYYMMDD-HHMMSS
+      forge-mcp-gateway-s150-u500-v0.7.0-YYYYMMDD-HHMMSS
+      forge-mcp-gateway-0.5.1-YYYYMMDD-HHMMSS
+
+    Returns dict with keys: config, is_sha, version — or None if unparseable.
+    """
+    if not run_name.startswith(_RUN_NAME_PREFIX):
+        return None
+
+    rest = run_name[len(_RUN_NAME_PREFIX) :]
+
+    config = None
+    config_match = re.match(r"(s\d+-u\d+)-", rest)
+    if config_match:
+        config = config_match.group(1)
+        rest = rest[config_match.end() :]
+
+    is_sha = False
+    version = None
+
+    if rest.startswith("vsha-"):
+        is_sha = True
+        sha_match = re.match(r"vsha-([a-f0-9]+)-\d{8}-\d{6}$", rest)
+        if sha_match:
+            version = sha_match.group(1)
+    else:
+        version_match = re.match(r"v?(.+?)-\d{8}-\d{6}$", rest)
+        if version_match:
+            version = version_match.group(1)
+
+    return {"config": config, "is_sha": is_sha, "version": version}
 
 
 class MCPGatewaySlackProvider(SlackNotificationProvider):
@@ -77,8 +117,54 @@ class MCPGatewaySlackProvider(SlackNotificationProvider):
 
         return "Thread for mcp_gateway run"
 
-    def should_notify(self, context: NotificationContext) -> bool:
-        return True
+    def notify(self, context: NotificationContext, *, dry_run: bool = False) -> bool:
+        """Override to skip notification for duplicate version/SHA runs."""
+        if not self.should_notify(context):
+            logger.info("Provider %s: should_notify returned False, skipping", type(self).__name__)
+            return True
+
+        token = self.get_slack_token()
+        if not token:
+            logger.warning("Provider %s: no Slack token available", type(self).__name__)
+            return False
+
+        channel_id = self.get_channel_id()
+        message = self.format_message(context)
+
+        if context.extra.get("_skip_notification"):
+            logger.info("Skipping notification: duplicate version/SHA already notified")
+            return True
+
+        anchor = self.get_thread_anchor(context)
+
+        import projects.core.notifications.slack.api as slack_api
+
+        client = slack_api.init_client(token)
+        if not client:
+            logger.error("Provider %s: failed to init Slack client", type(self).__name__)
+            return False
+
+        channel_msg_ts, _ = slack_api.search_channel_message(client, anchor, channel_id=channel_id)
+
+        if not channel_msg_ts:
+            channel_message = f"\U0001f9f5 {anchor}"
+            if dry_run:
+                logger.info("Would post channel message: %s", channel_message)
+            else:
+                channel_msg_ts, ok = slack_api.send_message(
+                    client, message=channel_message, channel_id=channel_id
+                )
+                if not ok:
+                    return False
+
+        if dry_run:
+            logger.info("Would post thread message:\n%s", message)
+            return True
+
+        _, ok = slack_api.send_message(
+            client, message=message, main_ts=channel_msg_ts, channel_id=channel_id
+        )
+        return ok
 
 
 # ---------------------------------------------------------------------------
@@ -112,7 +198,11 @@ def _format_kpi_table(context: NotificationContext) -> str:
     if not current_kpis:
         return ""
 
-    previous_kpis, previous_run_name = _load_previous_kpis_from_mlflow()
+    previous_kpis, previous_run_name, skip = _load_previous_kpis_from_mlflow()
+
+    if skip:
+        context.extra["_skip_notification"] = True
+        return ""
 
     if previous_kpis:
         return build_comparison_table(current_kpis, previous_kpis, previous_run_name, TARGET_KPIS)
@@ -121,23 +211,12 @@ def _format_kpi_table(context: NotificationContext) -> str:
 
 
 def _format_standard_links(context: NotificationContext) -> str:
-    """Generate artifact links reusing the core notification link builder."""
-    lines = []
-
-    try:
-        ci_link = get_ocpci_link("", is_dir=True)
-        if ci_link and "no_known_ci_engine" not in ci_link:
-            lines.append(f"\u2022 <{ci_link}|Test results>")
-            log_link = get_ocpci_link("run.log", is_raw_file=True)
-            lines.append(f"\u2022 <{log_link}|Execution logs>")
-    except Exception as e:
-        logger.debug("CI link generation unavailable: %s", e)
-
+    """Generate artifact links pointing to MLflow."""
     mlflow_url = extract_mlflow_url(context)
-    if mlflow_url:
-        lines.append(f"\u2022 <{mlflow_url}|MLflow run>")
+    if not mlflow_url:
+        return ""
 
-    return "\n".join(lines) if lines else ""
+    return f"\u2022 <{mlflow_url}|MLflow run (results & logs)>"
 
 
 def _format_failure_info(context: NotificationContext) -> str:
@@ -194,10 +273,17 @@ def _load_current_kpis(context: NotificationContext) -> dict[str, float]:
     return kpis
 
 
-def _load_previous_kpis_from_mlflow() -> tuple[dict[str, float], str]:
-    """Query MLflow for the most recent previous run's metrics.
+def _load_previous_kpis_from_mlflow() -> tuple[dict[str, float], str, bool]:
+    """Query MLflow for the previous matching run's metrics.
 
-    Returns (metrics_dict, run_name) or ({}, "") if unavailable.
+    Matching rules:
+    - Same load config (e.g. s150-u500)
+    - Same version type (SHA-based compared only to SHA-based, release to release)
+    - Same preset parameter value
+
+    Returns (metrics_dict, run_name, skip_notification):
+    - skip_notification is True when the previous matching run has the same
+      version/SHA (duplicate run, notification already sent).
     """
     try:
         from projects.caliper.engine.file_export.mlflow_secrets import (
@@ -221,12 +307,12 @@ def _load_previous_kpis_from_mlflow() -> tuple[dict[str, float], str]:
 
         if not all([vault_name, vault_secret, experiment_name]):
             logger.info("MLflow config incomplete, skipping comparison")
-            return {}, ""
+            return {}, "", False
 
         secrets_path = vault_lib.get_vault_content_path(vault_name, vault_secret)
         if not secrets_path or not secrets_path.exists():
             logger.info("MLflow secrets not available, skipping comparison")
-            return {}, ""
+            return {}, "", False
 
         secrets = load_mlflow_secrets_yaml(secrets_path)
 
@@ -237,23 +323,68 @@ def _load_previous_kpis_from_mlflow() -> tuple[dict[str, float], str]:
             exp = client.get_experiment_by_name(experiment_name)
             if not exp:
                 logger.info("MLflow experiment '%s' not found", experiment_name)
-                return {}, ""
+                return {}, "", False
 
             runs = client.search_runs(
                 experiment_ids=[exp.experiment_id],
                 order_by=["start_time DESC"],
-                max_results=2,
+                max_results=50,
             )
 
             if len(runs) < 2:
                 logger.info("No previous MLflow run found for comparison")
-                return {}, ""
+                return {}, "", False
 
-            previous_run = runs[1]
-            run_name = getattr(previous_run.info, "run_name", "") or previous_run.info.run_id[:8]
+            current_run = runs[0]
+            current_name = getattr(current_run.info, "run_name", "") or current_run.info.run_id[:8]
+            current_parsed = _parse_run_name(current_name)
+            current_preset = (current_run.data.params or {}).get("preset", "")
+
+            if not current_parsed:
+                logger.info("Cannot parse current run name '%s', skipping comparison", current_name)
+                return {}, "", False
+
+            # Find previous run matching: same config, same type, same preset
+            previous_run = None
+            for run in runs[1:]:
+                candidate_name = getattr(run.info, "run_name", "") or run.info.run_id[:8]
+                candidate_parsed = _parse_run_name(candidate_name)
+                if not candidate_parsed:
+                    continue
+
+                if candidate_parsed["config"] != current_parsed["config"]:
+                    continue
+                if candidate_parsed["is_sha"] != current_parsed["is_sha"]:
+                    continue
+
+                candidate_preset = (run.data.params or {}).get("preset", "")
+                if candidate_preset != current_preset:
+                    continue
+
+                previous_run = run
+                break
+
+            if previous_run is None:
+                logger.info(
+                    "No previous run matches config=%s, is_sha=%s, preset=%s",
+                    current_parsed["config"],
+                    current_parsed["is_sha"],
+                    current_preset,
+                )
+                return {}, "", False
+
+            prev_name = getattr(previous_run.info, "run_name", "") or previous_run.info.run_id[:8]
+            prev_parsed = _parse_run_name(prev_name)
+
+            # Check for duplicate: same version/SHA means already notified
+            if prev_parsed and prev_parsed["version"] == current_parsed["version"]:
+                logger.info(
+                    "Previous matching run has same version '%s', skipping notification",
+                    current_parsed["version"],
+                )
+                return {}, "", True
+
             raw_metrics = previous_run.data.metrics or {}
-
-            # Translate MLflow metric keys to kpi_id format
             mlflow_to_kpi = {v: k for k, v in _KPI_TO_MLFLOW_METRIC.items()}
             metrics = {}
             for mlflow_key, value in raw_metrics.items():
@@ -261,8 +392,8 @@ def _load_previous_kpis_from_mlflow() -> tuple[dict[str, float], str]:
                 if kpi_id:
                     metrics[kpi_id] = value
 
-            return metrics, run_name
+            return metrics, prev_name, False
 
     except Exception as e:
         logger.warning("MLflow comparison unavailable: %s", e)
-        return {}, ""
+        return {}, "", False


### PR DESCRIPTION
Add a pluggable notification provider system allowing each FORGE project to define its own Slack notification behavior. Implement MCPGatewaySlackProvider with structured messages including KPI comparison against previous MLflow runs.

- Add SlackNotificationProvider ABC and NotificationContext dataclass
- Auto-discover provider via config.yaml (notifications.slack.provider_module)
- Parameterize Slack API helpers to accept arbitrary channel_id
- MCP Gateway provider: header, metadata, KPI table, artifact links
- Reuse get_ocpci_link from core notification system for link generation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Slack notifications for MCP Gateway runs.
  * Notifications now include run duration, key KPI summaries, MLflow links, and structured failure details.
  * Messages are posted in threads for easier follow-up and are routed to the configured Slack channel.

* **Bug Fixes**
  * Reduced duplicate notifications by suppressing repeats for matching runs.
  * Improved notification delivery handling when Slack setup is unavailable or incomplete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->