### PR TITLE
fix: leftover label in test phase mcp-gw

### DIFF
--- a/projects/mcp_gateway/orchestration/presets.d/presets.yaml
+++ b/projects/mcp_gateway/orchestration/presets.d/presets.yaml
@@ -45,10 +45,18 @@ matrix-demo-1:
   experiment.warmup_seconds: 5
   experiment.tools_per_server: 10
 
-
 small-scale:
   runtime.mock_server: perf-mock-server
   experiment.servers: [1, 15, 45, 60]
+  experiment.concurrency: [500]
+  experiment.target: [gateway]
+  experiment.duration_seconds: 240
+  experiment.warmup_seconds: 60
+  experiment.tools_per_server: 10
+
+large-scale:
+  runtime.mock_server: perf-mock-server
+  experiment.servers: [75, 90, 110, 130, 140]
   experiment.concurrency: [500]
   experiment.target: [gateway]
   experiment.duration_seconds: 240

--- a/projects/mcp_gateway/orchestration/presets.d/presets.yaml
+++ b/projects/mcp_gateway/orchestration/presets.d/presets.yaml
@@ -44,3 +44,13 @@ matrix-demo-1:
   experiment.duration_seconds: 30
   experiment.warmup_seconds: 5
   experiment.tools_per_server: 10
+
+
+small-scale:
+  runtime.mock_server: perf-mock-server
+  experiment.servers: [1, 15, 45, 60]
+  experiment.concurrency: [500]
+  experiment.target: [gateway]
+  experiment.duration_seconds: 240
+  experiment.warmup_seconds: 60
+  experiment.tools_per_server: 10

--- a/projects/mcp_gateway/orchestration/test_phase.py
+++ b/projects/mcp_gateway/orchestration/test_phase.py
@@ -232,14 +232,15 @@ def _cleanup_servers(*, namespace: str, num_servers: int, mock_server: str) -> N
     deploy_mock_servers.cleanup_servers(namespace=namespace)
 
     api_group = cfg.get_api_group()
-    scale_out_label = "experiment=scale-out"
+    from projects.agentic_tools.mcp.toolbox.deploy_mock_servers.main import MOCK_MCP_LABEL
+
     run_oc(
         "delete",
         f"mcpserverregistrations.{api_group},httproute",
         "-n",
         namespace,
         "-l",
-        scale_out_label,
+        MOCK_MCP_LABEL,
         "--wait=false",
         "--ignore-not-found=true",
         check=False,
@@ -250,7 +251,7 @@ def _cleanup_servers(*, namespace: str, num_servers: int, mock_server: str) -> N
         "-n",
         "istio-system",
         "-l",
-        scale_out_label,
+        MOCK_MCP_LABEL,
         "--wait=false",
         "--ignore-not-found=true",
         check=False,


### PR DESCRIPTION
## Summary
- The `_cleanup_servers()` function in the MCP Gateway test phase was using a `experiment=scale-out` label selector to delete MCPServerRegistrations, HTTPRoutes, and DestinationRules between test iterations. This label was never applied to any of these resources — they are labeled with `forge.openshift.io/component=mock-mcp` (via `MOCK_MCP_LABEL`).
- As a result, cleanup between test iterations was a no-op, leaving stale resources that caused subsequent iterations to fail.

## Test plan
- [x] Verified `experiment=scale-out` is not set anywhere in the codebase
- [x] Verified `MOCK_MCP_LABEL` matches the label applied by `apply_infrastructure`
- [ ] Run `matrix-demo-1` preset with multi-iteration test to confirm cleanup works between iterations

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of Kubernetes resources during test runs by deleting the correct resource types using the appropriate label selector, ensuring related artifacts are removed consistently.
* **New Features**
  * Added a new `small-scale` orchestration preset to run smaller experiments with predefined server counts, concurrency, target, and timing parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->