### PR TITLE
[mcp_gateway] Replace MLflow historical data with S3-based KPI pipeline

### DIFF
--- a/fournos/gitops/base/workflows/task-forge-step.yaml
+++ b/fournos/gitops/base/workflows/task-forge-step.yaml
@@ -83,7 +83,7 @@ spec:
           export KUBECONFIG=$TARGET_KUBECONFIG
           export CLUSTERLESS_MODE="false"
           echo "Target cluster info:"
-          kubectl cluster-info
+          oc cluster-info
         else
           if [[ "$KUBECONFIG_SECRET_PARAM" == "fournos-clusterless-placeholder" ]]; then
             echo "Running in clusterless mode - no target cluster kubeconfig"
@@ -93,7 +93,7 @@ spec:
           fi
           export CLUSTERLESS_MODE="true"
           echo "Hub cluster info:"
-          kubectl cluster-info
+          oc cluster-info
         fi
 
         # Function to conditionally export environment variables from FournosJob spec

--- a/projects/caliper/cli/commands.py
+++ b/projects/caliper/cli/commands.py
@@ -711,6 +711,8 @@ def analyse_kpis_cmd(
     status_file: Path | None,
 ) -> None:
     """Analyze KPIs for orchestration (fork/exec)."""
+    import sys
+
     import yaml
 
     status_data = {"success": False}

--- a/projects/caliper/engine/kpi/analyze.py
+++ b/projects/caliper/engine/kpi/analyze.py
@@ -11,6 +11,55 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
+def _load_kpi_file(path: Path) -> dict[str, Any]:
+    """Load a KPI file, handling both single-document JSON and JSONL formats.
+
+    Returns a dict suitable for plugin consumption.  If the file is JSONL
+    (flat records from ``caliper kpi generate``), the records are grouped by
+    their labels into a hierarchical ``{"tests": [...]}`` structure so that
+    plugins receive a consistent interface.
+    """
+    text = path.read_text(encoding="utf-8").strip()
+    if not text:
+        return {}
+
+    # Try single JSON document first
+    try:
+        data = json.loads(text)
+        if isinstance(data, dict):
+            return data
+    except json.JSONDecodeError:
+        pass
+
+    # Fall back to JSONL (one JSON object per line)
+    records: list[dict[str, Any]] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if line:
+            records.append(json.loads(line))
+
+    if not records:
+        return {}
+
+    # Convert flat KPI records into the hierarchical format plugins expect:
+    #   {"tests": [{"labels": {...}, "kpis": [{"id": ..., "value": ...}, ...]}]}
+    groups: dict[str, dict[str, Any]] = {}
+    for rec in records:
+        labels = dict(rec.get("labels", {}))
+        labels.pop("higher_is_better", None)
+        group_key = json.dumps(labels, sort_keys=True)
+        if group_key not in groups:
+            groups[group_key] = {"labels": labels, "kpis": []}
+        groups[group_key]["kpis"].append({
+            "id": rec.get("kpi_id", ""),
+            "value": rec.get("value"),
+            "unit": rec.get("unit", ""),
+            "higher_is_better": rec.get("labels", {}).get("higher_is_better"),
+        })
+
+    return {"schema_version": "2", "tests": list(groups.values())}
+
+
 def _load_plugin(plugin_module: str):
     """Load plugin instance from module path.
 
@@ -90,18 +139,16 @@ def run_kpi_analysis(
         # Try plugin-specific analysis first
         plugin = _load_plugin(plugin_module)
         if plugin is not None:
-            with open(current_kpi_file) as f:
-                current_kpis = json.load(f)
+            current_kpis = _load_kpi_file(current_kpi_file)
 
             historical_kpis_data = []
             for kpi_file in historical_data_dir.rglob("kpis.json"):
                 try:
-                    with open(kpi_file) as f:
-                        data = json.load(f)
-                    if data.get("schema_version") == "2":
+                    data = _load_kpi_file(kpi_file)
+                    if data.get("tests"):
                         historical_kpis_data.append(data)
                     else:
-                        logger.debug(f"Skipping {kpi_file}: not schema v2")
+                        logger.debug(f"Skipping {kpi_file}: no test entries found")
                 except Exception as e:
                     logger.warning(f"Failed to load {kpi_file}: {e}")
 

--- a/projects/caliper/engine/kpi/analyze.py
+++ b/projects/caliper/engine/kpi/analyze.py
@@ -36,10 +36,6 @@ def run_kpi_analysis(
 ) -> int:
     """Run KPI analysis and generate output file.
 
-    If the plugin provides an `analyze_kpis` implementation (returns anything
-    other than {"status": "not_implemented"}), that is used. Otherwise falls
-    back to the default stub behaviour.
-
     Args:
         current_kpi_file: Path to current KPI JSON file
         historical_data_dir: Directory containing historical KPI files
@@ -65,48 +61,50 @@ def run_kpi_analysis(
             logger.error(f"Historical data directory not found: {historical_data_dir}")
             return 1
 
-        # Load current KPIs
-        with open(current_kpi_file) as f:
-            current_kpis = json.load(f)
-
-        # Find and load all historical KPI files
-        historical_kpi_files = list(historical_data_dir.rglob("kpis.json"))
+        # Find all historical KPI files
+        historical_kpi_files = []
+        for kpi_file in historical_data_dir.rglob("kpis.json"):
+            historical_kpi_files.append(str(kpi_file))
+            logger.info(f"Found historical KPI file: {kpi_file}")
 
         if not historical_kpi_files:
             logger.warning("No historical KPI files found for analysis")
+            # Return special exit code 2 to indicate warning (no historical data)
             analysis_result = {
                 "status": "warning",
                 "message": "no historical KPI found for regression testing",
                 "current_kpi_file": str(current_kpi_file),
-                "historical_kpi_files": [],
+                "historical_kpi_files": historical_kpi_files,
                 "baseline_files_count": 0,
                 "plugin_module": plugin_module,
                 "completed_at": time.time(),
             }
+            # Write warning result to output file
             output_file.parent.mkdir(parents=True, exist_ok=True)
             with open(output_file, "w") as f:
                 json.dump(analysis_result, f, indent=2)
-            return 2
+            return 2  # Special exit code for warning
 
         logger.info(f"Found {len(historical_kpi_files)} historical KPI files for analysis")
 
-        historical_kpis_data = []
-        for kpi_file in historical_kpi_files:
-            try:
-                with open(kpi_file) as f:
-                    data = json.load(f)
-                if data.get("schema_version") == "2":
-                    historical_kpis_data.append(data)
-                else:
-                    logger.debug(f"Skipping {kpi_file}: not schema v2")
-            except Exception as e:
-                logger.warning(f"Failed to load {kpi_file}: {e}")
-
         # Try plugin-specific analysis first
         plugin = _load_plugin(plugin_module)
-        output_file.parent.mkdir(parents=True, exist_ok=True)
-
         if plugin is not None:
+            with open(current_kpi_file) as f:
+                current_kpis = json.load(f)
+
+            historical_kpis_data = []
+            for kpi_file in historical_data_dir.rglob("kpis.json"):
+                try:
+                    with open(kpi_file) as f:
+                        data = json.load(f)
+                    if data.get("schema_version") == "2":
+                        historical_kpis_data.append(data)
+                    else:
+                        logger.debug(f"Skipping {kpi_file}: not schema v2")
+                except Exception as e:
+                    logger.warning(f"Failed to load {kpi_file}: {e}")
+
             result = plugin.analyze_kpis(
                 current_kpis=current_kpis,
                 historical_kpis=historical_kpis_data,
@@ -114,15 +112,15 @@ def run_kpi_analysis(
             )
 
             if result.get("status") != "not_implemented":
-                # Plugin provided its own analysis
                 result.setdefault("current_kpi_file", str(current_kpi_file))
                 result.setdefault("baseline_files_count", len(historical_kpis_data))
                 result.setdefault("plugin_module", plugin_module)
                 result.setdefault("completed_at", time.time())
 
+                output_file.parent.mkdir(parents=True, exist_ok=True)
                 with open(output_file, "w") as f:
                     json.dump(result, f, indent=2)
-                    f.write("\n")
+                    f.write("\n")  # Add EOL at EOF
 
                 status = result.get("status", "unknown")
                 if status in ("success", "warning"):
@@ -132,19 +130,23 @@ def run_kpi_analysis(
                     logger.error(f"Plugin analysis failed: {result.get('error', 'unknown')}")
                     return 1
 
-        # Default stub: just acknowledge historical data exists
+        # Create analysis result
         analysis_result = {
-            "status": "success",
+            "status": "success (stub)",
             "current_kpi_file": str(current_kpi_file),
-            "historical_kpi_files": [str(f) for f in historical_kpi_files],
-            "baseline_files_count": len(historical_kpis_data),
+            "historical_kpi_files": historical_kpi_files,
+            "baseline_files_count": len(historical_kpi_files),
             "plugin_module": plugin_module,
             "completed_at": time.time(),
         }
 
+        # Create output directory if needed
+        output_file.parent.mkdir(parents=True, exist_ok=True)
+
+        # Write analysis results to output file
         with open(output_file, "w") as f:
             json.dump(analysis_result, f, indent=2)
-            f.write("\n")
+            f.write("\n")  # Add EOL at EOF
 
         logger.info(f"Analysis completed successfully, results written to: {output_file}")
         return 0
@@ -152,6 +154,7 @@ def run_kpi_analysis(
     except Exception as e:
         logger.exception("KPI analysis failed")
 
+        # Create failure result
         failure_result = {
             "status": "failed",
             "error": str(e),
@@ -160,11 +163,12 @@ def run_kpi_analysis(
         }
 
         try:
+            # Attempt to write failure result
             if output_file:
                 output_file.parent.mkdir(parents=True, exist_ok=True)
                 with open(output_file, "w") as f:
                     json.dump(failure_result, f, indent=2)
-                    f.write("\n")
+                    f.write("\n")  # Add EOL at EOF
         except Exception:
             logger.exception("Failed to write error result to output file")
 

--- a/projects/caliper/engine/kpi/analyze.py
+++ b/projects/caliper/engine/kpi/analyze.py
@@ -11,6 +11,23 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
+def _load_plugin(plugin_module: str):
+    """Load plugin instance from module path.
+
+    Returns the plugin instance or None if loading fails.
+    """
+    try:
+        mod = __import__(plugin_module, fromlist=["get_plugin"])
+        get_plugin = getattr(mod, "get_plugin", None)
+        if get_plugin is None:
+            logger.warning(f"Plugin module {plugin_module} has no get_plugin() function")
+            return None
+        return get_plugin()
+    except Exception as e:
+        logger.warning(f"Could not load plugin {plugin_module}: {e}")
+        return None
+
+
 def run_kpi_analysis(
     current_kpi_file: Path,
     historical_data_dir: Path,
@@ -18,6 +35,10 @@ def run_kpi_analysis(
     plugin_module: str,
 ) -> int:
     """Run KPI analysis and generate output file.
+
+    If the plugin provides an `analyze_kpis` implementation (returns anything
+    other than {"status": "not_implemented"}), that is used. Otherwise falls
+    back to the default stub behaviour.
 
     Args:
         current_kpi_file: Path to current KPI JSON file
@@ -44,49 +65,86 @@ def run_kpi_analysis(
             logger.error(f"Historical data directory not found: {historical_data_dir}")
             return 1
 
-        # Find all historical KPI files
-        historical_kpi_files = []
-        for kpi_file in historical_data_dir.rglob("kpis.json"):
-            historical_kpi_files.append(str(kpi_file))
-            logger.info(f"Found historical KPI file: {kpi_file}")
+        # Load current KPIs
+        with open(current_kpi_file) as f:
+            current_kpis = json.load(f)
+
+        # Find and load all historical KPI files
+        historical_kpi_files = list(historical_data_dir.rglob("kpis.json"))
 
         if not historical_kpi_files:
             logger.warning("No historical KPI files found for analysis")
-            # Return special exit code 2 to indicate warning (no historical data)
             analysis_result = {
                 "status": "warning",
                 "message": "no historical KPI found for regression testing",
                 "current_kpi_file": str(current_kpi_file),
-                "historical_kpi_files": historical_kpi_files,
+                "historical_kpi_files": [],
                 "baseline_files_count": 0,
                 "plugin_module": plugin_module,
                 "completed_at": time.time(),
             }
-            # Write warning result to output file
             output_file.parent.mkdir(parents=True, exist_ok=True)
             with open(output_file, "w") as f:
                 json.dump(analysis_result, f, indent=2)
-            return 2  # Special exit code for warning
+            return 2
 
         logger.info(f"Found {len(historical_kpi_files)} historical KPI files for analysis")
 
-        # Create analysis result
+        historical_kpis_data = []
+        for kpi_file in historical_kpi_files:
+            try:
+                with open(kpi_file) as f:
+                    data = json.load(f)
+                if data.get("schema_version") == "2":
+                    historical_kpis_data.append(data)
+                else:
+                    logger.debug(f"Skipping {kpi_file}: not schema v2")
+            except Exception as e:
+                logger.warning(f"Failed to load {kpi_file}: {e}")
+
+        # Try plugin-specific analysis first
+        plugin = _load_plugin(plugin_module)
+        output_file.parent.mkdir(parents=True, exist_ok=True)
+
+        if plugin is not None:
+            result = plugin.analyze_kpis(
+                current_kpis=current_kpis,
+                historical_kpis=historical_kpis_data,
+                output_dir=output_file.parent,
+            )
+
+            if result.get("status") != "not_implemented":
+                # Plugin provided its own analysis
+                result.setdefault("current_kpi_file", str(current_kpi_file))
+                result.setdefault("baseline_files_count", len(historical_kpis_data))
+                result.setdefault("plugin_module", plugin_module)
+                result.setdefault("completed_at", time.time())
+
+                with open(output_file, "w") as f:
+                    json.dump(result, f, indent=2)
+                    f.write("\n")
+
+                status = result.get("status", "unknown")
+                if status in ("success", "warning"):
+                    logger.info(f"Plugin analysis completed with status: {status}")
+                    return 0 if status == "success" else 2
+                else:
+                    logger.error(f"Plugin analysis failed: {result.get('error', 'unknown')}")
+                    return 1
+
+        # Default stub: just acknowledge historical data exists
         analysis_result = {
-            "status": "success (stub)",
+            "status": "success",
             "current_kpi_file": str(current_kpi_file),
-            "historical_kpi_files": historical_kpi_files,
-            "baseline_files_count": len(historical_kpi_files),
+            "historical_kpi_files": [str(f) for f in historical_kpi_files],
+            "baseline_files_count": len(historical_kpis_data),
             "plugin_module": plugin_module,
             "completed_at": time.time(),
         }
 
-        # Create output directory if needed
-        output_file.parent.mkdir(parents=True, exist_ok=True)
-
-        # Write analysis results to output file
         with open(output_file, "w") as f:
             json.dump(analysis_result, f, indent=2)
-            f.write("\n")  # Add EOL at EOF
+            f.write("\n")
 
         logger.info(f"Analysis completed successfully, results written to: {output_file}")
         return 0
@@ -94,7 +152,6 @@ def run_kpi_analysis(
     except Exception as e:
         logger.exception("KPI analysis failed")
 
-        # Create failure result
         failure_result = {
             "status": "failed",
             "error": str(e),
@@ -103,12 +160,11 @@ def run_kpi_analysis(
         }
 
         try:
-            # Attempt to write failure result
             if output_file:
                 output_file.parent.mkdir(parents=True, exist_ok=True)
                 with open(output_file, "w") as f:
                     json.dump(failure_result, f, indent=2)
-                    f.write("\n")  # Add EOL at EOF
+                    f.write("\n")
         except Exception:
             logger.exception("Failed to write error result to output file")
 

--- a/projects/caliper/engine/model.py
+++ b/projects/caliper/engine/model.py
@@ -151,6 +151,28 @@ class PostProcessingPlugin(ABC):
 
         return str(output_path)
 
+    def analyze_kpis(
+        self,
+        current_kpis: dict[str, Any],
+        historical_kpis: list[dict[str, Any]],
+        output_dir: Path,
+    ) -> dict[str, Any]:
+        """Run project-specific KPI analysis against historical data.
+
+        Override this to implement custom regression detection, version-aware
+        filtering, or any project-specific comparison logic.
+
+        Args:
+            current_kpis: Parsed kpis.json from the current run (schema v2).
+            historical_kpis: List of parsed kpis.json dicts from historical runs.
+            output_dir: Directory where analysis output files should be written.
+
+        Returns:
+            Analysis result dict with at least a "status" key.
+            Status values: "success", "warning", "failed", "not_implemented".
+        """
+        return {"status": "not_implemented"}
+
     def build_ai_data_payload(self, model: UnifiedRunModel) -> dict[str, Any]:
         """Structured JSON for AI agent evaluation."""
         return {"schema_version": "1", "run_id": "", "metrics": {}}

--- a/projects/mcp_gateway/orchestration/config.yaml
+++ b/projects/mcp_gateway/orchestration/config.yaml
@@ -52,9 +52,9 @@ caliper:
       output: regression_analyze/kpi_analyze.json
 
     s3:
-      bucket: mcp-gateway-cpt-data
-      instance: nightly
-      directory: mcp-gateway-cpt-data
+      bucket: psap-dashboard-data
+      instance: mcp_gateway
+      directory: nightly
       vault:
         name: psap-forge-aws-s3-export
         aws_credentials_file: aws.credentials

--- a/projects/mcp_gateway/orchestration/config.yaml
+++ b/projects/mcp_gateway/orchestration/config.yaml
@@ -3,6 +3,7 @@ vaults:
   all-optional:
   - psap-forge-notifications
   - psap-forge-mlflow-export
+  - psap-forge-aws-s3-export
   prepare: []
   test: []
 
@@ -34,15 +35,43 @@ caliper:
       enabled: false
     kpi:
       enabled: true
-      generate:
+      artifacts_to_kpis:
         enabled: true
-        output: kpis.json
-      export:
+        output: kpis/kpis.json
+      kpis_to_csv:
+        enabled: true
+        output: kpis/kpis.csv
+        include_header_comments: true
+      artifacts_to_ai_data:
         enabled: false
+        output_dir: ai_data
+
     analyze:
-      enabled: false
-      baseline: null
-      output: kpi_analyze.json
+      enabled: true
+      historical_kpis: historical_data
+      output: regression_analyze/kpi_analyze.json
+
+    s3:
+      bucket: mcp-gateway-cpt-data
+      instance: nightly
+      directory: mcp-gateway-cpt-data
+      vault:
+        name: psap-forge-aws-s3-export
+        aws_credentials_file: aws.credentials
+      import:
+        enabled: true
+        output_dir: historical_data
+        include_kpis_json: true
+        include_kpis_csv: true
+        include_ai_data: false
+        max_downloads: 50
+      export:
+        enabled: true
+        upload_id: null
+        dry_run: false
+        include_csv: true
+        include_kpis_json: true
+        include_ai_data: false
 
   export:
     from: null

--- a/projects/mcp_gateway/orchestration/notifications.py
+++ b/projects/mcp_gateway/orchestration/notifications.py
@@ -1,9 +1,7 @@
 """
 Per-project Slack notification provider for MCP Gateway.
 
-Sends structured performance summaries with KPI comparison against the
-previous MLflow run. Reuses shared helpers from the core notification
-framework.
+Sends structured performance summaries with current KPI results.
 
 Channel ID is read from the project's config.yaml at
 ``notifications.slack.channel_id``.
@@ -14,7 +12,7 @@ from __future__ import annotations
 import json
 import logging
 import os
-import re
+from pathlib import Path
 
 from projects.core.library import config
 from projects.core.notifications.helpers import (
@@ -36,53 +34,6 @@ TARGET_KPIS = [
     ("mcp_gw_p99_ms", "P99 latency", "ms"),
     ("mcp_gw_failure_rate", "Failure rate", "%"),
 ]
-
-# Mapping from kpis.jsonl IDs to MLflow metrics.json keys (logged via mlflow.log_metric)
-_KPI_TO_MLFLOW_METRIC = {
-    "mcp_gw_requests_per_second": "requests_per_second",
-    "mcp_gw_p95_ms": "p95_ms",
-    "mcp_gw_p99_ms": "p99_ms",
-    "mcp_gw_failure_rate": "failure_rate",
-}
-
-_RUN_NAME_PREFIX = "forge-mcp-gateway-"
-
-
-def _parse_run_name(run_name: str) -> dict | None:
-    """Parse a forge-mcp-gateway run name into components.
-
-    Expected formats:
-      forge-mcp-gateway-s150-u500-vsha-<hash>-YYYYMMDD-HHMMSS
-      forge-mcp-gateway-s150-u500-v0.7.0-YYYYMMDD-HHMMSS
-      forge-mcp-gateway-0.5.1-YYYYMMDD-HHMMSS
-
-    Returns dict with keys: config, is_sha, version — or None if unparseable.
-    """
-    if not run_name.startswith(_RUN_NAME_PREFIX):
-        return None
-
-    rest = run_name[len(_RUN_NAME_PREFIX) :]
-
-    config = None
-    config_match = re.match(r"(s\d+-u\d+)-", rest)
-    if config_match:
-        config = config_match.group(1)
-        rest = rest[config_match.end() :]
-
-    is_sha = False
-    version = None
-
-    if rest.startswith("vsha-"):
-        is_sha = True
-        sha_match = re.match(r"vsha-([a-f0-9]+)-\d{8}-\d{6}$", rest)
-        if sha_match:
-            version = sha_match.group(1)
-    else:
-        version_match = re.match(r"v?(.+?)-\d{8}-\d{6}$", rest)
-        if version_match:
-            version = version_match.group(1)
-
-    return {"config": config, "is_sha": is_sha, "version": version}
 
 
 class MCPGatewaySlackProvider(SlackNotificationProvider):
@@ -143,27 +94,20 @@ def _format_metadata(context: NotificationContext) -> str:
 
 
 def _format_kpi_table(context: NotificationContext) -> str:
-    """Build comparison table: current KPIs vs previous MLflow run."""
+    """Build KPI comparison table using historical data from S3.
+
+    If historical data is available, shows a comparison table with deltas.
+    Falls back to a simple current KPI list if no history is found.
+    """
     current_kpis = _load_current_kpis(context)
     if not current_kpis:
         return ""
 
-    # Extract current run_id from export status to avoid race with parallel jobs
-    current_run_id = None
-    if isinstance(context.status, dict):
-        backends = context.status.get("caliper_artifacts_export", {}).get("backends", {})
-        current_run_id = backends.get("mlflow", {}).get("run_id")
-
-    previous_kpis, previous_run_name, skip = _load_previous_kpis_from_mlflow(current_run_id)
-
-    if skip:
-        context.extra["_skip_notification"] = True
-        return ""
-
+    previous_kpis, prev_run_name = _load_previous_kpis(context)
     if previous_kpis:
-        return build_comparison_table(current_kpis, previous_kpis, previous_run_name, TARGET_KPIS)
-    else:
-        return build_current_kpis_list(current_kpis, TARGET_KPIS)
+        return build_comparison_table(current_kpis, previous_kpis, prev_run_name, TARGET_KPIS)
+
+    return build_current_kpis_list(current_kpis, TARGET_KPIS)
 
 
 def _format_standard_links(context: NotificationContext) -> str:
@@ -213,16 +157,8 @@ def _find_kpis_json(artifact_dir):
     return None
 
 
-def _load_current_kpis(context: NotificationContext) -> dict[str, float]:
-    """Read KPI values from kpis.json in the artifact directory."""
-    test_root = get_test_artifacts_root(context)
-    if not test_root:
-        return {}
-
-    kpis_file = _find_kpis_json(test_root)
-    if not kpis_file:
-        return {}
-
+def _extract_kpis_from_file(kpis_file: Path) -> dict[str, float]:
+    """Extract target KPI values from a kpis.json file."""
     target_ids = {k[0] for k in TARGET_KPIS}
     kpis: dict[str, float] = {}
 
@@ -242,149 +178,93 @@ def _load_current_kpis(context: NotificationContext) -> dict[str, float]:
     return kpis
 
 
-def _load_previous_kpis_from_mlflow(
-    current_run_id: str | None = None,
-) -> tuple[dict[str, float], str, bool]:
-    """Query MLflow for the previous matching run's metrics.
+def _load_current_kpis(context: NotificationContext) -> dict[str, float]:
+    """Read KPI values from kpis.json in the artifact directory."""
+    test_root = get_test_artifacts_root(context)
+    if not test_root:
+        return {}
 
-    Args:
-        current_run_id: MLflow run ID of this notification's run. When provided
-            the current run is located by ID (avoids races with parallel jobs).
+    kpis_file = _find_kpis_json(test_root)
+    if not kpis_file:
+        return {}
 
-    Matching rules:
-    - Same load config (e.g. s150-u500)
-    - Same version type (SHA-based compared only to SHA-based, release to release)
-    - Same preset parameter value
+    return _extract_kpis_from_file(kpis_file)
 
-    Returns (metrics_dict, run_name, skip_notification):
-    - skip_notification is True when the previous matching run has the same
-      version/SHA (duplicate run, notification already sent).
-    """
+
+def _get_current_version() -> str:
+    """Get the MCP Gateway version of the current run."""
+    version = os.environ.get("MCP_GATEWAY_VERSION", "")
+    if not version:
+        version = os.environ.get("MCP_GW_VERSION", "")
+    return version
+
+
+def _get_version_from_kpis_json(kpis_file: Path) -> str | None:
+    """Extract mcp_gateway_version from a kpis.json file's labels."""
     try:
-        from projects.caliper.engine.file_export.mlflow_secrets import (
-            load_mlflow_secrets_yaml,
-            mlflow_connection_env,
-        )
-        from projects.core.library import vault as vault_lib
-
-        vault_name = config.project.get_config(
-            "caliper.export.backend.mlflow.secrets.vault.name", None, print=False, warn=False
-        )
-        vault_secret = config.project.get_config(
-            "caliper.export.backend.mlflow.secrets.vault.mlflow_secret",
-            None,
-            print=False,
-            warn=False,
-        )
-        experiment_name = config.project.get_config(
-            "caliper.export.backend.mlflow.config.experiment", None, print=False, warn=False
-        )
-
-        if not all([vault_name, vault_secret, experiment_name]):
-            logger.info("MLflow config incomplete, skipping comparison")
-            return {}, "", False
-
-        secrets_path = vault_lib.get_vault_content_path(vault_name, vault_secret)
-        if not secrets_path or not secrets_path.exists():
-            logger.info("MLflow secrets not available, skipping comparison")
-            return {}, "", False
-
-        secrets = load_mlflow_secrets_yaml(secrets_path)
-
-        with mlflow_connection_env(secrets):
-            import mlflow
-
-            client = mlflow.tracking.MlflowClient()
-            exp = client.get_experiment_by_name(experiment_name)
-            if not exp:
-                logger.info("MLflow experiment '%s' not found", experiment_name)
-                return {}, "", False
-
-            runs = client.search_runs(
-                experiment_ids=[exp.experiment_id],
-                order_by=["start_time DESC"],
-                max_results=50,
-            )
-
-            if len(runs) < 2:
-                logger.info("No previous MLflow run found for comparison")
-                return {}, "", False
-
-            # Locate the current run explicitly by ID when available
-            current_run = None
-            if current_run_id:
-                for run in runs:
-                    if run.info.run_id == current_run_id:
-                        current_run = run
-                        break
-                if current_run is None:
-                    logger.info(
-                        "Current run_id '%s' not found in recent runs, falling back to runs[0]",
-                        current_run_id,
-                    )
-            if current_run is None:
-                current_run = runs[0]
-
-            current_name = getattr(current_run.info, "run_name", "") or current_run.info.run_id[:8]
-            current_parsed = _parse_run_name(current_name)
-            current_preset = (current_run.data.params or {}).get("preset", "")
-
-            if not current_parsed:
-                logger.info("Cannot parse current run name '%s', skipping comparison", current_name)
-                return {}, "", False
-
-            # Find previous run matching: same config, same type, same preset
-            previous_run = None
-            for run in runs:
-                if run.info.run_id == current_run.info.run_id:
-                    continue
-                candidate_name = getattr(run.info, "run_name", "") or run.info.run_id[:8]
-                candidate_parsed = _parse_run_name(candidate_name)
-                if not candidate_parsed:
-                    continue
-
-                if candidate_parsed["config"] != current_parsed["config"]:
-                    continue
-                if candidate_parsed["is_sha"] != current_parsed["is_sha"]:
-                    continue
-
-                candidate_preset = (run.data.params or {}).get("preset", "")
-                if candidate_preset != current_preset:
-                    continue
-
-                previous_run = run
-                break
-
-            if previous_run is None:
-                logger.info(
-                    "No previous run matches config=%s, is_sha=%s, preset=%s",
-                    current_parsed["config"],
-                    current_parsed["is_sha"],
-                    current_preset,
-                )
-                return {}, "", False
-
-            prev_name = getattr(previous_run.info, "run_name", "") or previous_run.info.run_id[:8]
-            prev_parsed = _parse_run_name(prev_name)
-
-            # Check for duplicate: same version/SHA means already notified
-            if prev_parsed and prev_parsed["version"] == current_parsed["version"]:
-                logger.info(
-                    "Previous matching run has same version '%s', skipping notification",
-                    current_parsed["version"],
-                )
-                return {}, "", True
-
-            raw_metrics = previous_run.data.metrics or {}
-            mlflow_to_kpi = {v: k for k, v in _KPI_TO_MLFLOW_METRIC.items()}
-            metrics = {}
-            for mlflow_key, value in raw_metrics.items():
-                kpi_id = mlflow_to_kpi.get(mlflow_key)
-                if kpi_id:
-                    metrics[kpi_id] = value
-
-            return metrics, prev_name, False
-
+        with open(kpis_file) as f:
+            data = json.load(f)
+        for test in data.get("tests", []):
+            labels = test.get("labels", {})
+            version = labels.get("mcp_gateway_version")
+            if version:
+                return str(version)
     except Exception as e:
-        logger.warning("MLflow comparison unavailable: %s", e)
-        return {}, "", False
+        logger.debug("Could not extract version from %s: %s", kpis_file, e)
+    return None
+
+
+def _load_previous_kpis(context: NotificationContext) -> tuple[dict[str, float], str]:
+    """Load the most recent historical KPIs from a *different* version.
+
+    After S3 import, historical kpis.json files are stored at:
+        {artifact_dir}/historical_data/{upload_id}/kpis.json
+
+    The upload_id is a timestamp (e.g. "25-07-12_143021_123"), so sorting
+    the directories in reverse gives us the most recent previous run.
+
+    To provide meaningful comparisons, this function skips historical runs
+    that have the same mcp_gateway_version as the current run. This avoids
+    noise from comparing e.g. v0.7.0 against v0.7.0.
+
+    Returns:
+        Tuple of (kpi_values_dict, run_name_string).
+        Returns ({}, "") if no historical data is available.
+    """
+    test_root = get_test_artifacts_root(context)
+    if not test_root:
+        return {}, ""
+
+    historical_dir = test_root / "historical_data"
+    if not historical_dir.exists():
+        logger.info("No historical_data directory found at %s", historical_dir)
+        return {}, ""
+
+    historical_kpi_files = sorted(historical_dir.glob("*/kpis.json"), reverse=True)
+    if not historical_kpi_files:
+        logger.info("No historical kpis.json files found in %s", historical_dir)
+        return {}, ""
+
+    current_version = _get_current_version()
+
+    for kpis_file in historical_kpi_files:
+        if current_version:
+            hist_version = _get_version_from_kpis_json(kpis_file)
+            if hist_version and hist_version == current_version:
+                logger.debug(
+                    "Skipping %s (same version: %s)", kpis_file.parent.name, hist_version
+                )
+                continue
+
+        run_name = kpis_file.parent.name
+        hist_version = _get_version_from_kpis_json(kpis_file)
+        if hist_version:
+            run_name = f"{hist_version} ({run_name})"
+
+        logger.info("Using historical data from run: %s", run_name)
+        kpis = _extract_kpis_from_file(kpis_file)
+        if kpis:
+            return kpis, run_name
+
+    logger.info("No historical data from a different version found")
+    return {}, ""

--- a/projects/mcp_gateway/orchestration/notifications.py
+++ b/projects/mcp_gateway/orchestration/notifications.py
@@ -191,50 +191,50 @@ def _load_current_kpis(context: NotificationContext) -> dict[str, float]:
     return _extract_kpis_from_file(kpis_file)
 
 
-def _get_current_version() -> str:
-    """Get the MCP Gateway version of the current run."""
-    version = os.environ.get("MCP_GATEWAY_VERSION", "")
-    if not version:
-        version = os.environ.get("MCP_GW_VERSION", "")
-    return version
-
-
-def _get_version_from_kpis_json(kpis_file: Path) -> str | None:
-    """Extract mcp_gateway_version from a kpis.json file's labels."""
-    try:
-        with open(kpis_file) as f:
-            data = json.load(f)
-        for test in data.get("tests", []):
-            labels = test.get("labels", {})
-            version = labels.get("mcp_gateway_version")
-            if version:
-                return str(version)
-    except Exception as e:
-        logger.debug("Could not extract version from %s: %s", kpis_file, e)
-    return None
-
-
 def _load_previous_kpis(context: NotificationContext) -> tuple[dict[str, float], str]:
-    """Load the most recent historical KPIs from a *different* version.
+    """Load the most recent historical KPIs matching current run's config.
+
+    Uses the same matching logic as the analyze step:
+    - Same preset, same load config (num_servers + users)
+    - Same version type (SHA vs semver)
+    - Different version
 
     After S3 import, historical kpis.json files are stored at:
         {artifact_dir}/historical_data/{upload_id}/kpis.json
-
-    The upload_id is a timestamp (e.g. "25-07-12_143021_123"), so sorting
-    the directories in reverse gives us the most recent previous run.
-
-    To provide meaningful comparisons, this function skips historical runs
-    that have the same mcp_gateway_version as the current run. This avoids
-    noise from comparing e.g. v0.7.0 against v0.7.0.
 
     Returns:
         Tuple of (kpi_values_dict, run_name_string).
         Returns ({}, "") if no historical data is available.
     """
+    from projects.mcp_gateway.postprocess.mcp_gateway.analyze import (
+        _extract_tests,
+        _find_matching_baseline,
+    )
+
     test_root = get_test_artifacts_root(context)
     if not test_root:
         return {}, ""
 
+    # Load current run's kpis.json to get its config
+    current_kpis_file = _find_kpis_json(test_root)
+    if not current_kpis_file:
+        return {}, ""
+
+    try:
+        with open(current_kpis_file) as f:
+            current_data = json.load(f)
+    except Exception as e:
+        logger.warning("Failed to load current kpis.json: %s", e)
+        return {}, ""
+
+    current_tests = _extract_tests(current_data)
+    if not current_tests:
+        return {}, ""
+
+    # Use first test entry as the reference for matching
+    current_test = current_tests[0]
+
+    # Load all historical test entries
     historical_dir = test_root / "historical_data"
     if not historical_dir.exists():
         logger.info("No historical_data directory found at %s", historical_dir)
@@ -245,26 +245,39 @@ def _load_previous_kpis(context: NotificationContext) -> tuple[dict[str, float],
         logger.info("No historical kpis.json files found in %s", historical_dir)
         return {}, ""
 
-    current_version = _get_current_version()
-
+    # Collect all historical test entries (ordered by most recent first)
+    all_historical_tests = []
     for kpis_file in historical_kpi_files:
-        if current_version:
-            hist_version = _get_version_from_kpis_json(kpis_file)
-            if hist_version and hist_version == current_version:
-                logger.debug(
-                    "Skipping %s (same version: %s)", kpis_file.parent.name, hist_version
-                )
-                continue
+        try:
+            with open(kpis_file) as f:
+                hist_data = json.load(f)
+            tests = _extract_tests(hist_data)
+            all_historical_tests.extend(tests)
+        except Exception as e:
+            logger.debug("Failed to load %s: %s", kpis_file, e)
 
-        run_name = kpis_file.parent.name
-        hist_version = _get_version_from_kpis_json(kpis_file)
-        if hist_version:
-            run_name = f"{hist_version} ({run_name})"
+    # Find matching baseline using the analyze module's logic
+    baseline = _find_matching_baseline(current_test, all_historical_tests)
+    if not baseline:
+        logger.info(
+            "No matching historical run (config=%s, preset=%s, type=%s)",
+            current_test.config.load_config,
+            current_test.config.preset,
+            "sha" if current_test.config.is_sha else "semver",
+        )
+        return {}, ""
 
-        logger.info("Using historical data from run: %s", run_name)
-        kpis = _extract_kpis_from_file(kpis_file)
-        if kpis:
-            return kpis, run_name
+    # Build run name for display
+    run_name = baseline.config.version
+    if not run_name:
+        run_name = "previous run"
 
-    logger.info("No historical data from a different version found")
+    # Extract target KPIs from baseline
+    target_ids = {k[0] for k in TARGET_KPIS}
+    kpis = {kpi_id: val for kpi_id, val in baseline.values.items() if kpi_id in target_ids}
+
+    if kpis:
+        logger.info("Using baseline: version=%s config=%s", run_name, baseline.config.load_config)
+        return kpis, run_name
+
     return {}, ""

--- a/projects/mcp_gateway/postprocess/mcp_gateway/analyze.py
+++ b/projects/mcp_gateway/postprocess/mcp_gateway/analyze.py
@@ -1,0 +1,306 @@
+"""MCP Gateway KPI analysis: version-aware, config-aware regression detection.
+
+Comparison rules (matching the MLflow-based logic):
+- Never compare the same version against itself
+- SHA-based versions only compare against other SHA-based versions
+- Semver versions only compare against other semver versions
+- Runs must match by load config (num_servers + users)
+- Runs must match by preset
+- For matrix runs (multiple tests in one kpis.json), each test entry
+  is compared independently against its matching historical counterpart
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TestConfig:
+    """Identifies a unique test configuration for matching."""
+
+    preset: str
+    num_servers: str
+    users: str
+    version: str
+    is_sha: bool
+
+    @property
+    def load_config(self) -> str:
+        """The load configuration key (equivalent to s<N>-u<N>)."""
+        return f"s{self.num_servers}-u{self.users}"
+
+
+@dataclass
+class TestKPIs:
+    """KPI values for a single test entry with its config."""
+
+    config: TestConfig
+    values: dict[str, float]
+    labels: dict[str, Any]
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def analyze_kpis(
+    current_kpis: dict[str, Any],
+    historical_kpis: list[dict[str, Any]],
+    output_dir: Path,
+) -> dict[str, Any]:
+    """Analyze current KPIs against historical data with full matching logic.
+
+    Args:
+        current_kpis: Parsed kpis.json from the current run (schema v2).
+        historical_kpis: List of parsed kpis.json dicts from historical runs.
+        output_dir: Directory where analysis output files should be written.
+
+    Returns:
+        Analysis result dict with status and findings.
+    """
+    if not historical_kpis:
+        return {
+            "status": "warning",
+            "message": "no historical KPI data available for analysis",
+        }
+
+    current_tests = _extract_tests(current_kpis)
+    if not current_tests:
+        return {
+            "status": "warning",
+            "message": "no KPI values found in current run",
+        }
+
+    historical_tests = []
+    for hist_data in historical_kpis:
+        historical_tests.extend(_extract_tests(hist_data))
+
+    if not historical_tests:
+        return {
+            "status": "warning",
+            "message": "no valid historical test entries found",
+        }
+
+    is_matrix = len(current_tests) > 1
+    all_findings = []
+
+    for current_test in current_tests:
+        baseline = _find_matching_baseline(current_test, historical_tests)
+        if not baseline:
+            logger.info(
+                "No matching baseline for config=%s preset=%s version_type=%s",
+                current_test.config.load_config,
+                current_test.config.preset,
+                "sha" if current_test.config.is_sha else "semver",
+            )
+            continue
+
+        findings = _compare_kpis(current_test, baseline)
+        all_findings.append({
+            "load_config": current_test.config.load_config,
+            "preset": current_test.config.preset,
+            "current_version": current_test.config.version,
+            "baseline_version": baseline.config.version,
+            "kpis": findings,
+        })
+
+    if not all_findings:
+        return {
+            "status": "warning",
+            "message": "no matching historical runs found for comparison",
+            "current_configs": [t.config.load_config for t in current_tests],
+            "current_version": current_tests[0].config.version if current_tests else "",
+        }
+
+    regressions = []
+    for group in all_findings:
+        for kpi in group["kpis"]:
+            if kpi["status"] == "regression":
+                regressions.append({
+                    "load_config": group["load_config"],
+                    "kpi_id": kpi["kpi_id"],
+                    "delta_pct": kpi["delta_pct"],
+                })
+
+    return {
+        "status": "success",
+        "is_matrix": is_matrix,
+        "comparisons": all_findings,
+        "regressions_count": len(regressions),
+        "regressions": regressions,
+        "completed_at": time.time(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Extraction helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_sha_version(version: str) -> bool:
+    """Determine if a version string is SHA-based."""
+    if not version:
+        return False
+    if version.startswith("sha-"):
+        return True
+    # Pure hex string of sufficient length (40 chars for full SHA, or 7+ for short)
+    if len(version) >= 7 and all(c in "0123456789abcdef" for c in version):
+        return True
+    return False
+
+
+def _normalize_version(version: str) -> str:
+    """Strip common prefixes for comparison."""
+    if version.startswith("sha-"):
+        return version[4:]
+    return version.lstrip("v")
+
+
+def _extract_tests(kpis_data: dict[str, Any]) -> list[TestKPIs]:
+    """Extract all test entries from a kpis.json as TestKPIs objects."""
+    results = []
+
+    for test in kpis_data.get("tests", []):
+        labels = test.get("labels", {})
+        version = str(labels.get("mcp_gateway_version", ""))
+
+        config = TestConfig(
+            preset=str(labels.get("preset", "")),
+            num_servers=str(labels.get("num_servers", "")),
+            users=str(labels.get("users", "")),
+            version=version,
+            is_sha=_is_sha_version(version),
+        )
+
+        values: dict[str, float] = {}
+        for kpi in test.get("kpis", []):
+            kpi_id = kpi.get("id")
+            value = kpi.get("value")
+            if kpi_id and value is not None:
+                values[kpi_id] = float(value)
+
+        if values:
+            results.append(TestKPIs(config=config, values=values, labels=labels))
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Matching logic
+# ---------------------------------------------------------------------------
+
+
+def _find_matching_baseline(
+    current: TestKPIs,
+    historical_tests: list[TestKPIs],
+) -> TestKPIs | None:
+    """Find the best matching historical test entry.
+
+    Matching rules:
+    1. Same preset
+    2. Same load config (num_servers + users)
+    3. Same version type (SHA vs semver)
+    4. Different version (skip duplicates)
+    """
+    for hist in historical_tests:
+        # Must match preset
+        if hist.config.preset != current.config.preset:
+            continue
+
+        # Must match load config (num_servers + users)
+        if hist.config.load_config != current.config.load_config:
+            continue
+
+        # Must match version type (SHA vs semver)
+        if hist.config.is_sha != current.config.is_sha:
+            continue
+
+        # Must be a different version
+        cur_normalized = _normalize_version(current.config.version)
+        hist_normalized = _normalize_version(hist.config.version)
+        if cur_normalized == hist_normalized:
+            continue
+
+        return hist
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Comparison logic
+# ---------------------------------------------------------------------------
+
+# Threshold for marking a change as regression or improvement (percentage)
+REGRESSION_THRESHOLD_PCT = 5.0
+
+
+def _compare_kpis(
+    current: TestKPIs,
+    baseline: TestKPIs,
+) -> list[dict[str, Any]]:
+    """Compare current KPIs against baseline and detect regressions."""
+    findings = []
+
+    for kpi_id, cur_val in current.values.items():
+        base_val = baseline.values.get(kpi_id)
+        if base_val is None:
+            continue
+
+        # Get direction from the kpis.json data
+        higher_is_better = _get_kpi_direction(current, kpi_id)
+
+        if base_val == 0:
+            delta_pct = 0.0
+        else:
+            delta_pct = ((cur_val - base_val) / abs(base_val)) * 100
+
+        status = _classify_change(delta_pct, higher_is_better)
+
+        findings.append({
+            "kpi_id": kpi_id,
+            "current_value": cur_val,
+            "baseline_value": base_val,
+            "delta_pct": round(delta_pct, 2),
+            "higher_is_better": higher_is_better,
+            "status": status,
+        })
+
+    return findings
+
+
+def _get_kpi_direction(test: TestKPIs, kpi_id: str) -> bool:
+    """Look up higher_is_better for a KPI from the raw test data."""
+    # We stored labels but not the full kpi metadata in TestKPIs.
+    # Re-check via a known mapping for mcp_gateway KPIs.
+    _LOWER_IS_BETTER = {
+        "mcp_gw_avg_response_time_ms",
+        "mcp_gw_p50_ms",
+        "mcp_gw_p95_ms",
+        "mcp_gw_p99_ms",
+        "mcp_gw_failure_rate",
+    }
+    return kpi_id not in _LOWER_IS_BETTER
+
+
+def _classify_change(delta_pct: float, higher_is_better: bool) -> str:
+    """Classify a percentage change as regression, improvement, or stable."""
+    if abs(delta_pct) < REGRESSION_THRESHOLD_PCT:
+        return "stable"
+
+    if higher_is_better:
+        return "improvement" if delta_pct > 0 else "regression"
+    else:
+        return "improvement" if delta_pct < 0 else "regression"

--- a/projects/mcp_gateway/postprocess/mcp_gateway/analyze.py
+++ b/projects/mcp_gateway/postprocess/mcp_gateway/analyze.py
@@ -109,13 +109,15 @@ def analyze_kpis(
             continue
 
         findings = _compare_kpis(current_test, baseline)
-        all_findings.append({
-            "load_config": current_test.config.load_config,
-            "preset": current_test.config.preset,
-            "current_version": current_test.config.version,
-            "baseline_version": baseline.config.version,
-            "kpis": findings,
-        })
+        all_findings.append(
+            {
+                "load_config": current_test.config.load_config,
+                "preset": current_test.config.preset,
+                "current_version": current_test.config.version,
+                "baseline_version": baseline.config.version,
+                "kpis": findings,
+            }
+        )
 
     if not all_findings:
         return {
@@ -129,11 +131,13 @@ def analyze_kpis(
     for group in all_findings:
         for kpi in group["kpis"]:
             if kpi["status"] == "regression":
-                regressions.append({
-                    "load_config": group["load_config"],
-                    "kpi_id": kpi["kpi_id"],
-                    "delta_pct": kpi["delta_pct"],
-                })
+                regressions.append(
+                    {
+                        "load_config": group["load_config"],
+                        "kpi_id": kpi["kpi_id"],
+                        "delta_pct": kpi["delta_pct"],
+                    }
+                )
 
     return {
         "status": "success",
@@ -269,14 +273,16 @@ def _compare_kpis(
 
         status = _classify_change(delta_pct, higher_is_better)
 
-        findings.append({
-            "kpi_id": kpi_id,
-            "current_value": cur_val,
-            "baseline_value": base_val,
-            "delta_pct": round(delta_pct, 2),
-            "higher_is_better": higher_is_better,
-            "status": status,
-        })
+        findings.append(
+            {
+                "kpi_id": kpi_id,
+                "current_value": cur_val,
+                "baseline_value": base_val,
+                "delta_pct": round(delta_pct, 2),
+                "higher_is_better": higher_is_better,
+                "status": status,
+            }
+        )
 
     return findings
 

--- a/projects/mcp_gateway/postprocess/mcp_gateway/plugin.py
+++ b/projects/mcp_gateway/postprocess/mcp_gateway/plugin.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 from typing import Any
 
 from projects.caliper.engine.model import (
@@ -12,6 +13,7 @@ from projects.caliper.engine.model import (
     UnifiedRunModel,
 )
 
+from .analyze import analyze_kpis as _analyze_kpis
 from .parsing import MCPGatewayKpiHandler, MCPGatewayParser
 
 logger = logging.getLogger(__name__)
@@ -32,6 +34,14 @@ class MCPGatewayPlugin(PostProcessingPlugin):
 
     def compute_kpis(self, model: UnifiedRunModel) -> list[dict[str, Any]]:
         return self.kpi_handler.compute_kpis(model)
+
+    def analyze_kpis(
+        self,
+        current_kpis: dict[str, Any],
+        historical_kpis: list[dict[str, Any]],
+        output_dir: Path,
+    ) -> dict[str, Any]:
+        return _analyze_kpis(current_kpis, historical_kpis, output_dir)
 
 
 def get_plugin() -> PostProcessingPlugin:


### PR DESCRIPTION
## Summary

- Replace MLflow-based historical data fetching with Caliper's standard S3 import/export pipeline for KPI comparison
- Rewrite Slack notifications to use S3-imported historical `kpis.json` files with version-aware filtering (skips same-version runs)
- Add full S3 configuration (bucket, vault, import/export settings) and enable KPI CSV generation

## Details

The previous implementation queried MLflow directly for historical run data, which had timing issues (called during `do_test` before MLflow export) and didn't align with how other projects (skeleton, llm_d) handle historical data.

This PR switches to Caliper's standard approach:
1. After KPI generation, S3 import downloads previous runs' `kpis.json` into `historical_data/`
2. The `analyse_kpis` step compares current vs historical KPIs
3. S3 export uploads the current run's KPIs for future comparisons
4. Notifications read from `historical_data/` and filter by `mcp_gateway_version` to find the most recent *different* version for meaningful comparison

## Test plan

- [ ] Verify S3 bucket `mcp-gateway-cpt-data` is created and accessible
- [ ] Run a nightly test and confirm KPIs are exported to S3
- [ ] Run a second test and confirm historical data is imported and comparison table appears in Slack
- [ ] Verify version filtering works (same version runs are skipped in comparison)


Made with [Cursor](https://cursor.com)