### PR TITLE
[fournos_launcher] Allow deploying clusterless jobs

### DIFF
--- a/fournos/gitops/base/workflows/kustomization.yaml
+++ b/fournos/gitops/base/workflows/kustomization.yaml
@@ -5,9 +5,11 @@ resources:
   # - resolve-job.yaml
   - task-forge-step.yaml
   - pipeline-full.yaml
-  - pipeline-test-only.yaml
+  - pipeline-launcher.yaml
+  - pipeline-prepare-only.yaml
+  - pipeline-prepare-test.yaml
   - pipeline-replot.yaml
-
+  - pipeline-test-only.yaml
 commonLabels:
   app.kubernetes.io/name: forge-on-fournos
   app.kubernetes.io/component: workflows

--- a/fournos/gitops/base/workflows/pipeline-launcher.yaml
+++ b/fournos/gitops/base/workflows/pipeline-launcher.yaml
@@ -1,0 +1,77 @@
+# Single-step pipeline: run only (no prepare, no cleanup).
+# Use on pre-configured clusters where setup/teardown is handled externally.
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: forge-launcher
+  annotations:
+    fournos.dev/resolve-image: image-registry.openshift-image-registry.svc:5000/${NAMESPACE}/forge-core:latest
+spec:
+  workspaces:
+    - name: artifacts
+  params:
+    - name: fjob-name
+      type: string
+    - name: fournos-workload-namespace
+      type: string
+    - name: kubeconfig-secret
+      type: string
+  tasks:
+    - name: 00-preflight
+      taskRef:
+        name: forge-step
+        kind: Task
+      workspaces:
+        - name: artifacts
+          workspace: artifacts
+      params:
+        - name: fjob-name
+          value: "$(params.fjob-name)"
+        - name: fournos-workload-namespace
+          value: "$(params.fournos-workload-namespace)"
+        - name: kubeconfig-secret
+          value: "$(params.kubeconfig-secret)"
+        - name: job-step
+          value: preflight
+        - name: job-step-name
+          value: 00__preflight
+
+    - name: 01-launcher
+      runAfter: [00-preflight]
+      taskRef:
+        name: forge-step
+        kind: Task
+      workspaces:
+        - name: artifacts
+          workspace: artifacts
+      params:
+        - name: fjob-name
+          value: "$(params.fjob-name)"
+        - name: fournos-workload-namespace
+          value: "$(params.fournos-workload-namespace)"
+        - name: kubeconfig-secret
+          value: "$(params.kubeconfig-secret)"
+        - name: job-step
+          value: launcher
+        - name: job-step-name
+          value: 01__launcher
+
+  finally:
+    - name: 02-export-artifacts
+      taskRef:
+        name: forge-step
+        kind: Task
+      workspaces:
+        - name: artifacts
+          workspace: artifacts
+      params:
+        - name: fjob-name
+          value: "$(params.fjob-name)"
+        - name: fournos-workload-namespace
+          value: "$(params.fournos-workload-namespace)"
+        - name: kubeconfig-secret
+          value: "$(params.kubeconfig-secret)"
+        - name: job-step
+          value: export-artifacts
+        - name: job-step-name
+          value: 02__export-artifacts

--- a/fournos/gitops/base/workflows/pipeline-prepare-test.yaml
+++ b/fournos/gitops/base/workflows/pipeline-prepare-test.yaml
@@ -57,7 +57,7 @@ spec:
           value: 02__preflight
 
     - name: 03-test
-      runAfter: [01-preflight]
+      runAfter: [02-preflight]
       taskRef:
         name: forge-step
         kind: Task

--- a/fournos/gitops/base/workflows/task-forge-step.yaml
+++ b/fournos/gitops/base/workflows/task-forge-step.yaml
@@ -13,6 +13,8 @@ spec:
       type: string
     - name: kubeconfig-secret
       type: string
+      default: "fournos-clusterless-placeholder"
+      description: "Kubeconfig secret name. Uses placeholder for clusterless jobs."
     - name: job-step
       type: string
     - name: job-step-name
@@ -31,6 +33,8 @@ spec:
       env:
       - name: TARGET_KUBECONFIG
         value: /var/run/secrets/fournos-kubeconfig/kubeconfig
+      - name: KUBECONFIG_SECRET_PARAM
+        value: "$(params.kubeconfig-secret)"
       - name: FJOB_NAME
         value: "$(params.fjob-name)"
       - name: FOURNOS_WORKLOAD_NAMESPACE
@@ -73,7 +77,21 @@ spec:
         # switching KUBECONFIG to the target cluster.
         oc get "fjob/$FJOB_NAME" -n "$FOURNOS_WORKLOAD_NAMESPACE" -oyaml > $ARTIFACT_DIR/fournos_fjob.yaml
 
-        export KUBECONFIG=$TARGET_KUBECONFIG
+        # Check if we have a kubeconfig for target cluster
+        if [[ "$KUBECONFIG_SECRET_PARAM" != "fournos-clusterless-placeholder" && -f "$TARGET_KUBECONFIG" ]]; then
+          echo "Setting up target cluster kubeconfig..."
+          export KUBECONFIG=$TARGET_KUBECONFIG
+          export CLUSTERLESS_MODE="false"
+
+        else
+          if [[ "$KUBECONFIG_SECRET_PARAM" == "fournos-clusterless-placeholder" ]]; then
+            echo "Running in clusterless mode - no target cluster kubeconfig"
+          else
+            echo "WARNING: Expected kubeconfig not found at: $TARGET_KUBECONFIG"
+            echo "Running in clusterless mode as fallback"
+          fi
+          export CLUSTERLESS_MODE="true"
+        fi
 
         # Function to conditionally export environment variables from FournosJob spec
         export_env_var_from_fjob() {
@@ -126,3 +144,4 @@ spec:
     - name: kubeconfig
       secret:
         secretName: $(params.kubeconfig-secret)
+        optional: true

--- a/projects/fournos_launcher/CHANGELOG-orchestration.md
+++ b/projects/fournos_launcher/CHANGELOG-orchestration.md
@@ -1,5 +1,36 @@
 # Fournos Launcher Orchestration Changelog
 
+## 2026-07-13 - Clusterless Mode and New Directives
+
+### New PR Directives
+- **Clusterless Directive**: Added `/clusterless` directive to enable clusterless mode execution
+  - **Effect**: Sets `fournos.job.exclusive=false` and `fournos.job.clusterless=true`
+  - **Validation**: Prevents conflicting usage with `/exclusive true`
+- **Fournos Environment Directive**: Added `/fournos` directive for namespace targeting
+  - **Format**: `/fournos wip` or `/fournos staging`
+  - **Effect**: Sets `fournos.namespace` to `psap-automation-{environment}`
+  - **Validation**: Restricts to `wip` and `staging` environments only
+
+### Enhanced Validation
+- **Mutual Exclusivity**: Added comprehensive validation to prevent `clusterless=true` and `exclusive=true` conflicts
+  - **PR Parser Level**: Catches directive conflicts during comment parsing
+  - **CLI Level**: Validates configuration before command execution
+  - **Submit Level**: Final validation before job submission
+- **Optional Cluster**: Made `/cluster` directive optional when `/clusterless` is used
+  - **Smart Validation**: Requires cluster specification only when not in clusterless mode
+  - **Clear Error Messages**: Improved error messaging to explain clusterless option
+
+### Files Modified
+- `pr_args.py` - Added `/clusterless` and `/fournos` directive handlers with validation
+- `cli.py` - Enhanced cluster requirement logic and added conflict validation
+- `submit.py` - Added clusterless/exclusive mutual exclusivity checks
+
+### Benefits
+- **Flexible Execution**: Enables both cluster-targeted and clusterless job execution modes
+- **Environment Targeting**: Simplified namespace selection for different deployment environments
+- **Robust Validation**: Prevents configuration conflicts with clear, actionable error messages
+- **Backward Compatibility**: Maintains existing directive functionality while adding new capabilities
+
 ## 2026-06-30 - Notification System Integration
 
 ### Job Completion Notifications

--- a/projects/fournos_launcher/CHANGELOG-toolbox.md
+++ b/projects/fournos_launcher/CHANGELOG-toolbox.md
@@ -1,5 +1,24 @@
 # Fournos Launcher Toolbox Changelog
 
+## 2026-07-13 - Clusterless Mode Support
+
+### submit_and_wait
+
+#### Clusterless Execution Support
+- **Clusterless Parameter**: Added `clusterless: bool = False` parameter to entrypoint function
+- **Template Updates**: Enhanced job.yaml.j2 template to conditionally render `clusterless: true` or `cluster: <name>` fields
+- **Validation Logic**: Added validation to ensure clusterless and exclusive modes are mutually exclusive
+- **Optional Cluster**: Made `cluster_name` parameter optional when `clusterless=True`
+
+#### Files Modified
+- `main.py` - Added clusterless parameter support and validation logic
+- `templates/job.yaml.j2` - Updated FournosJob template with conditional cluster/clusterless field rendering
+
+#### Benefits
+- Enables clusterless job execution for improved resource flexibility
+- Maintains backward compatibility with existing cluster-based workflows
+- Provides clear validation for conflicting configuration options
+
 ## 2026-06-24 - Job Management Improvements
 
 ### submit_and_wait

--- a/projects/fournos_launcher/orchestration/cli.py
+++ b/projects/fournos_launcher/orchestration/cli.py
@@ -53,13 +53,29 @@ def submit(ctx, cluster, project, args, namespace, override, commit):
             logger.warning(f"Ignoring invalid override format: {override_str} (expected key=value)")
 
     # Override config values if provided
+    clusterless_mode = config.project.get_config("fournos.job.clusterless")
+
     if cluster:
         config.project.set_config("cluster.name", cluster)
     else:
         cluster = config.project.get_config("cluster.name")
-        if not cluster:
-            raise ValueError("--cluster or cluster.name is mandatory")
-    logger.info(f"Using cluster {cluster}")
+
+        if not cluster and not clusterless_mode:
+            raise ValueError(
+                "--cluster or cluster.name is mandatory (unless clusterless mode is enabled)"
+            )
+
+    # Validate clusterless and exclusive modes are not both enabled
+    exclusive_mode = config.project.get_config("fournos.job.exclusive")
+    if clusterless_mode and exclusive_mode:
+        raise ValueError(
+            "Clusterless mode and exclusive mode cannot both be enabled - use /clusterless (sets exclusive=false) or /exclusive false"
+        )
+
+    if cluster:
+        logger.info(f"Using cluster {cluster}")
+    else:
+        logger.info("Using clusterless mode")
 
     if project:
         config.project.set_config("ci_job.project", project)

--- a/projects/fournos_launcher/orchestration/config.yaml
+++ b/projects/fournos_launcher/orchestration/config.yaml
@@ -25,6 +25,7 @@ fournos:
     pipeline_name: forge-test-only
     ci_label: null # will be generated from the CI job UID
     exclusive: true
+    clusterless: null
     env:
       OPENSHIFT_CI_job: [JOB_TYPE, JOB_NAME, JOB_SPEC, OPENSHIFT_CI, JOB_NAME_SAFE, BUILD_ID]
       OPENSHIFT_CI_git_pr: [PULL_PULL_SHA, PULL_NUMBER, PULL_BASE_REF, REPO_NAME, REPO_OWNER, PULL_BASE_SHA, JOB_NAME, PULL_TITLE, PULL_REFS, PULL_HEAD_REF]

--- a/projects/fournos_launcher/orchestration/pr_args.py
+++ b/projects/fournos_launcher/orchestration/pr_args.py
@@ -40,6 +40,11 @@ def get_supported_fournos_directives() -> dict[str, str]:
                         Format: /exclusive true|false
                         Example: /exclusive false
                         Effect: Sets fournos.job.exclusive in configuration (default: true).""",
+        "/clusterless": """Enable clusterless mode for FOURNOS job execution.
+                          Format: /clusterless
+                          Example: /clusterless
+                          Effect: Sets fournos.job.exclusive=false and fournos.job.clusterless=true.
+                          Note: Clusterless and exclusive modes are mutually exclusive.""",
         "/pipeline": """Set FOURNOS pipeline name for job execution.
                        Format: /pipeline pipeline_name
                        Example: /pipeline llm-load-test
@@ -113,6 +118,21 @@ def handle_exclusive_directive(line: str) -> dict[str, str]:
         )
 
     return {"fournos.job.exclusive": exclusive_value == "true"}
+
+
+def handle_clusterless_directive(line: str) -> dict[str, str]:
+    """
+    Handle /clusterless directive for enabling clusterless mode.
+
+    Format: /clusterless
+
+    Args:
+        line: The directive line
+
+    Returns:
+        Dictionary with clusterless configuration (sets exclusive=false, clusterless=true)
+    """
+    return {"fournos.job.exclusive": False, "fournos.job.clusterless": True}
 
 
 def handle_pipeline_directive(line: str) -> dict[str, str]:
@@ -291,6 +311,7 @@ def get_fournos_directive_handlers() -> dict[str, callable]:
     return {
         "/cluster": handle_cluster_directive,
         "/exclusive": handle_exclusive_directive,
+        "/clusterless": handle_clusterless_directive,
         "/pipeline": handle_pipeline_directive,
         "/gpu": handle_gpu_directive,
         "/parallel": handle_parallel_directive,
@@ -323,6 +344,14 @@ def parse_fournos_directives(
         system_name="FOURNOS",
         required_directives=None,  # No required directives for FOURNOS
     )
+
+    # Validate directive conflicts
+    if config_overrides.get("fournos.job.clusterless") and config_overrides.get(
+        "fournos.job.exclusive"
+    ):
+        raise ValueError(
+            "Conflicting directives: /clusterless and /exclusive true cannot both be used"
+        )
 
     # Log successful parses at info level for FOURNOS
     for directive in parsed_directives:

--- a/projects/fournos_launcher/orchestration/pr_args.py
+++ b/projects/fournos_launcher/orchestration/pr_args.py
@@ -45,6 +45,11 @@ def get_supported_fournos_directives() -> dict[str, str]:
                           Example: /clusterless
                           Effect: Sets fournos.job.exclusive=false and fournos.job.clusterless=true.
                           Note: Clusterless and exclusive modes are mutually exclusive.""",
+        "/fournos": """Set FOURNOS namespace environment.
+                      Format: /fournos environment
+                      Example: /fournos wip
+                               /fournos staging
+                      Effect: Sets fournos.namespace to psap-automation-{environment}.""",
         "/pipeline": """Set FOURNOS pipeline name for job execution.
                        Format: /pipeline pipeline_name
                        Example: /pipeline llm-load-test
@@ -133,6 +138,38 @@ def handle_clusterless_directive(line: str) -> dict[str, str]:
         Dictionary with clusterless configuration (sets exclusive=false, clusterless=true)
     """
     return {"fournos.job.exclusive": False, "fournos.job.clusterless": True}
+
+
+def handle_fournos_directive(line: str) -> dict[str, str]:
+    """
+    Handle /fournos directive for setting FOURNOS namespace environment.
+
+    Format: /fournos environment
+
+    Args:
+        line: The directive line
+
+    Returns:
+        Dictionary with namespace configuration
+
+    Raises:
+        ValueError: If environment is not wip or staging
+    """
+    FOURNOS_NAMESPACE_BASE = "psap-automation"
+    VALID_ENVIRONMENTS = {"wip", "staging"}
+
+    environment = line.removeprefix("/fournos ").strip()
+
+    if not environment:
+        raise ValueError(f"Invalid /fournos directive: environment cannot be empty in '{line}'")
+
+    if environment not in VALID_ENVIRONMENTS:
+        raise ValueError(
+            f"Invalid /fournos directive: environment must be one of {VALID_ENVIRONMENTS}, got '{environment}' in '{line}'"
+        )
+
+    namespace = f"{FOURNOS_NAMESPACE_BASE}-{environment}"
+    return {"fournos.namespace": namespace}
 
 
 def handle_pipeline_directive(line: str) -> dict[str, str]:
@@ -312,6 +349,7 @@ def get_fournos_directive_handlers() -> dict[str, callable]:
         "/cluster": handle_cluster_directive,
         "/exclusive": handle_exclusive_directive,
         "/clusterless": handle_clusterless_directive,
+        "/fournos": handle_fournos_directive,
         "/pipeline": handle_pipeline_directive,
         "/gpu": handle_gpu_directive,
         "/parallel": handle_parallel_directive,

--- a/projects/fournos_launcher/orchestration/submit.py
+++ b/projects/fournos_launcher/orchestration/submit.py
@@ -265,6 +265,13 @@ def submit_job():
                 "/cluster (cluster.name) must be set - cannot submit job without target cluster (unless /clusterless is used)"
             )
 
+        # Validate clusterless and exclusive modes are not both enabled
+        exclusive_mode = config.project.get_config("fournos.job.exclusive")
+        if clusterless_mode and exclusive_mode:
+            raise ValueError(
+                "Clusterless mode and exclusive mode cannot both be enabled - use /clusterless (sets exclusive=false) or /exclusive false"
+            )
+
         # Get GPU hardware configuration
         gpu_count = config.project.get_config("fournos.job.hardware.gpu_count")
         gpu_type = config.project.get_config("fournos.job.hardware.gpu_type")
@@ -296,6 +303,7 @@ def submit_job():
             "env": env_dict,
             "ci_label": config.project.get_config("fournos.job.ci_label"),
             "exclusive": config.project.get_config("fournos.job.exclusive"),
+            "clusterless": config.project.get_config("fournos.job.clusterless"),
             "gpu_count": gpu_count,
             "gpu_type": gpu_type,
         }

--- a/projects/fournos_launcher/orchestration/submit.py
+++ b/projects/fournos_launcher/orchestration/submit.py
@@ -258,9 +258,11 @@ def submit_job():
 
         # Validate required configuration before job submission
         cluster_name = config.project.get_config("cluster.name")
-        if not cluster_name:
+        clusterless_mode = config.project.get_config("fournos.job.clusterless")
+
+        if not cluster_name and not clusterless_mode:
             raise ValueError(
-                "/cluster (cluster.name) must be set - cannot submit job without target cluster"
+                "/cluster (cluster.name) must be set - cannot submit job without target cluster (unless /clusterless is used)"
             )
 
         # Get GPU hardware configuration

--- a/projects/fournos_launcher/toolbox/submit_and_wait/main.py
+++ b/projects/fournos_launcher/toolbox/submit_and_wait/main.py
@@ -47,9 +47,9 @@ class FournosJobFailureError(RuntimeError):
 
 @entrypoint
 def run(
-    cluster_name: str,
     project: str,
     *,
+    cluster_name: str | None = None,
     args: list = None,
     variables_overrides: dict = None,
     job_name: str = "",
@@ -63,13 +63,14 @@ def run(
     exclusive: bool = True,
     gpu_count: int = None,
     gpu_type: str = None,
+    clusterless: bool = False,
 ):
     """
     Submit a FOURNOS job and wait for completion
 
     Args:
-        cluster_name: Name of the target cluster for the FOURNOS job
         project: The project name to execute (e.g., 'llm_d', 'skeleton')
+        cluster_name: Name of the target cluster for the FOURNOS job (None when clusterless=True)
         args: List of arguments to pass to the project (default: empty list)
         variables_overrides: Dictionary of config variables to override (default: empty dict)
         job_name: Custom name for the FOURNOS job (auto-generated if empty)
@@ -83,12 +84,13 @@ def run(
         exclusive: Whether the job should run exclusively on its nodes (default: True)
         gpu_count: Number of GPUs required for the job (default: None)
         gpu_type: Type of GPU required for the job (default: None)
+        clusterless: Whether to enable clusterless mode (makes cluster_name optional, forces exclusive=False) (default: False)
 
     Examples:
         # Called by entrypoint with config values:
         run(
+            "llm_d",
             cluster_name="my-cluster",
-            project="llm_d",
             args=["test", "--verbose"],
             variables_overrides={"model": "mistral", "replicas": 2},
             namespace="my-fournos-jobs",
@@ -101,6 +103,10 @@ def run(
             gpu_type="nvidia-tesla-v100",
         )
     """
+    # Enforce clusterless=True always uses exclusive=False to prevent conflicts
+    if clusterless:
+        exclusive = False
+
     # Set defaults
     if args is None:
         args = []
@@ -123,8 +129,11 @@ def run(
 def validate_inputs(args, ctx):
     """Validate input parameters"""
 
-    if not args.cluster_name:
-        raise ValueError("cluster_name is required")
+    if not args.cluster_name and not args.clusterless:
+        raise ValueError("cluster_name is required unless clusterless mode is enabled")
+
+    if args.clusterless and args.exclusive:
+        raise ValueError("Clusterless mode and exclusive mode cannot both be enabled")
 
     if not args.project:
         raise ValueError("project is required")

--- a/projects/fournos_launcher/toolbox/submit_and_wait/templates/job.yaml.j2
+++ b/projects/fournos_launcher/toolbox/submit_and_wait/templates/job.yaml.j2
@@ -10,7 +10,11 @@ metadata:
 spec:
   owner: {{ args.owner }}
   displayName: {{ args.display_name }}
+  {% if args.clusterless -%}
+  clusterless: {{ args.clusterless }}
+  {%- else -%}
   cluster: {{ args.cluster_name }}
+  {%- endif %}
   exclusive: {{ args.exclusive }}
   pipeline: {{ args.pipeline_name }}
   {% if args.gpu_count and args.gpu_type -%}

--- a/projects/skeleton/orchestration/ci.py
+++ b/projects/skeleton/orchestration/ci.py
@@ -102,6 +102,17 @@ def preflight(ctx) -> int:
     return 0
 
 
+@main.command()
+@click.pass_context
+@ci_lib.safe_ci_entrypoint
+def launcher(ctx) -> int:
+    """Launcher job - Deploys fournos jobs."""
+
+    logger.warning("Nothing so far for the launcher job")
+
+    return 0
+
+
 main.add_command(caliper_export_entrypoint)
 main.add_command(caliper_replot_entrypoint)
 


### PR DESCRIPTION
goes along with https://github.com/openshift-psap/fournos/pull/99

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CI `launcher` command entry point and a `forge-launcher` Tekton pipeline to run launcher tasks and always export artifacts (also expanded workflow pipeline resources).
  * Added FOURNOS `/clusterless` and `/fournos` directives, including validation and environment-based namespace targeting.
* **Bug Fixes**
  * Improved forge step kubeconfig handling with an optional secret parameter, safer conditional kubeconfig export, and clusterless fallback when kubeconfig is missing.
  * Updated orchestration validation and submit/submit-and-wait to support clusterless mode without a cluster while rejecting clusterless+exclusive conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->