### PR TITLE
feat: add prepare and cleanup steps for rhaiis project

### DIFF
--- a/projects/rhaiis/orchestration/ci.py
+++ b/projects/rhaiis/orchestration/ci.py
@@ -7,6 +7,7 @@ import click
 import prepare_rhaiis
 import test_rhaiis
 
+from projects.core.agentic.on_failure import agent_review_on_failure
 from projects.core.ci_entrypoint.fournos_resolve import create_fournos_resolve_entrypoint
 from projects.core.library import ci as ci_lib
 from projects.core.library import vault
@@ -59,6 +60,7 @@ def main(ctx):
 @main.command()
 @click.pass_context
 @ci_lib.safe_ci_entrypoint
+@agent_review_on_failure
 def prepare(ctx):
     """Prepare phase - Set up environment and dependencies."""
     return prepare_rhaiis.prepare()
@@ -83,19 +85,33 @@ def pre_cleanup(ctx):
 @main.command()
 @click.pass_context
 @ci_lib.safe_ci_entrypoint
+@agent_review_on_failure
 def post_cleanup(ctx):
     """Post-cleanup phase - Clean up resources after test."""
     return prepare_rhaiis.cleanup()
+
+
+REQUIRED_CRDS = [
+    "inferenceservices.serving.kserve.io",
+    "servingruntimes.serving.kserve.io",
+]
 
 
 @main.command()
 @click.pass_context
 @ci_lib.safe_ci_entrypoint
 def preflight(ctx) -> int:
-    """Preflight check phase - Validate that the cluster if ready for testing."""
+    """Preflight check phase - Validate that the cluster is ready for testing."""
+    from projects.core.dsl.utils.k8s import oc_resource_exists
 
-    logger.warning("Nothing so far for the preflight check")
+    logger.info("Starting preflight checks")
+    missing = [crd for crd in REQUIRED_CRDS if not oc_resource_exists("crd", crd)]
 
+    if missing:
+        logger.error("Preflight failed — missing CRDs: %s", ", ".join(missing))
+        return 1
+
+    logger.info("Preflight passed — all required CRDs present")
     return 0
 
 

--- a/projects/rhaiis/orchestration/ci.py
+++ b/projects/rhaiis/orchestration/ci.py
@@ -7,7 +7,6 @@ import click
 import prepare_rhaiis
 import test_rhaiis
 
-from projects.core.agentic.on_failure import agent_review_on_failure
 from projects.core.ci_entrypoint.fournos_resolve import create_fournos_resolve_entrypoint
 from projects.core.library import ci as ci_lib
 from projects.core.library import vault
@@ -60,7 +59,6 @@ def main(ctx):
 @main.command()
 @click.pass_context
 @ci_lib.safe_ci_entrypoint
-@agent_review_on_failure
 def prepare(ctx):
     """Prepare phase - Set up environment and dependencies."""
     return prepare_rhaiis.prepare()
@@ -85,7 +83,6 @@ def pre_cleanup(ctx):
 @main.command()
 @click.pass_context
 @ci_lib.safe_ci_entrypoint
-@agent_review_on_failure
 def post_cleanup(ctx):
     """Post-cleanup phase - Clean up resources after test."""
     return prepare_rhaiis.cleanup()

--- a/projects/rhaiis/orchestration/ci.py
+++ b/projects/rhaiis/orchestration/ci.py
@@ -88,12 +88,6 @@ def post_cleanup(ctx):
     return prepare_rhaiis.cleanup()
 
 
-REQUIRED_CRDS = [
-    "inferenceservices.serving.kserve.io",
-    "servingruntimes.serving.kserve.io",
-]
-
-
 @main.command()
 @click.pass_context
 @ci_lib.safe_ci_entrypoint
@@ -101,14 +95,43 @@ def preflight(ctx) -> int:
     """Preflight check phase - Validate that the cluster is ready for testing."""
     from projects.core.dsl.utils.k8s import oc_resource_exists
 
-    logger.info("Starting preflight checks")
-    missing = [crd for crd in REQUIRED_CRDS if not oc_resource_exists("crd", crd)]
+    platform = runtime_config.get_platform_config()
+    deploy_cfg = runtime_config.get_deploy_config()
+    ns = runtime_config.get_namespace()
+    errors = []
 
-    if missing:
-        logger.error("Preflight failed — missing CRDs: %s", ", ".join(missing))
+    logger.info("Starting preflight checks")
+
+    required_crds = platform.get("required_crds", [])
+    for crd in required_crds:
+        if not oc_resource_exists("crd", crd):
+            errors.append(f"CRD not found: {crd}")
+        else:
+            logger.info("CRD found: %s", crd)
+
+    if not oc_resource_exists("namespace", ns):
+        errors.append(f"Namespace not found: {ns}")
+    else:
+        logger.info("Namespace found: %s", ns)
+
+    secret_name = deploy_cfg.get("image_pull_secret", "")
+    if secret_name and not oc_resource_exists("secret", secret_name, namespace=ns):
+        errors.append(f"Image pull secret not found: {secret_name} in {ns}")
+    elif secret_name:
+        logger.info("Image pull secret found: %s in %s", secret_name, ns)
+
+    pvc_name = deploy_cfg.get("storage_pvc", "")
+    if pvc_name and not oc_resource_exists("pvc", pvc_name, namespace=ns):
+        errors.append(f"PVC not found: {pvc_name} in {ns}")
+    elif pvc_name:
+        logger.info("PVC found: %s in %s", pvc_name, ns)
+
+    if errors:
+        for err in errors:
+            logger.error("Preflight failed — %s", err)
         return 1
 
-    logger.info("Preflight passed — all required CRDs present")
+    logger.info("Preflight passed — all checks passed")
     return 0
 
 

--- a/projects/rhaiis/orchestration/ci.py
+++ b/projects/rhaiis/orchestration/ci.py
@@ -84,8 +84,8 @@ def pre_cleanup(ctx):
 @click.pass_context
 @ci_lib.safe_ci_entrypoint
 def post_cleanup(ctx):
-    """Post-cleanup phase - Clean up resources after test."""
-    return prepare_rhaiis.cleanup()
+    """Post-cleanup phase - Clean up resources and optionally remove operators."""
+    return prepare_rhaiis.cleanup(cleanup_subscriptions=True)
 
 
 @main.command()

--- a/projects/rhaiis/orchestration/config.d/platform.yaml
+++ b/projects/rhaiis/orchestration/config.d/platform.yaml
@@ -1,0 +1,46 @@
+operators:
+  nfd:
+    package: nfd
+    namespace: openshift-nfd
+    channel: stable
+    source: redhat-operators
+    bootstrap_crd: nodefeaturediscoveries.nfd.openshift.io
+  gpu-operator-certified:
+    package: gpu-operator-certified
+    namespace: nvidia-gpu-operator
+    channel: v24.9
+    source: certified-operators
+    bootstrap_crd: clusterpolicies.nvidia.com
+  rhcl-operator:
+    package: rhcl-operator
+    namespace: redhat-ods-operator
+    channel: stable
+    source: redhat-operators
+  rhoai-operator:
+    package: rhods-operator
+    namespace: redhat-ods-operator
+    channel: stable
+    source: redhat-operators
+
+datasciencecluster:
+  name: default-dsc
+  namespace: redhat-ods-applications
+  components:
+    - kserve
+
+prepare:
+  scc:
+    policy: anyuid
+    service_account: sa
+  image_pull_secret:
+    vault_name: psap-rhaiis-image-pull
+    vault_content: .dockerconfigjson
+  model_pvc:
+    storage_class: lvms-vg1
+    size: 300Gi
+    access_mode: ReadWriteOnce
+
+cleanup:
+  preserve_operators:
+    nfd: true
+    gpu-operator-certified: true

--- a/projects/rhaiis/orchestration/config.d/platform.yaml
+++ b/projects/rhaiis/orchestration/config.d/platform.yaml
@@ -51,3 +51,4 @@ cleanup:
   preserve_operators:
     nfd: true
     gpu-operator-certified: true
+    servicemeshoperator3: true

--- a/projects/rhaiis/orchestration/config.d/platform.yaml
+++ b/projects/rhaiis/orchestration/config.d/platform.yaml
@@ -52,5 +52,3 @@ cleanup:
     nfd: true
     gpu-operator-certified: true
     servicemeshoperator3: true
-    rhcl-operator: true
-    rhoai-operator: true

--- a/projects/rhaiis/orchestration/config.d/platform.yaml
+++ b/projects/rhaiis/orchestration/config.d/platform.yaml
@@ -52,3 +52,5 @@ cleanup:
     nfd: true
     gpu-operator-certified: true
     servicemeshoperator3: true
+    rhcl-operator: true
+    rhoai-operator: true

--- a/projects/rhaiis/orchestration/config.d/platform.yaml
+++ b/projects/rhaiis/orchestration/config.d/platform.yaml
@@ -8,7 +8,7 @@ operators:
   gpu-operator-certified:
     package: gpu-operator-certified
     namespace: nvidia-gpu-operator
-    channel: v24.9
+    channel: stable
     source: certified-operators
     bootstrap_crd: clusterpolicies.nvidia.com
   rhcl-operator:

--- a/projects/rhaiis/orchestration/config.d/platform.yaml
+++ b/projects/rhaiis/orchestration/config.d/platform.yaml
@@ -28,10 +28,17 @@ datasciencecluster:
   components:
     - kserve
 
+required_crds:
+  - inferenceservices.serving.kserve.io
+  - servingruntimes.serving.kserve.io
+
+labels:
+  app.kubernetes.io/managed-by: forge
+  forge.openshift.io/project: rhaiis
+
 prepare:
   scc:
     policy: anyuid
-    service_account: sa
   image_pull_secret:
     vault_name: psap-rhaiis-image-pull
     vault_content: .dockerconfigjson

--- a/projects/rhaiis/orchestration/config.d/rhaiis.yaml
+++ b/projects/rhaiis/orchestration/config.d/rhaiis.yaml
@@ -16,7 +16,7 @@ deploy:
   memory_request: "16Gi"
   storage_source: hf
   storage_pvc: model-pvc-2
-  image_pull_secret: ""
+  image_pull_secret: rhaiis-image-pull
   service_account_name: ""
   ready_timeout: 3600
   health_check_timeout: 120

--- a/projects/rhaiis/orchestration/config.yaml
+++ b/projects/rhaiis/orchestration/config.yaml
@@ -1,6 +1,7 @@
 vaults:
 - psap-forge-notifications
 - psap-forge-mlflow-export
+- psap-rhaiis-image-pull
 
 benchmarks:
   guidellm:

--- a/projects/rhaiis/orchestration/config.yaml
+++ b/projects/rhaiis/orchestration/config.yaml
@@ -3,11 +3,6 @@ vaults:
 - psap-forge-mlflow-export
 - psap-rhaiis-image-pull
 
-agentic:
-  enabled: false
-  on_failure:
-    enabled: false
-
 benchmarks:
   guidellm:
     enabled: true

--- a/projects/rhaiis/orchestration/config.yaml
+++ b/projects/rhaiis/orchestration/config.yaml
@@ -3,6 +3,11 @@ vaults:
 - psap-forge-mlflow-export
 - psap-rhaiis-image-pull
 
+agentic:
+  enabled: false
+  on_failure:
+    enabled: false
+
 benchmarks:
   guidellm:
     enabled: true

--- a/projects/rhaiis/orchestration/prepare_rhaiis.py
+++ b/projects/rhaiis/orchestration/prepare_rhaiis.py
@@ -1,53 +1,306 @@
-import logging
+from __future__ import annotations
 
-from projects.core.dsl.utils.k8s import oc
+import logging
+from typing import Any
+
+from projects.core.dsl.utils.k8s import oc, oc_apply, oc_resource_exists
+from projects.core.orchestration.utils.k8s import ensure_namespace
 from projects.rhaiis.orchestration import runtime_config
 
 logger = logging.getLogger(__name__)
 
 
-def prepare():
+def prepare() -> int:
+    verify_oc_access()
+
+    platform = runtime_config.get_platform_config()
+
+    prepare_nfd(platform)
+    prepare_gpu_operator(platform)
+    prepare_kserve(platform)
+
     ns = runtime_config.get_namespace()
     deploy_cfg = runtime_config.get_deploy_config()
-    logger.info(f"Preparing namespace {ns} for rhaiis benchmarks")
+    prepare_cfg = platform.get("prepare", {})
 
+    ensure_test_namespace(ns)
+    ensure_service_account(ns, deploy_cfg)
+    ensure_scc_policy(ns, prepare_cfg)
+    ensure_image_pull_secret(ns, deploy_cfg, prepare_cfg)
+    ensure_model_pvc(ns, deploy_cfg, prepare_cfg)
+
+    return 0
+
+
+def cleanup() -> int:
+    ns = runtime_config.get_namespace()
+    logger.info("Cleaning up rhaiis benchmark resources in %s", ns)
+
+    if not oc_resource_exists("namespace", ns):
+        logger.info("Namespace %s does not exist, nothing to clean up", ns)
+        return 0
+
+    oc("delete", "inferenceservice", "--all", "-n", ns, "--ignore-not-found", check=False)
+    oc("delete", "servingruntime", "--all", "-n", ns, "--ignore-not-found", check=False)
+    oc("delete", "job", "--all", "-n", ns, "--ignore-not-found", check=False)
+    oc("delete", "pod", "--all", "-n", ns, "--ignore-not-found", check=False)
+
+    logger.info("Cleanup complete")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Cluster-level: operators
+# ---------------------------------------------------------------------------
+
+
+def verify_oc_access() -> None:
     result = oc("whoami", check=False)
     if result.returncode != 0:
         raise RuntimeError("Cannot connect to cluster")
-    logger.info(f"Connected to cluster as {result.stdout.strip()}")
+    logger.info("Connected to cluster as %s", result.stdout.strip())
 
-    result = oc("get", "namespace", ns, check=False)
-    if result.returncode != 0:
-        oc("create", "namespace", ns)
-        logger.info(f"Created namespace {ns}")
-    else:
-        logger.info(f"Namespace {ns} already exists")
 
+def _operator_spec(platform: dict[str, Any], package: str) -> dict[str, Any]:
+    operators = platform.get("operators", {})
+    if package not in operators:
+        raise KeyError(f"Unknown operator package in platform config: {package}")
+    return {"package": package, **operators[package]}
+
+
+def _ensure_operator_subscription(operator_spec: dict[str, str]) -> None:
+    from projects.cluster.toolbox.cluster_deploy_operator import main as cluster_deploy_operator
+
+    cluster_deploy_operator.run(
+        package_name=operator_spec["package"],
+        target_namespace=operator_spec["namespace"],
+        source_name=operator_spec["source"],
+        channel=operator_spec["channel"],
+        source_namespace=operator_spec.get("source_namespace", "openshift-marketplace"),
+        display_name=operator_spec.get("display_name", operator_spec["package"]),
+        artifact_dirname_suffix=f"_{operator_spec['package']}",
+    )
+
+
+def prepare_nfd(platform: dict[str, Any]) -> None:
+    from projects.cluster.toolbox.wait_for_crds import main as wait_for_crds_command
+    from projects.gpu_operator.toolbox.bootstrap_nfd_instance import (
+        main as bootstrap_nfd_instance,
+    )
+
+    logger.info("Preparing NFD operator")
+    spec = _operator_spec(platform, "nfd")
+    _ensure_operator_subscription(spec)
+
+    if spec.get("bootstrap_crd"):
+        wait_for_crds_command.run(
+            crd_names=[spec["bootstrap_crd"]],
+            display_name="NFD bootstrap CRD",
+        )
+
+    bootstrap_nfd_instance.run()
+    logger.info("NFD operator ready")
+
+
+def prepare_gpu_operator(platform: dict[str, Any]) -> None:
+    from projects.cluster.toolbox.wait_for_crds import main as wait_for_crds_command
+    from projects.gpu_operator.toolbox.bootstrap_gpu_clusterpolicy import (
+        main as bootstrap_gpu_clusterpolicy,
+    )
+
+    logger.info("Preparing GPU operator")
+    spec = _operator_spec(platform, "gpu-operator-certified")
+    _ensure_operator_subscription(spec)
+
+    if spec.get("bootstrap_crd"):
+        wait_for_crds_command.run(
+            crd_names=[spec["bootstrap_crd"]],
+            display_name="GPU Operator bootstrap CRD",
+        )
+
+    bootstrap_gpu_clusterpolicy.run()
+    logger.info("GPU operator ready")
+
+
+def prepare_kserve(platform: dict[str, Any]) -> None:
+    from projects.rhoai.toolbox.apply_datasciencecluster import (
+        main as apply_datasciencecluster_command,
+    )
+    from projects.rhoai.toolbox.wait_datasciencecluster_ready import (
+        main as wait_datasciencecluster_ready_command,
+    )
+
+    logger.info("Preparing KServe via RHOAI")
+
+    rhcl_spec = _operator_spec(platform, "rhcl-operator")
+    _ensure_operator_subscription(rhcl_spec)
+
+    rhoai_spec = _operator_spec(platform, "rhoai-operator")
+    _ensure_operator_subscription(rhoai_spec)
+
+    dsc = platform.get("datasciencecluster", {})
+    dsc_name = dsc.get("name", "default-dsc")
+    dsc_namespace = dsc.get("namespace", "redhat-ods-applications")
+    dsc_components = dsc.get("components", ["kserve"])
+
+    apply_datasciencecluster_command.run(
+        datasciencecluster_name=dsc_name,
+        namespace=dsc_namespace,
+        components=dsc_components,
+    )
+
+    wait_datasciencecluster_ready_command.run(
+        datasciencecluster_name=dsc_name,
+        namespace=dsc_namespace,
+    )
+
+    logger.info("KServe ready via RHOAI")
+
+
+# ---------------------------------------------------------------------------
+# Per-run: namespace, SA, SCC, secrets, PVC
+# ---------------------------------------------------------------------------
+
+
+def ensure_test_namespace(namespace: str) -> None:
+    ensure_namespace(
+        namespace,
+        labels={
+            "app.kubernetes.io/managed-by": "forge",
+            "forge.openshift.io/project": "rhaiis",
+        },
+    )
+    logger.info("Namespace %s ready", namespace)
+
+
+def ensure_service_account(namespace: str, deploy_cfg: dict[str, Any]) -> None:
     sa_name = deploy_cfg.get("service_account_name", "")
-    if sa_name:
-        result = oc("get", "serviceaccount", sa_name, "-n", ns, check=False)
-        if result.returncode != 0:
-            oc("create", "serviceaccount", sa_name, "-n", ns)
-            logger.info(f"Created service account {sa_name}")
-        else:
-            logger.info(f"Service account {sa_name} already exists")
+    if not sa_name:
+        return
 
+    if oc_resource_exists("serviceaccount", sa_name, namespace=namespace):
+        logger.info("Service account %s already exists in %s", sa_name, namespace)
+        return
+
+    oc("create", "serviceaccount", sa_name, "-n", namespace)
+    logger.info("Created service account %s in %s", sa_name, namespace)
+
+
+def ensure_scc_policy(namespace: str, prepare_cfg: dict[str, Any]) -> None:
+    scc = prepare_cfg.get("scc", {})
+    policy = scc.get("policy", "")
+    sa = scc.get("service_account", "")
+    if not policy or not sa:
+        logger.info("SCC policy not configured, skipping")
+        return
+
+    oc("adm", "policy", "add-scc-to-user", policy, "-z", sa, "-n", namespace, check=False)
+    logger.info("Applied SCC %s to SA %s in %s", policy, sa, namespace)
+
+
+def ensure_image_pull_secret(
+    namespace: str, deploy_cfg: dict[str, Any], prepare_cfg: dict[str, Any]
+) -> None:
     secret_name = deploy_cfg.get("image_pull_secret", "")
-    if secret_name:
-        result = oc("get", "secret", secret_name, "-n", ns, check=False)
-        if result.returncode == 0:
-            logger.info(f"Image pull secret {secret_name} exists")
-        else:
-            logger.warning(
-                f"Image pull secret {secret_name} not found in {ns} — "
-                "deployment may fail if images require authentication"
-            )
+    if not secret_name:
+        return
+
+    if oc_resource_exists("secret", secret_name, namespace=namespace):
+        logger.info("Image pull secret %s already exists in %s", secret_name, namespace)
+        return
+
+    vault_name = prepare_cfg.get("image_pull_secret", {}).get(
+        "vault_name", "psap-rhaiis-image-pull"
+    )
+    vault_content = prepare_cfg.get("image_pull_secret", {}).get(
+        "vault_content", ".dockerconfigjson"
+    )
+
+    from projects.core.library import env, vault
+
+    try:
+        dockerconfig_path = vault.get_vault_content_path(vault_name, vault_content)
+    except Exception:
+        logger.warning("Vault %s not available — cannot create image pull secret", vault_name)
+        return
+
+    if not dockerconfig_path or not dockerconfig_path.exists():
+        logger.warning("Vault content %s/%s not found", vault_name, vault_content)
+        return
+
+    manifest = {
+        "apiVersion": "v1",
+        "kind": "Secret",
+        "metadata": {
+            "name": secret_name,
+            "namespace": namespace,
+            "labels": {
+                "app.kubernetes.io/managed-by": "forge",
+                "forge.openshift.io/project": "rhaiis",
+            },
+        },
+        "type": "kubernetes.io/dockerconfigjson",
+        "data": {
+            ".dockerconfigjson": _base64_encode_file(dockerconfig_path),
+        },
+    }
+
+    artifact_path = env.ARTIFACT_DIR / "src" / "image-pull-secret.yaml"
+    oc_apply(artifact_path, manifest)
+    logger.info("Created image pull secret %s in %s from vault %s", secret_name, namespace, vault_name)
 
 
-def cleanup():
-    ns = runtime_config.get_namespace()
-    logger.info(f"Cleaning up rhaiis benchmark resources in {ns}")
+def _base64_encode_file(path: Any) -> str:
+    import base64
 
-    oc("delete", "job", "--all", "-n", ns, "--ignore-not-found", check=False)
-    oc("delete", "pod", "--all", "-n", ns, "--ignore-not-found", check=False)
-    logger.info("Cleanup complete")
+    content = path.read_bytes()
+    return base64.b64encode(content).decode("ascii")
+
+
+def ensure_model_pvc(
+    namespace: str, deploy_cfg: dict[str, Any], prepare_cfg: dict[str, Any]
+) -> None:
+    pvc_name = deploy_cfg.get("storage_pvc", "")
+    if not pvc_name:
+        return
+
+    if oc_resource_exists("pvc", pvc_name, namespace=namespace):
+        logger.info("PVC %s already exists in %s", pvc_name, namespace)
+        return
+
+    pvc_cfg = prepare_cfg.get("model_pvc", {})
+    storage_class = pvc_cfg.get("storage_class", "")
+    size = pvc_cfg.get("size", "300Gi")
+    access_mode = pvc_cfg.get("access_mode", "ReadWriteOnce")
+
+    if not storage_class:
+        logger.warning("No storage_class configured for model PVC, skipping creation")
+        return
+
+    manifest = {
+        "apiVersion": "v1",
+        "kind": "PersistentVolumeClaim",
+        "metadata": {
+            "name": pvc_name,
+            "namespace": namespace,
+            "labels": {
+                "app.kubernetes.io/managed-by": "forge",
+                "forge.openshift.io/project": "rhaiis",
+                "forge.openshift.io/preserve": "true",
+            },
+        },
+        "spec": {
+            "accessModes": [access_mode],
+            "resources": {"requests": {"storage": size}},
+            "storageClassName": storage_class,
+        },
+    }
+
+    from projects.core.library import env
+
+    artifact_path = env.ARTIFACT_DIR / "src" / "model-pvc.yaml"
+    oc_apply(artifact_path, manifest)
+    logger.info(
+        "Created PVC %s (%s, %s, %s) in %s",
+        pvc_name, storage_class, size, access_mode, namespace,
+    )

--- a/projects/rhaiis/orchestration/prepare_rhaiis.py
+++ b/projects/rhaiis/orchestration/prepare_rhaiis.py
@@ -264,8 +264,9 @@ def ensure_image_pull_secret(
         },
     }
 
-    artifact_path = env.ARTIFACT_DIR / "src" / "image-pull-secret.yaml"
-    oc_apply(artifact_path, manifest)
+    src_dir = env.ARTIFACT_DIR / "src"
+    src_dir.mkdir(parents=True, exist_ok=True)
+    oc_apply(src_dir / "image-pull-secret.yaml", manifest)
     logger.info("Created image pull secret %s in %s from vault %s", secret_name, namespace, vault_name)
 
 
@@ -317,8 +318,9 @@ def ensure_model_pvc(
 
     from projects.core.library import env
 
-    artifact_path = env.ARTIFACT_DIR / "src" / "model-pvc.yaml"
-    oc_apply(artifact_path, manifest)
+    src_dir = env.ARTIFACT_DIR / "src"
+    src_dir.mkdir(parents=True, exist_ok=True)
+    oc_apply(src_dir / "model-pvc.yaml", manifest)
     logger.info(
         "Created PVC %s (%s, %s, %s) in %s",
         pvc_name, storage_class, size, access_mode, namespace,

--- a/projects/rhaiis/orchestration/prepare_rhaiis.py
+++ b/projects/rhaiis/orchestration/prepare_rhaiis.py
@@ -68,17 +68,36 @@ def _operator_spec(platform: dict[str, Any], package: str) -> dict[str, Any]:
     return {"package": package, **operators[package]}
 
 
+def _operator_csv_exists(namespace: str, package: str) -> bool:
+    result = oc(
+        "get", "csv", "-n", namespace,
+        "-o", "jsonpath={.items[*].metadata.name}",
+        check=False, log_stdout=False,
+    )
+    if result.returncode != 0:
+        return False
+    csv_names = result.stdout.strip().split()
+    return any(package in name for name in csv_names)
+
+
 def _ensure_operator_subscription(operator_spec: dict[str, str]) -> None:
+    package = operator_spec["package"]
+    namespace = operator_spec["namespace"]
+
+    if _operator_csv_exists(namespace, package):
+        logger.info("Operator %s already installed in %s, skipping", package, namespace)
+        return
+
     from projects.cluster.toolbox.cluster_deploy_operator import main as cluster_deploy_operator
 
     cluster_deploy_operator.run(
-        package_name=operator_spec["package"],
-        target_namespace=operator_spec["namespace"],
+        package_name=package,
+        target_namespace=namespace,
         source_name=operator_spec["source"],
         channel=operator_spec["channel"],
         source_namespace=operator_spec.get("source_namespace", "openshift-marketplace"),
-        display_name=operator_spec.get("display_name", operator_spec["package"]),
-        artifact_dirname_suffix=f"_{operator_spec['package']}",
+        display_name=operator_spec.get("display_name", package),
+        artifact_dirname_suffix=f"_{package}",
     )
 
 

--- a/projects/rhaiis/orchestration/prepare_rhaiis.py
+++ b/projects/rhaiis/orchestration/prepare_rhaiis.py
@@ -70,9 +70,14 @@ def _operator_spec(platform: dict[str, Any], package: str) -> dict[str, Any]:
 
 def _operator_csv_exists(namespace: str, package: str) -> bool:
     result = oc(
-        "get", "csv", "-n", namespace,
-        "-o", "jsonpath={.items[*].metadata.name}",
-        check=False, log_stdout=False,
+        "get",
+        "csv",
+        "-n",
+        namespace,
+        "-o",
+        "jsonpath={.items[*].metadata.name}",
+        check=False,
+        log_stdout=False,
     )
     if result.returncode != 0:
         return False
@@ -267,7 +272,9 @@ def ensure_image_pull_secret(
     src_dir = env.ARTIFACT_DIR / "src"
     src_dir.mkdir(parents=True, exist_ok=True)
     oc_apply(src_dir / "image-pull-secret.yaml", manifest)
-    logger.info("Created image pull secret %s in %s from vault %s", secret_name, namespace, vault_name)
+    logger.info(
+        "Created image pull secret %s in %s from vault %s", secret_name, namespace, vault_name
+    )
 
 
 def _base64_encode_file(path: Any) -> str:
@@ -323,5 +330,9 @@ def ensure_model_pvc(
     oc_apply(src_dir / "model-pvc.yaml", manifest)
     logger.info(
         "Created PVC %s (%s, %s, %s) in %s",
-        pvc_name, storage_class, size, access_mode, namespace,
+        pvc_name,
+        storage_class,
+        size,
+        access_mode,
+        namespace,
     )

--- a/projects/rhaiis/orchestration/prepare_rhaiis.py
+++ b/projects/rhaiis/orchestration/prepare_rhaiis.py
@@ -33,21 +33,50 @@ def prepare() -> int:
     return 0
 
 
-def cleanup() -> int:
+def cleanup(*, cleanup_subscriptions: bool = False) -> int:
     ns = runtime_config.get_namespace()
     logger.info("Cleaning up rhaiis benchmark resources in %s", ns)
 
-    if not oc_resource_exists("namespace", ns):
-        logger.info("Namespace %s does not exist, nothing to clean up", ns)
-        return 0
+    if oc_resource_exists("namespace", ns):
+        oc("delete", "inferenceservice", "--all", "-n", ns, "--ignore-not-found", check=False)
+        oc("delete", "servingruntime", "--all", "-n", ns, "--ignore-not-found", check=False)
+        oc("delete", "job", "--all", "-n", ns, "--ignore-not-found", check=False)
+        oc("delete", "pod", "--all", "-n", ns, "--ignore-not-found", check=False)
+        logger.info("Namespace cleanup complete")
+    else:
+        logger.info("Namespace %s does not exist, skipping namespace cleanup", ns)
 
-    oc("delete", "inferenceservice", "--all", "-n", ns, "--ignore-not-found", check=False)
-    oc("delete", "servingruntime", "--all", "-n", ns, "--ignore-not-found", check=False)
-    oc("delete", "job", "--all", "-n", ns, "--ignore-not-found", check=False)
-    oc("delete", "pod", "--all", "-n", ns, "--ignore-not-found", check=False)
+    if cleanup_subscriptions:
+        _cleanup_operators()
 
-    logger.info("Cleanup complete")
     return 0
+
+
+def _cleanup_operators() -> None:
+    from projects.cluster.toolbox.cleanup_operators import main as cleanup_operators_command
+    from projects.core.library import config
+
+    platform = runtime_config.get_platform_config()
+    cleanup_config = config.project.get_config("cleanup", {})
+    preserve = cleanup_config.get("preserve_operators", {})
+
+    operators = platform.get("operators", {})
+    to_delete = []
+
+    for package_name, operator_spec in operators.items():
+        if preserve.get(package_name, False):
+            logger.info("Preserving operator: %s", package_name)
+            continue
+        namespace = operator_spec.get("namespace", "openshift-operators")
+        logger.info("Marking operator for deletion: %s in %s", package_name, namespace)
+        to_delete.append({"name": package_name, "namespace": namespace})
+
+    if not to_delete:
+        logger.info("No operators to clean up")
+        return
+
+    logger.info("Cleaning up %d operator(s)", len(to_delete))
+    cleanup_operators_command.run(operators=to_delete)
 
 
 # ---------------------------------------------------------------------------
@@ -212,6 +241,7 @@ def ensure_test_namespace(namespace: str, labels: dict[str, str]) -> None:
 def ensure_service_account(namespace: str, deploy_cfg: dict[str, Any]) -> None:
     sa_name = deploy_cfg.get("service_account_name", "")
     if not sa_name:
+        logger.info("No service account configured, skipping")
         return
 
     if oc_resource_exists("serviceaccount", sa_name, namespace=namespace):

--- a/projects/rhaiis/orchestration/prepare_rhaiis.py
+++ b/projects/rhaiis/orchestration/prepare_rhaiis.py
@@ -76,15 +76,21 @@ def _find_operator_csv(namespace: str, package: str) -> tuple[str | None, str | 
         "-n",
         namespace,
         "-o",
-        r'jsonpath={range .items[*]}{.metadata.name}{"\t"}{.status.phase}{"\n"}{end}',
+        "jsonpath={range .items[*]}{.metadata.name}={.status.phase};{end}",
         check=False,
         log_stdout=False,
     )
     if result.returncode != 0:
         return None, None
-    for line in result.stdout.strip().splitlines():
-        name, _, phase = line.partition("\t")
+    for entry in result.stdout.strip().split(";"):
+        entry = entry.strip()
+        if not entry:
+            continue
+        if "=" not in entry:
+            continue
+        name, phase = entry.rsplit("=", 1)
         if package in name:
+            logger.info("Found CSV %s in phase %s", name, phase)
             return name, phase
     return None, None
 

--- a/projects/rhaiis/orchestration/prepare_rhaiis.py
+++ b/projects/rhaiis/orchestration/prepare_rhaiis.py
@@ -22,12 +22,13 @@ def prepare() -> int:
     ns = runtime_config.get_namespace()
     deploy_cfg = runtime_config.get_deploy_config()
     prepare_cfg = platform.get("prepare", {})
+    labels = platform.get("labels", {})
 
-    ensure_test_namespace(ns)
+    ensure_test_namespace(ns, labels)
     ensure_service_account(ns, deploy_cfg)
-    ensure_scc_policy(ns, prepare_cfg)
+    ensure_scc_policy(ns, deploy_cfg, prepare_cfg)
     ensure_image_pull_secret(ns, deploy_cfg, prepare_cfg)
-    ensure_model_pvc(ns, deploy_cfg, prepare_cfg)
+    ensure_model_pvc(ns, deploy_cfg, prepare_cfg, labels)
 
     return 0
 
@@ -68,28 +69,31 @@ def _operator_spec(platform: dict[str, Any], package: str) -> dict[str, Any]:
     return {"package": package, **operators[package]}
 
 
-def _operator_csv_exists(namespace: str, package: str) -> bool:
+def _operator_csv_succeeded(namespace: str, package: str) -> bool:
     result = oc(
         "get",
         "csv",
         "-n",
         namespace,
         "-o",
-        "jsonpath={.items[*].metadata.name}",
+        r'jsonpath={range .items[*]}{.metadata.name}{"\t"}{.status.phase}{"\n"}{end}',
         check=False,
         log_stdout=False,
     )
     if result.returncode != 0:
         return False
-    csv_names = result.stdout.strip().split()
-    return any(package in name for name in csv_names)
+    for line in result.stdout.strip().splitlines():
+        name, _, phase = line.partition("\t")
+        if package in name and phase == "Succeeded":
+            return True
+    return False
 
 
 def _ensure_operator_subscription(operator_spec: dict[str, str]) -> None:
     package = operator_spec["package"]
     namespace = operator_spec["namespace"]
 
-    if _operator_csv_exists(namespace, package):
+    if _operator_csv_succeeded(namespace, package):
         logger.info("Operator %s already installed in %s, skipping", package, namespace)
         return
 
@@ -186,14 +190,8 @@ def prepare_kserve(platform: dict[str, Any]) -> None:
 # ---------------------------------------------------------------------------
 
 
-def ensure_test_namespace(namespace: str) -> None:
-    ensure_namespace(
-        namespace,
-        labels={
-            "app.kubernetes.io/managed-by": "forge",
-            "forge.openshift.io/project": "rhaiis",
-        },
-    )
+def ensure_test_namespace(namespace: str, labels: dict[str, str]) -> None:
+    ensure_namespace(namespace, labels=labels)
     logger.info("Namespace %s ready", namespace)
 
 
@@ -210,15 +208,20 @@ def ensure_service_account(namespace: str, deploy_cfg: dict[str, Any]) -> None:
     logger.info("Created service account %s in %s", sa_name, namespace)
 
 
-def ensure_scc_policy(namespace: str, prepare_cfg: dict[str, Any]) -> None:
+def ensure_scc_policy(
+    namespace: str, deploy_cfg: dict[str, Any], prepare_cfg: dict[str, Any]
+) -> None:
     scc = prepare_cfg.get("scc", {})
-    policy = scc.get("policy", "")
-    sa = scc.get("service_account", "")
-    if not policy or not sa:
+    policy = scc.get("policy")
+    sa = deploy_cfg.get("service_account_name", "")
+    if not policy:
         logger.info("SCC policy not configured, skipping")
         return
+    if not sa:
+        logger.info("No service account configured, skipping SCC")
+        return
 
-    oc("adm", "policy", "add-scc-to-user", policy, "-z", sa, "-n", namespace, check=False)
+    oc("adm", "policy", "add-scc-to-user", policy, "-z", sa, "-n", namespace)
     logger.info("Applied SCC %s to SA %s in %s", policy, sa, namespace)
 
 
@@ -227,65 +230,55 @@ def ensure_image_pull_secret(
 ) -> None:
     secret_name = deploy_cfg.get("image_pull_secret", "")
     if not secret_name:
+        logger.info("No image pull secret configured, skipping")
         return
 
     if oc_resource_exists("secret", secret_name, namespace=namespace):
         logger.info("Image pull secret %s already exists in %s", secret_name, namespace)
         return
 
-    vault_name = prepare_cfg.get("image_pull_secret", {}).get(
-        "vault_name", "psap-rhaiis-image-pull"
-    )
-    vault_content = prepare_cfg.get("image_pull_secret", {}).get(
-        "vault_content", ".dockerconfigjson"
-    )
+    vault_cfg = prepare_cfg.get("image_pull_secret", {})
+    vault_name = vault_cfg.get("vault_name")
+    vault_content = vault_cfg.get("vault_content")
 
-    from projects.core.library import env, vault
+    if not vault_name or not vault_content:
+        raise RuntimeError(
+            f"Image pull secret {secret_name} is configured but "
+            "platform.prepare.image_pull_secret.vault_name/vault_content are missing"
+        )
+
+    from projects.core.library import vault
 
     try:
         dockerconfig_path = vault.get_vault_content_path(vault_name, vault_content)
-    except Exception:
-        logger.warning("Vault %s not available — cannot create image pull secret", vault_name)
-        return
+    except Exception as exc:
+        raise RuntimeError(
+            f"Vault {vault_name} not available — cannot create image pull secret {secret_name}"
+        ) from exc
 
     if not dockerconfig_path or not dockerconfig_path.exists():
-        logger.warning("Vault content %s/%s not found", vault_name, vault_content)
-        return
+        raise FileNotFoundError(f"Vault content {vault_name}/{vault_content} not found")
 
-    manifest = {
-        "apiVersion": "v1",
-        "kind": "Secret",
-        "metadata": {
-            "name": secret_name,
-            "namespace": namespace,
-            "labels": {
-                "app.kubernetes.io/managed-by": "forge",
-                "forge.openshift.io/project": "rhaiis",
-            },
-        },
-        "type": "kubernetes.io/dockerconfigjson",
-        "data": {
-            ".dockerconfigjson": _base64_encode_file(dockerconfig_path),
-        },
-    }
-
-    src_dir = env.ARTIFACT_DIR / "src"
-    src_dir.mkdir(parents=True, exist_ok=True)
-    oc_apply(src_dir / "image-pull-secret.yaml", manifest)
+    oc(
+        "create",
+        "secret",
+        "generic",
+        secret_name,
+        f"--from-file=.dockerconfigjson={dockerconfig_path}",
+        "--type=kubernetes.io/dockerconfigjson",
+        "-n",
+        namespace,
+    )
     logger.info(
         "Created image pull secret %s in %s from vault %s", secret_name, namespace, vault_name
     )
 
 
-def _base64_encode_file(path: Any) -> str:
-    import base64
-
-    content = path.read_bytes()
-    return base64.b64encode(content).decode("ascii")
-
-
 def ensure_model_pvc(
-    namespace: str, deploy_cfg: dict[str, Any], prepare_cfg: dict[str, Any]
+    namespace: str,
+    deploy_cfg: dict[str, Any],
+    prepare_cfg: dict[str, Any],
+    labels: dict[str, str],
 ) -> None:
     pvc_name = deploy_cfg.get("storage_pvc", "")
     if not pvc_name:
@@ -296,13 +289,16 @@ def ensure_model_pvc(
         return
 
     pvc_cfg = prepare_cfg.get("model_pvc", {})
-    storage_class = pvc_cfg.get("storage_class", "")
-    size = pvc_cfg.get("size", "300Gi")
-    access_mode = pvc_cfg.get("access_mode", "ReadWriteOnce")
+    storage_class = pvc_cfg.get("storage_class")
+    size = pvc_cfg["size"]
+    access_mode = pvc_cfg["access_mode"]
 
-    if not storage_class:
-        logger.warning("No storage_class configured for model PVC, skipping creation")
-        return
+    pvc_spec: dict[str, Any] = {
+        "accessModes": [access_mode],
+        "resources": {"requests": {"storage": size}},
+    }
+    if storage_class:
+        pvc_spec["storageClassName"] = storage_class
 
     manifest = {
         "apiVersion": "v1",
@@ -311,16 +307,11 @@ def ensure_model_pvc(
             "name": pvc_name,
             "namespace": namespace,
             "labels": {
-                "app.kubernetes.io/managed-by": "forge",
-                "forge.openshift.io/project": "rhaiis",
+                **labels,
                 "forge.openshift.io/preserve": "true",
             },
         },
-        "spec": {
-            "accessModes": [access_mode],
-            "resources": {"requests": {"storage": size}},
-            "storageClassName": storage_class,
-        },
+        "spec": pvc_spec,
     }
 
     from projects.core.library import env

--- a/projects/rhaiis/orchestration/prepare_rhaiis.py
+++ b/projects/rhaiis/orchestration/prepare_rhaiis.py
@@ -106,13 +106,10 @@ def _ensure_operator_subscription(operator_spec: dict[str, str]) -> None:
         return
 
     if csv_name and csv_phase != "Succeeded":
-        logger.warning(
-            "Operator %s CSV %s is in %s phase (not Succeeded), skipping install to avoid conflict",
-            package,
-            csv_name,
-            csv_phase,
+        raise RuntimeError(
+            f"Operator {package} CSV {csv_name} is in {csv_phase} phase (not Succeeded). "
+            f"Manual intervention required — check the CSV in namespace {namespace}"
         )
-        return
 
     from projects.cluster.toolbox.cluster_deploy_operator import main as cluster_deploy_operator
 

--- a/projects/rhaiis/orchestration/prepare_rhaiis.py
+++ b/projects/rhaiis/orchestration/prepare_rhaiis.py
@@ -54,10 +54,9 @@ def cleanup(*, cleanup_subscriptions: bool = False) -> int:
 
 def _cleanup_operators() -> None:
     from projects.cluster.toolbox.cleanup_operators import main as cleanup_operators_command
-    from projects.core.library import config
 
     platform = runtime_config.get_platform_config()
-    cleanup_config = config.project.get_config("cleanup", {})
+    cleanup_config = platform.get("cleanup", {})
     preserve = cleanup_config.get("preserve_operators", {})
 
     operators = platform.get("operators", {})

--- a/projects/rhaiis/orchestration/prepare_rhaiis.py
+++ b/projects/rhaiis/orchestration/prepare_rhaiis.py
@@ -69,7 +69,7 @@ def _operator_spec(platform: dict[str, Any], package: str) -> dict[str, Any]:
     return {"package": package, **operators[package]}
 
 
-def _operator_csv_succeeded(namespace: str, package: str) -> bool:
+def _find_operator_csv(namespace: str, package: str) -> tuple[str | None, str | None]:
     result = oc(
         "get",
         "csv",
@@ -81,20 +81,31 @@ def _operator_csv_succeeded(namespace: str, package: str) -> bool:
         log_stdout=False,
     )
     if result.returncode != 0:
-        return False
+        return None, None
     for line in result.stdout.strip().splitlines():
         name, _, phase = line.partition("\t")
-        if package in name and phase == "Succeeded":
-            return True
-    return False
+        if package in name:
+            return name, phase
+    return None, None
 
 
 def _ensure_operator_subscription(operator_spec: dict[str, str]) -> None:
     package = operator_spec["package"]
     namespace = operator_spec["namespace"]
 
-    if _operator_csv_succeeded(namespace, package):
+    csv_name, csv_phase = _find_operator_csv(namespace, package)
+
+    if csv_name and csv_phase == "Succeeded":
         logger.info("Operator %s already installed in %s, skipping", package, namespace)
+        return
+
+    if csv_name and csv_phase != "Succeeded":
+        logger.warning(
+            "Operator %s CSV %s is in %s phase (not Succeeded), skipping install to avoid conflict",
+            package,
+            csv_name,
+            csv_phase,
+        )
         return
 
     from projects.cluster.toolbox.cluster_deploy_operator import main as cluster_deploy_operator

--- a/projects/rhaiis/orchestration/prepare_rhaiis.py
+++ b/projects/rhaiis/orchestration/prepare_rhaiis.py
@@ -109,8 +109,13 @@ def _find_operator_csv(namespace: str, package: str) -> tuple[str | None, str | 
         log_stdout=False,
     )
     if result.returncode != 0:
+        logger.info("CSV query failed for %s in %s (rc=%d)", package, namespace, result.returncode)
         return None, None
-    for entry in result.stdout.strip().split(";"):
+    raw = result.stdout.strip()
+    logger.info(
+        "CSV query for %s in %s: %d chars, %d entries", package, namespace, len(raw), raw.count(";")
+    )
+    for entry in raw.split(";"):
         entry = entry.strip()
         if not entry:
             continue

--- a/projects/rhaiis/orchestration/runtime_config.py
+++ b/projects/rhaiis/orchestration/runtime_config.py
@@ -59,6 +59,10 @@ def get_vaults() -> list[str]:
     return config.project.get_config("vaults")
 
 
+def get_platform_config() -> dict:
+    return dict(config.project.get_config("platform"))
+
+
 def get_test_model_key() -> str:
     return config.project.get_config("tests.rhaiis.model_key")
 

--- a/vaults/psap-rhaiis-image-pull.yaml
+++ b/vaults/psap-rhaiis-image-pull.yaml
@@ -1,0 +1,10 @@
+env_key: PSAP_RHAIIS_IMAGE_PULL_SECRET_PATH
+description: |
+  Vault to store container registry credentials for rhaiis image pulling
+
+content:
+  .dockerconfigjson:
+    description: |
+      Docker/Podman registry auth config in JSON format
+    sample: |
+      {"auths":{"quay.io":{"auth":"base64-encoded-credentials"}}}


### PR DESCRIPTION
## Summary
- Rewrite `prepare_rhaiis.py` with a 9-step prepare sequence:
  - **Cluster-level**: NFD, GPU operator, KServe (via RHOAI) — skips if CSV already exists to avoid triggering upgrades
  - **Per-run**: namespace with forge labels, SA, SCC (`anyuid`), vault-based image pull secret, model PVC
- Add `config.d/platform.yaml` with operator specs, DSC config, SCC/PVC/vault settings
- Add vault definition `psap-rhaiis-image-pull` for container registry credentials
- Update `ci.py` with preflight CRD validation for KServe
- Enhanced cleanup: also deletes InferenceServices and ServingRuntimes
- Default `image_pull_secret: rhaiis-image-pull` — no longer needs FournosJob override

## Cluster-side prerequisite
The vault secret `vault-psap-rhaiis-image-pull` must exist in `psap-secrets` on psap-automation with the `fournos.dev/vault-entry=true` label. See Fournos README "Adding a project vault secret" section.

## Test plan
- [x] Full pipeline `rhaiis-mlflow-full-tfsnx` succeeded on forge-smoke-testing
- [x] Operators skipped (already installed) — prepare completed in ~22s
- [x] SCC policy applied, image pull secret created from vault, PVC created
- [x] Preflight passed (KServe CRDs found)
- [x] Test phase completed (~41m), post-cleanup + export succeeded

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive orchestration preflight validation to check required CRDs and the target namespace, and optionally verify image pull secrets and storage.
  * Expanded orchestration setup to install/bootstrapping required operators and configure the benchmark namespace, service account, SCC policy, image pull secret, and model PVC when configured.
  * Extended cleanup with an option to also remove cluster operator subscriptions.
* **Bug Fixes**
  * Improved failure handling so preflight now correctly returns non-zero when checks fail, preventing misleading “success” outcomes.
* **Chores**
  * Updated platform and Vault configuration, including the image pull secret name and newly added registry credentials Vault.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

The completed pipellne https://mlflow.apps.psap-automation.ibm.rhperfscale.org/#/experiments/233/runs/34cd9812b0a84004a6b2cfd58d23b436/artifacts?workspace=default

On  the forge-smoke-testing, all operators were already installed, so the prepare step validated their presence by checking   for existing CSVs and skipped installation:

1.   Operator nfd already installed in openshift-nfd, skipping
2.   Operator gpu-operator-certified already installed in nvidia-gpu-operator, skipping
3.   Operator rhcl-operator already installed in redhat-ods-operator, skipping
4.   Operator rhods-operator already installed in redhat-ods-operator, skipping