### PR TITLE
fix: pass full image reference to run_guidellm_benchmark

### DIFF
--- a/projects/rhaiis/orchestration/test_phase.py
+++ b/projects/rhaiis/orchestration/test_phase.py
@@ -115,7 +115,6 @@ def _run_test(
         logger.info("Running benchmark at rates=%s", rates)
 
         benchmark_image = benchmark_cfg.get("image", "ghcr.io/vllm-project/guidellm:v0.6.0")
-        image, version = runtime_config.split_image_tag(benchmark_image)
 
         guidellm_args = runtime_config.build_guidellm_args(
             benchmark_cfg=benchmark_cfg,
@@ -129,8 +128,7 @@ def _run_test(
             endpoint_url=f"{endpoint_url}/v1",
             name=f"guidellm-{deployment_name}",
             namespace=namespace,
-            image=image,
-            version=version,
+            image=benchmark_image,
             timeout=benchmark_timeout,
             pvc_size=benchmark_cfg.get("pvc_size", "5Gi"),
             guidellm_args=guidellm_args,


### PR DESCRIPTION
## Summary
- The shared `run_guidellm_benchmark` function was refactored to take a single `image` param (full `image:tag`), but rhaiis `test_phase.py` still split them and passed `version` as a separate kwarg
- The `version` kwarg was silently ignored, causing the guidellm job to pull `:latest` instead of `:v0.6.0` and crash immediately on startup (`BackoffLimitExceeded` within 2 seconds)
- Fix: pass the full `benchmark_image` directly as `image` and remove the unused `version` kwarg

## Test plan
- [x] Submitted FournosJob `rhaiis-mlflow-full-n277x` — guidellm pod now running successfully (previously crashed within 2s)
- [ ] Verify full pipeline completes end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated benchmark execution to use the full configured image reference as provided, which improves consistency when running benchmarks with custom image tags or references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->