### PR TITLE
feat: Discover related operator during cleanup

### DIFF
--- a/projects/cluster/tests/test_cleanup_operators.py
+++ b/projects/cluster/tests/test_cleanup_operators.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from projects.cluster.toolbox.cleanup_operators import main as cleanup_operators
+
+
+def test_subscription_owner_refs_from_installplans() -> None:
+    installplans = {
+        "items": [
+            {
+                "metadata": {
+                    "ownerReferences": [
+                        {"kind": "Subscription", "name": "authorino-operator"},
+                        {"kind": "Subscription", "name": "dns-operator"},
+                        {"kind": "ClusterServiceVersion", "name": "ignored-csv"},
+                        {"kind": "Subscription", "name": "authorino-operator"},
+                    ]
+                }
+            }
+        ]
+    }
+
+    assert cleanup_operators._subscription_owner_refs_from_installplans(installplans) == [
+        "authorino-operator",
+        "dns-operator",
+    ]
+
+
+def test_expand_operators_with_installplan_owners(monkeypatch) -> None:
+    discovered_owners = {
+        ("rhods-operator", "redhat-ods-operator"): [
+            "authorino-operator-stable-redhat-operators-openshift-marketplace",
+            "dns-operator-stable-redhat-operators-openshift-marketplace",
+            "limitador-operator-stable-redhat-operators-openshift-marketplace",
+            "rhcl-operator",
+            "rhods-operator",
+        ],
+        (
+            "authorino-operator-stable-redhat-operators-openshift-marketplace",
+            "redhat-ods-operator",
+        ): ["rhods-operator"],
+    }
+
+    def fake_discover(subscription_name: str, namespace: str) -> list[str]:
+        return discovered_owners.get((subscription_name, namespace), [])
+
+    monkeypatch.setattr(
+        cleanup_operators,
+        "_discover_installplan_subscription_owners",
+        fake_discover,
+    )
+
+    assert cleanup_operators._expand_operators_with_installplan_owners(
+        [
+            ("rhods-operator", "redhat-ods-operator"),
+            ("rhcl-operator", "openshift-operators"),
+        ]
+    ) == [
+        ("rhods-operator", "redhat-ods-operator"),
+        ("rhcl-operator", "openshift-operators"),
+        (
+            "authorino-operator-stable-redhat-operators-openshift-marketplace",
+            "redhat-ods-operator",
+        ),
+        (
+            "dns-operator-stable-redhat-operators-openshift-marketplace",
+            "redhat-ods-operator",
+        ),
+        (
+            "limitador-operator-stable-redhat-operators-openshift-marketplace",
+            "redhat-ods-operator",
+        ),
+        ("rhcl-operator", "redhat-ods-operator"),
+    ]

--- a/projects/cluster/tests/test_cleanup_operators.py
+++ b/projects/cluster/tests/test_cleanup_operators.py
@@ -6,6 +6,7 @@ from projects.cluster.toolbox.cleanup_operators import main as cleanup_operators
 def test_subscription_owner_refs_from_installplans() -> None:
     installplans = {
         "items": [
+            {"metadata": {"ownerReferences": [{"kind": "Subscription", "name": "other-operator"}]}},
             {
                 "metadata": {
                     "ownerReferences": [
@@ -15,38 +16,73 @@ def test_subscription_owner_refs_from_installplans() -> None:
                         {"kind": "Subscription", "name": "authorino-operator"},
                     ]
                 }
-            }
+            },
         ]
     }
 
-    assert cleanup_operators._subscription_owner_refs_from_installplans(installplans) == [
-        "authorino-operator",
-        "dns-operator",
-    ]
+    assert cleanup_operators._subscription_owner_refs_from_installplans(
+        installplans, "authorino-operator"
+    ) == ["dns-operator"]
 
 
 def test_expand_operators_with_installplan_owners(monkeypatch) -> None:
-    discovered_owners = {
-        ("rhods-operator", "redhat-ods-operator"): [
-            "authorino-operator-stable-redhat-operators-openshift-marketplace",
-            "dns-operator-stable-redhat-operators-openshift-marketplace",
-            "limitador-operator-stable-redhat-operators-openshift-marketplace",
-            "rhcl-operator",
-            "rhods-operator",
-        ],
-        (
-            "authorino-operator-stable-redhat-operators-openshift-marketplace",
-            "redhat-ods-operator",
-        ): ["rhods-operator"],
+    installplans_by_namespace = {
+        "redhat-ods-operator": {
+            "items": [
+                {
+                    "metadata": {
+                        "ownerReferences": [
+                            {"kind": "Subscription", "name": "rhods-operator"},
+                            {
+                                "kind": "Subscription",
+                                "name": "authorino-operator-stable-redhat-operators-openshift-marketplace",
+                            },
+                            {
+                                "kind": "Subscription",
+                                "name": "dns-operator-stable-redhat-operators-openshift-marketplace",
+                            },
+                            {
+                                "kind": "Subscription",
+                                "name": "limitador-operator-stable-redhat-operators-openshift-marketplace",
+                            },
+                            {"kind": "Subscription", "name": "rhcl-operator"},
+                        ]
+                    }
+                },
+                {
+                    "metadata": {
+                        "ownerReferences": [
+                            {
+                                "kind": "Subscription",
+                                "name": "authorino-operator-stable-redhat-operators-openshift-marketplace",
+                            },
+                            {"kind": "Subscription", "name": "rhods-operator"},
+                        ]
+                    }
+                },
+            ]
+        },
+        "openshift-operators": {
+            "items": [
+                {
+                    "metadata": {
+                        "ownerReferences": [{"kind": "Subscription", "name": "rhcl-operator"}]
+                    }
+                }
+            ]
+        },
     }
 
-    def fake_discover(subscription_name: str, namespace: str) -> list[str]:
-        return discovered_owners.get((subscription_name, namespace), [])
+    fetch_count = {}
+
+    def fake_fetch(namespace: str) -> dict:
+        fetch_count[namespace] = fetch_count.get(namespace, 0) + 1
+        return installplans_by_namespace[namespace]
 
     monkeypatch.setattr(
         cleanup_operators,
-        "_discover_installplan_subscription_owners",
-        fake_discover,
+        "_fetch_installplans",
+        fake_fetch,
     )
 
     assert cleanup_operators._expand_operators_with_installplan_owners(
@@ -71,3 +107,4 @@ def test_expand_operators_with_installplan_owners(monkeypatch) -> None:
         ),
         ("rhcl-operator", "redhat-ods-operator"),
     ]
+    assert fetch_count == {"redhat-ods-operator": 1, "openshift-operators": 1}

--- a/projects/cluster/toolbox/cleanup_operators/main.py
+++ b/projects/cluster/toolbox/cleanup_operators/main.py
@@ -79,6 +79,7 @@ def _expand_operators_with_installplan_owners(
     expanded_operators = []
     seen_operators = set(operators)
     pending_operators = deque(operators)
+    installplans_by_namespace: dict[str, dict] = {}
 
     while pending_operators:
         operator_name, namespace = pending_operators.popleft()
@@ -86,7 +87,13 @@ def _expand_operators_with_installplan_owners(
 
         # Follow ownerReferences transitively because dependency InstallPlans can
         # point back to the root subscription or to other related subscriptions.
-        owner_names = _discover_installplan_subscription_owners(operator_name, namespace)
+        if namespace not in installplans_by_namespace:
+            installplans_by_namespace[namespace] = _fetch_installplans(namespace)
+
+        owner_names = _subscription_owner_refs_from_installplans(
+            installplans_by_namespace[namespace],
+            operator_name,
+        )
         for owner_name in owner_names:
             owner_key = (owner_name, namespace)
             if owner_key in seen_operators:
@@ -102,48 +109,52 @@ def _expand_operators_with_installplan_owners(
     return expanded_operators
 
 
-def _discover_installplan_subscription_owners(subscription_name: str, namespace: str) -> list[str]:
+def _fetch_installplans(namespace: str) -> dict:
     result = shell.run(
-        f"oc get installplan -n {namespace} "
-        f"-l operators.coreos.com/{subscription_name}.{namespace} "
-        "-o yaml",
+        f"oc get installplan -n {namespace} -o yaml",
         check=False,
         log_stdout=False,
     )
 
     if result.returncode != 0:
         logger.warning(
-            f"Failed to list InstallPlans for subscription {subscription_name} "
-            f"in namespace {namespace} (exit {result.returncode}); "
-            f"related subscriptions may not be fully discovered: {result.stderr}"
+            f"Failed to list InstallPlans in namespace {namespace} "
+            f"(exit {result.returncode}); related subscriptions may not be fully discovered: "
+            f"{result.stderr}"
         )
-        return []
+        return {}
 
     try:
-        installplans = yaml.safe_load(result.stdout) or {}
+        return yaml.safe_load(result.stdout) or {}
     except yaml.YAMLError as e:
-        logger.warning(
-            f"Could not parse InstallPlans for subscription {subscription_name} "
-            f"in namespace {namespace}: {e}"
-        )
-        return []
-
-    return _subscription_owner_refs_from_installplans(installplans)
+        logger.warning(f"Could not parse InstallPlans in namespace {namespace}: {e}")
+        return {}
 
 
-def _subscription_owner_refs_from_installplans(installplans: dict) -> list[str]:
+def _subscription_owner_refs_from_installplans(
+    installplans: dict,
+    subscription_name: str,
+) -> list[str]:
     owner_names = []
     seen_owner_names = set()
     for installplan in installplans.get("items", []):
-        for owner_reference in installplan.get("metadata", {}).get("ownerReferences", []):
-            owner_name = owner_reference.get("name")
-            if (
-                owner_reference.get("kind") == "Subscription"
-                and owner_name
-                and owner_name not in seen_owner_names
-            ):
-                seen_owner_names.add(owner_name)
-                owner_names.append(owner_name)
+        owner_references = installplan.get("metadata", {}).get("ownerReferences", [])
+        subscription_owner_names = dict.fromkeys(
+            owner_reference.get("name")
+            for owner_reference in owner_references
+            if owner_reference.get("kind") == "Subscription" and owner_reference.get("name")
+        )
+        if subscription_name not in subscription_owner_names:
+            continue
+
+        for owner_name in subscription_owner_names:
+            if owner_name == subscription_name:
+                continue
+            if owner_name in seen_owner_names:
+                continue
+
+            seen_owner_names.add(owner_name)
+            owner_names.append(owner_name)
 
     return owner_names
 

--- a/projects/cluster/toolbox/cleanup_operators/main.py
+++ b/projects/cluster/toolbox/cleanup_operators/main.py
@@ -111,6 +111,14 @@ def _discover_installplan_subscription_owners(subscription_name: str, namespace:
         log_stdout=False,
     )
 
+    if result.returncode != 0:
+        logger.warning(
+            f"Failed to list InstallPlans for subscription {subscription_name} "
+            f"in namespace {namespace} (exit {result.returncode}); "
+            f"related subscriptions may not be fully discovered: {result.stderr}"
+        )
+        return []
+
     try:
         installplans = yaml.safe_load(result.stdout) or {}
     except yaml.YAMLError as e:

--- a/projects/cluster/toolbox/cleanup_operators/main.py
+++ b/projects/cluster/toolbox/cleanup_operators/main.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import logging
+from collections import deque
+
+import yaml
 
 from projects.core.dsl import entrypoint, execute_tasks, shell, task
 from projects.core.dsl.utils.k8s import oc_resource_exists
@@ -43,16 +46,22 @@ def setup_directories(args, ctx):
 
 
 @task
+def discover_related_operators(args, ctx):
+    """Discover related operators from OLM InstallPlan ownerReferences"""
+    requested_operators = [(op["name"], op["namespace"]) for op in args.operators]
+    ctx.all_operators = _expand_operators_with_installplan_owners(requested_operators)
+
+    return f"Discovered {len(ctx.all_operators)} operator subscription(s) to clean up"
+
+
+@task
 def validate_operators(args, ctx):
     """Categorize operators by subscription existence"""
 
     existing_subscriptions = []
     missing_subscriptions = []
 
-    for operator_info in args.operators:
-        operator_name = operator_info["name"]
-        namespace = operator_info["namespace"]
-
+    for operator_name, namespace in ctx.all_operators:
         if oc_resource_exists("subscription", operator_name, namespace=namespace):
             existing_subscriptions.append((operator_name, namespace))
         else:
@@ -61,10 +70,74 @@ def validate_operators(args, ctx):
     ctx.existing_subscriptions = existing_subscriptions
     ctx.missing_subscriptions = missing_subscriptions
 
-    # Store all operators for resource cleanup
-    ctx.all_operators = [(op["name"], op["namespace"]) for op in args.operators]
-
     return f"Found {len(existing_subscriptions)} existing subscriptions, {len(missing_subscriptions)} missing (will clean up resources for all)"
+
+
+def _expand_operators_with_installplan_owners(
+    operators: list[tuple[str, str]],
+) -> list[tuple[str, str]]:
+    expanded_operators = []
+    seen_operators = set(operators)
+    pending_operators = deque(operators)
+
+    while pending_operators:
+        operator_name, namespace = pending_operators.popleft()
+        expanded_operators.append((operator_name, namespace))
+
+        # Follow ownerReferences transitively because dependency InstallPlans can
+        # point back to the root subscription or to other related subscriptions.
+        owner_names = _discover_installplan_subscription_owners(operator_name, namespace)
+        for owner_name in owner_names:
+            owner_key = (owner_name, namespace)
+            if owner_key in seen_operators:
+                continue
+
+            seen_operators.add(owner_key)
+            logger.info(
+                f"Discovered related subscription from InstallPlan ownerReferences: "
+                f"{owner_name} in namespace {namespace}"
+            )
+            pending_operators.append(owner_key)
+
+    return expanded_operators
+
+
+def _discover_installplan_subscription_owners(subscription_name: str, namespace: str) -> list[str]:
+    result = shell.run(
+        f"oc get installplan -n {namespace} "
+        f"-l operators.coreos.com/{subscription_name}.{namespace} "
+        "-o yaml",
+        check=False,
+        log_stdout=False,
+    )
+
+    try:
+        installplans = yaml.safe_load(result.stdout) or {}
+    except yaml.YAMLError as e:
+        logger.warning(
+            f"Could not parse InstallPlans for subscription {subscription_name} "
+            f"in namespace {namespace}: {e}"
+        )
+        return []
+
+    return _subscription_owner_refs_from_installplans(installplans)
+
+
+def _subscription_owner_refs_from_installplans(installplans: dict) -> list[str]:
+    owner_names = []
+    seen_owner_names = set()
+    for installplan in installplans.get("items", []):
+        for owner_reference in installplan.get("metadata", {}).get("ownerReferences", []):
+            owner_name = owner_reference.get("name")
+            if (
+                owner_reference.get("kind") == "Subscription"
+                and owner_name
+                and owner_name not in seen_owner_names
+            ):
+                seen_owner_names.add(owner_name)
+                owner_names.append(owner_name)
+
+    return owner_names
 
 
 @task


### PR DESCRIPTION
# Summary

A run deploying `rhcl-operator` failed immediately with:

```
reason: InterOperatorGroupOwnerConflict
message: intersecting operatorgroups provide the same apis
```

The pre-cleanup phase had cleaned up the `rhcl-operator` Subscription, but a related Subscription from a prior deployment (e.g. RHAIIS) remained on the cluster with an OperatorGroup claiming all-namespaces coverage, conflicting with the new deployment attempt.

OLM links related Subscriptions through InstallPlan `ownerReferences`: when an operator is installed, its InstallPlan records the originating Subscription as an ownerRef. If prior runs left related Subscriptions behind that share the same InstallPlan, those weren't visible to the cleanup script, it only knew about the explicitly-named operators passed in.

## Proposed fix

Add a `discover_related_operators` task that, before validation and cleanup, fans out over InstallPlans labeled for each target Subscription, collects any additional Subscription ownerReferences found, and adds them to the cleanup set.

This also separates two concerns that were previously conflated: discovery (expanding the operator set) is now its own explicit task before validation (categorizing by subscription existence) and cleanup (deletion).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cleanup now expands the operator list by discovering additional related operators via OLM InstallPlans, helping ensure dependent subscriptions are included.

* **Bug Fixes**
  * Validation and cleanup now operate on the expanded operator set, and the validation output includes clearer counts of existing versus missing subscriptions.

* **Tests**
  * Added coverage for operator expansion and subscription reference discovery logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->