### PR TITLE
feat: Isolate benchmark workloads with per-deployment lifecycle

### DIFF
--- a/projects/core/dsl/utils/__init__.py
+++ b/projects/core/dsl/utils/__init__.py
@@ -39,5 +39,13 @@ def slugify_identifier(value: str, *, max_length: int = 63) -> str:
 
 
 def truncate_k8s_name(value: str, *, max_length: int = 63) -> str:
-    """Truncate a string to Kubernetes name length limits."""
-    return value[:max_length].rstrip("-")
+    """Truncate a string to Kubernetes name length limits.
+
+    When truncation occurs, a short hash suffix is appended to avoid
+    collisions between names that share a long common prefix.
+    """
+    if len(value) <= max_length:
+        return value
+    hash_suffix = hashlib.sha256(value.encode()).hexdigest()[:6]
+    prefix = value[: max_length - len(hash_suffix) - 1].rstrip("-")
+    return f"{prefix}-{hash_suffix}"

--- a/projects/llm_d/docs/benchmark-isolation.md
+++ b/projects/llm_d/docs/benchmark-isolation.md
@@ -84,7 +84,9 @@ previous 2D behavior with no overhead.
 
 Workloads can override deployment profile settings via `deployment_overrides`
 in `config.d/workloads.yaml`. This dict is deep-merged on top of the resolved
-deployment profile when building the LLMISVC manifest.
+deployment profile when building the LLMISVC manifest. Lists (like `vllm_args`)
+are **replaced entirely**, not concatenated — this avoids duplicate or
+conflicting flags when the override supplies a different set of arguments.
 
 ```yaml
 benchmarks:

--- a/projects/llm_d/docs/benchmark-isolation.md
+++ b/projects/llm_d/docs/benchmark-isolation.md
@@ -1,0 +1,109 @@
+# Benchmark Isolation: Per-Workload Deployment
+
+## Why each benchmark needs a fresh deployment
+
+The llm_d test harness deploys an LLMInferenceService (LLMISVC) for each
+benchmark workload rather than sharing a single deployment across workloads.
+Three factors drive this design:
+
+### 1. `--max-model-len` affects performance
+
+The vLLM serving engine's `--max-model-len` parameter controls the maximum
+sequence length and directly impacts memory allocation, scheduling behavior,
+and throughput. Different workloads have different token distributions:
+
+- `short` uses `prompt_tokens=256, output_tokens=128`
+- `heavy-heterogeneous` uses prompts up to 30,000 tokens
+
+Running `heavy-heterogeneous` against a server configured with
+`--max-model-len=4096` would truncate or reject requests, while running
+`short` against `--max-model-len=32768` wastes GPU memory on unused KV-cache
+blocks. Workloads can provide `deployment_overrides` to set the right
+`--max-model-len` for their token distribution.
+
+### 2. KV-cache pollution across workloads
+
+When multiple benchmarks share a deployment, residual KV-cache entries from
+the first workload can affect the performance measurements of subsequent
+workloads. The current mitigation relies on guidellm's prefixed prompts to
+generate unique cache keys per benchmark. This works for standard load
+generation but is not a guarantee of isolation.
+
+### 3. Future trace-replay workloads
+
+Trace-replay workloads (replaying production request traces) will require
+starting the vLLM server with `VLLM_DEV_MODE=1` so that the KV-cache can
+be explicitly cleared between runs. This is a deployment-time environment
+variable, not a runtime toggle, reinforcing the need for per-workload
+deployment isolation.
+
+## Architecture: 3D RunSpec matrix
+
+The test matrix is a Cartesian product of three dimensions:
+
+```
+model_name x deployment_profile x benchmark_key
+```
+
+Each combination (a `RunSpec`) gets:
+1. Its own Kubernetes namespace
+2. A fresh LLMISVC deployment with the profile's vLLM args
+3. A smoke test to verify the deployment is healthy
+4. A single benchmark run
+5. Full teardown (LLMISVC, benchmark job, PVC, namespace resources)
+
+### Example
+
+```
+/var runtime.model_name: Qwen/Qwen3-0.6B
+/var runtime.deployment_profile: [approximate-prefix-cache, distributed-default]
+/var runtime.benchmark_key: [short, multi-turn]
+```
+
+Produces 1 x 2 x 2 = 4 isolated test runs, each with its own namespace:
+
+| RunSpec | Model | Profile | Benchmark |
+|---------|-------|---------|-----------|
+| 1 | Qwen3-0.6B | approximate-prefix-cache | short |
+| 2 | Qwen3-0.6B | approximate-prefix-cache | multi-turn |
+| 3 | Qwen3-0.6B | distributed-default | short |
+| 4 | Qwen3-0.6B | distributed-default | multi-turn |
+
+## Backward compatibility
+
+| Scenario | `benchmark_key` value | Matrix | Behavior |
+|----------|-----------------------|--------|----------|
+| Smoke-only | `null` | M x P | No benchmark, just smoke test |
+| Single benchmark | `"short"` | M x P x 1 | One benchmark per deploy (same as before) |
+| Multiple benchmarks | `["a", "b"]` | M x P x 2 | Each gets its own deployment |
+
+When `benchmark_key` is null or a single scalar, the matrix degrades to the
+previous 2D behavior with no overhead.
+
+## Per-workload deployment overrides
+
+Workloads can override deployment profile settings via `deployment_overrides`
+in `config.d/workloads.yaml`. This dict is deep-merged on top of the resolved
+deployment profile when building the LLMISVC manifest.
+
+```yaml
+benchmarks:
+  heavy-heterogeneous:
+    args:
+      backend_type: openai_http
+      rate_type: concurrent
+      rate: [300, 200, 100, 50, 1]
+      data: prompt_tokens=8000,...
+    deployment_overrides:
+      vllm_args:
+        - --max-model-len=32768
+
+  trace-replay:
+    args:
+      backend_type: openai_http
+      ...
+    deployment_overrides:
+      env:
+        - name: VLLM_DEV_MODE
+          value: "1"
+```

--- a/projects/llm_d/orchestration/ci.py
+++ b/projects/llm_d/orchestration/ci.py
@@ -107,10 +107,17 @@ def preflight(ctx) -> int:
 @agent_review_on_failure
 def test(ctx) -> int:
     """Test phase - Execute the main testing logic."""
+    from projects.llm_d.orchestration import runtime_config
+
     # Trigger config review analysis asynchronously (don't block test execution)
     trigger_config_review_for_ci(env.BASE_ARTIFACT_DIR, async_mode=True)
 
-    return test_toolbox_run()
+    exit_code = 0
+    for run_spec in runtime_config.get_run_specs():
+        with runtime_config.activate_run_spec(run_spec):
+            with env.NextArtifactDir(run_spec.artifact_dirname):
+                exit_code = max(exit_code, test_toolbox_run())
+    return exit_code
 
 
 @main.command()

--- a/projects/llm_d/orchestration/cleanup_phase.py
+++ b/projects/llm_d/orchestration/cleanup_phase.py
@@ -30,11 +30,7 @@ def cleanup_namespace(*, namespace: str | None = None) -> None:
         namespace = runtime_config.get_namespace()
     platform = runtime_config.get_platform_config()
     inference_service_name = platform["inference_service"]["name"]
-    benchmark_job_names = runtime_config.get_benchmark_job_names()
-    # Multiple benchmarks may share a job_name (defaults to "guidellm-benchmark");
-    # the broad labeled sweep below deletes every forge-labeled job/pod/pvc
-    # regardless, so a single representative name is enough for the named pass.
-    benchmark_name = benchmark_job_names[0] if benchmark_job_names else None
+    benchmark_name = runtime_config.get_benchmark_job_name()
 
     if not oc_resource_exists("namespace", namespace):
         return

--- a/projects/llm_d/orchestration/runtime_config.py
+++ b/projects/llm_d/orchestration/runtime_config.py
@@ -28,6 +28,8 @@ class RunSpec:
     model_slug: str
     deployment_profile_name: str
     deployment_profile_slug: str
+    benchmark_key: str | None
+    benchmark_slug: str | None
     namespace: str
     artifact_dirname: str
     namespace_is_managed: bool
@@ -99,14 +101,14 @@ def _normalize_string_or_list(value: Any, field_name: str) -> list[str]:
     return [value] if value else []
 
 
-def _deep_merge(base: Any, override: Any) -> Any:
+def deep_merge(base: Any, override: Any) -> Any:
     if not isinstance(base, dict) or not isinstance(override, dict):
         return copy.deepcopy(override)
 
     merged = copy.deepcopy(base)
     for key, value in override.items():
         if key in merged and isinstance(merged[key], dict) and isinstance(value, dict):
-            merged[key] = _deep_merge(merged[key], value)
+            merged[key] = deep_merge(merged[key], value)
         else:
             merged[key] = copy.deepcopy(value)
     return merged
@@ -235,7 +237,7 @@ def _resolve_benchmark_config(benchmark_name: str) -> dict[str, Any]:
     benchmark_args = benchmark.get("args", {})
     workload_args = workload_defaults.get("args", {})
     if workload_args:
-        benchmark["args"] = _deep_merge(workload_args, benchmark_args)
+        benchmark["args"] = deep_merge(workload_args, benchmark_args)
 
     return benchmark
 
@@ -253,22 +255,20 @@ def get_benchmark_config() -> dict[str, Any] | None:
     return _resolve_benchmark_config(benchmark_keys[0])
 
 
-def get_benchmark_configs() -> list[tuple[str, dict[str, Any]]]:
-    return [
-        (benchmark_key, _resolve_benchmark_config(benchmark_key))
-        for benchmark_key in get_benchmark_keys()
-    ]
+def get_benchmark_deployment_overrides() -> dict[str, Any]:
+    """Return deployment overrides from the active benchmark config, if any."""
+    benchmark = get_benchmark_config()
+    if benchmark is None:
+        return {}
+    return benchmark.get("deployment_overrides", {})
 
 
-def get_benchmark_job_names() -> list[str]:
-    """Distinct k8s benchmark job names for the active run, in order.
-
-    A single benchmark_key collapses to one name; multiple benchmarks that
-    share a default job_name dedupe to one entry. Empty when benchmarking
-    is disabled, so cleanup paths can treat it uniformly.
-    """
-    all_names = [benchmark.get("job_name") for _, benchmark in get_benchmark_configs()]
-    return list(dict.fromkeys(name for name in all_names if name))
+def get_benchmark_job_name() -> str | None:
+    """The k8s benchmark job name for the active run, or None when benchmarking is disabled."""
+    benchmark = get_benchmark_config()
+    if benchmark is None:
+        return None
+    return benchmark.get("job_name")
 
 
 def get_deployment_profile_name() -> str:
@@ -291,10 +291,10 @@ def get_deployment_profile() -> dict[str, Any]:
     defaults = copy.deepcopy(deployment_config.get("defaults", {}))
 
     scheduler_manifest = profile.pop("scheduler_manifest", None)
-    resolved_profile = _deep_merge(defaults, profile)
+    resolved_profile = deep_merge(defaults, profile)
     if scheduler_manifest:
         scheduler_data = _load_yaml(get_config_dir() / scheduler_manifest)
-        resolved_profile = _deep_merge(resolved_profile, scheduler_data)
+        resolved_profile = deep_merge(resolved_profile, scheduler_data)
 
     return resolved_profile
 
@@ -312,6 +312,10 @@ def get_run_specs() -> list[RunSpec]:
         _get_runtime_value("deployment_profile"),
         "runtime.deployment_profile",
     )
+    benchmark_keys = _normalize_string_or_list(
+        _get_runtime_value("benchmark_key"),
+        "runtime.benchmark_key",
+    )
 
     if not model_names:
         raise ValueError("runtime.model_name must be set to a model name or list of model names")
@@ -320,25 +324,37 @@ def get_run_specs() -> list[RunSpec]:
             "runtime.deployment_profile must be set to a deployment profile or list of profiles"
         )
 
-    combinations = list(product(model_names, profile_names))
+    if benchmark_keys:
+        benchmark_entries = [
+            (key, slugify_identifier(key, max_length=24)) for key in benchmark_keys
+        ]
+    else:
+        benchmark_entries = [(None, None)]
+
+    combinations = list(product(model_names, profile_names, benchmark_entries))
     base_namespace = _derive_base_namespace()
     namespace_max_length = get_platform_config()["cluster"]["namespace"]["max_length"]
     # Compute base managed state once (ignores per-spec overrides)
     namespace_is_managed = get_namespace_is_managed()
     run_specs: list[RunSpec] = []
 
-    for model_name, profile_name in combinations:
+    for model_name, profile_name, (bench_key, bench_slug) in combinations:
         model_slug = get_model_slug(model_name)
         profile_slug = slugify_identifier(profile_name, max_length=24)
         if len(combinations) == 1:
             namespace = base_namespace
             artifact_dirname = "llmd_run"
         else:
+            ns_parts = [base_namespace, model_slug, profile_slug]
+            dir_parts = ["llmd_run", profile_slug, model_slug]
+            if bench_slug is not None:
+                ns_parts.append(bench_slug)
+                dir_parts.append(bench_slug)
             namespace = truncate_k8s_name(
-                f"{base_namespace}-{model_slug}-{profile_slug}",
+                "-".join(ns_parts),
                 max_length=namespace_max_length,
             )
-            artifact_dirname = f"llmd_run_{profile_slug}_{model_slug}"
+            artifact_dirname = "_".join(dir_parts)
 
         run_specs.append(
             RunSpec(
@@ -346,6 +362,8 @@ def get_run_specs() -> list[RunSpec]:
                 model_slug=model_slug,
                 deployment_profile_name=profile_name,
                 deployment_profile_slug=profile_slug,
+                benchmark_key=bench_key,
+                benchmark_slug=bench_slug,
                 namespace=namespace,
                 artifact_dirname=artifact_dirname,
                 namespace_is_managed=namespace_is_managed,
@@ -364,12 +382,14 @@ def activate_run_spec(run_spec: RunSpec):
         "model_name": _get_runtime_value("model_name"),
         "deployment_profile": _get_runtime_value("deployment_profile"),
         "namespace_override": _get_runtime_value("namespace_override"),
+        "benchmark_key": _get_runtime_value("benchmark_key"),
     }
     prev_managed_override = _namespace_is_managed_override
 
     config.project.set_config("runtime.model_name", run_spec.model_name)
     config.project.set_config("runtime.deployment_profile", run_spec.deployment_profile_name)
     config.project.set_config("runtime.namespace_override", run_spec.namespace)
+    config.project.set_config("runtime.benchmark_key", run_spec.benchmark_key)
     _namespace_is_managed_override = run_spec.namespace_is_managed
     try:
         yield
@@ -377,6 +397,7 @@ def activate_run_spec(run_spec: RunSpec):
         config.project.set_config("runtime.model_name", saved["model_name"])
         config.project.set_config("runtime.deployment_profile", saved["deployment_profile"])
         config.project.set_config("runtime.namespace_override", saved["namespace_override"])
+        config.project.set_config("runtime.benchmark_key", saved["benchmark_key"])
         _namespace_is_managed_override = prev_managed_override
 
 

--- a/projects/llm_d/orchestration/test_phase.py
+++ b/projects/llm_d/orchestration/test_phase.py
@@ -40,11 +40,8 @@ def create_test_labels() -> None:
         "deployment_profile": deployment_profile,
     }
 
-    # Add guidellm configuration information
     if benchmark_keys:
-        labels["guidellm_loadshape"] = (
-            benchmark_keys[0] if len(benchmark_keys) == 1 else benchmark_keys
-        )
+        labels["guidellm_loadshape"] = benchmark_keys[0]
 
     write_test_labels(env.ARTIFACT_DIR, labels)
     logger.info("Created test labels: %s", labels)
@@ -222,6 +219,10 @@ def _build_inference_service_manifest() -> Path:
     deployment_profile = runtime_config.get_deployment_profile()
     model_cache = runtime_config.get_model_cache_config()
 
+    benchmark_overrides = runtime_config.get_benchmark_deployment_overrides()
+    if benchmark_overrides:
+        deployment_profile = runtime_config.deep_merge(deployment_profile, benchmark_overrides)
+
     # Build the InferenceService manifest
     manifest = render_inference_service_from_parts(
         config_dir=config_dir,
@@ -267,30 +268,29 @@ def run_smoke_request(*, endpoint_url: str) -> dict[str, object]:
 
 
 def run_guidellm_benchmark(*, endpoint_url: str) -> None:
-    # Load config where it's consumed
     from projects.llm_d.orchestration import runtime_config
 
     namespace = runtime_config.get_namespace()
-    benchmark_configs = runtime_config.get_benchmark_configs()
+    benchmark = runtime_config.get_benchmark_config()
 
-    if not benchmark_configs:
-        return  # Skip if benchmark is disabled
+    if benchmark is None:
+        return
 
-    for benchmark_key, benchmark in benchmark_configs:
-        guidellm_args = build_guidellm_args(benchmark)
-        if not any(arg.startswith("--processor=") for arg in guidellm_args):
-            guidellm_args.append(f"--processor={runtime_config.get_model_name()}")
-        artifact_name = f"benchmark_{slugify_identifier(benchmark_key, max_length=48)}"
-        with env.NextArtifactDir(artifact_name):
-            run_guidellm_benchmark_command.run(
-                endpoint_url=endpoint_url,
-                name=benchmark.get("job_name"),
-                namespace=namespace,
-                image=benchmark.get("image"),
-                timeout=benchmark.get("timeout_seconds"),
-                pvc_size=benchmark.get("pvc_size"),
-                guidellm_args=guidellm_args,
-            )
+    benchmark_key = runtime_config.get_benchmark_keys()[0]
+    guidellm_args = build_guidellm_args(benchmark)
+    if not any(arg.startswith("--processor=") for arg in guidellm_args):
+        guidellm_args.append(f"--processor={runtime_config.get_model_name()}")
+    artifact_name = f"benchmark_{slugify_identifier(benchmark_key, max_length=48)}"
+    with env.NextArtifactDir(artifact_name):
+        run_guidellm_benchmark_command.run(
+            endpoint_url=endpoint_url,
+            name=benchmark.get("job_name"),
+            namespace=namespace,
+            image=benchmark.get("image"),
+            timeout=benchmark.get("timeout_seconds"),
+            pvc_size=benchmark.get("pvc_size"),
+            guidellm_args=guidellm_args,
+        )
 
 
 def capture_inference_service_state() -> None:
@@ -318,7 +318,6 @@ def write_endpoint_url(*, artifact_dir: Path, endpoint_url: str | None) -> None:
 
 def cleanup_test_resources() -> None:
     """Cleanup test resources using the toolbox script"""
-    # Load config where it's consumed
     from projects.llm_d.orchestration import runtime_config
 
     namespace = runtime_config.get_namespace()
@@ -326,18 +325,12 @@ def cleanup_test_resources() -> None:
     inference_service = platform["inference_service"]
     smoke = platform["smoke"]
 
-    # Narrow cleanup (no broad sweep): cover every benchmark job name. Benchmarks
-    # typically share a single job_name, so this dedupes to one call; when
-    # benchmarking is disabled, run once with None so the IS/smoke cleanup still
-    # runs. oc delete is idempotent across iterations.
-    benchmark_job_names = runtime_config.get_benchmark_job_names() or [None]
-    for benchmark_job_name in benchmark_job_names:
-        cleanup_test_resources_command.run(
-            namespace=namespace,
-            inference_service_name=inference_service["name"],
-            smoke_pod_name=smoke["pod_name"],
-            benchmark_job_name=benchmark_job_name,
-        )
+    cleanup_test_resources_command.run(
+        namespace=namespace,
+        inference_service_name=inference_service["name"],
+        smoke_pod_name=smoke["pod_name"],
+        benchmark_job_name=runtime_config.get_benchmark_job_name(),
+    )
 
 
 def capture_namespace_events_after_test(

--- a/projects/llm_d/tests/test_profiles.py
+++ b/projects/llm_d/tests/test_profiles.py
@@ -165,10 +165,31 @@ def test_release_preset_expands_benchmark_list_and_merges_workload_args() -> Non
         "multi-turn",
     ]
 
-    benchmark_configs = dict(runtime_config.get_benchmark_configs())
-    assert benchmark_configs["concurrent-1k-1k"]["args"]["request_type"] == "text_completions"
-    assert benchmark_configs["heavy-heterogeneous"]["args"]["request_type"] == "text_completions"
-    assert benchmark_configs["multi-turn"]["args"]["request_type"] == "text_completions"
+    run_specs = runtime_config.get_run_specs()
+    for run_spec in run_specs:
+        with runtime_config.activate_run_spec(run_spec):
+            benchmark = runtime_config.get_benchmark_config()
+            assert benchmark["args"]["request_type"] == "text_completions"
+
+
+def test_release_preset_produces_3_run_specs() -> None:
+    _init_project_config()
+
+    core_config.project.apply_preset("gpt-oss-120b-inference-scheduling-release")
+
+    run_specs = runtime_config.get_run_specs()
+
+    assert len(run_specs) == 3
+    assert [spec.benchmark_key for spec in run_specs] == [
+        "concurrent-1k-1k",
+        "heavy-heterogeneous",
+        "multi-turn",
+    ]
+    assert all(spec.model_name == "openai/gpt-oss-120b" for spec in run_specs)
+    assert all(spec.deployment_profile_name == "distributed-default" for spec in run_specs)
+
+    namespaces = [spec.namespace for spec in run_specs]
+    assert len(namespaces) == len(set(namespaces))
 
 
 def test_ci_init_uses_framework_project_args_preset_and_keeps_var_overrides() -> None:
@@ -544,6 +565,116 @@ def test_model_and_deployment_profile_accept_yaml_list_strings() -> None:
     ]
     assert run_specs[0].model_slug == "openai-gpt-oss-120b"
     assert run_specs[2].model_slug == "qwen-qwen3-0-6b"
+    # With a single benchmark_key (or null), benchmark fields reflect the scalar
+    assert all(spec.benchmark_key is not None or spec.benchmark_slug is None for spec in run_specs)
+
+
+def test_3d_matrix_with_multiple_benchmark_keys() -> None:
+    _init_project_config()
+
+    core_config.project.set_config(
+        "runtime.model_name",
+        "[openai/gpt-oss-120b, Qwen/Qwen3-0.6B]",
+    )
+    core_config.project.set_config(
+        "runtime.deployment_profile",
+        "[distributed-default, precise-prefix-cache]",
+    )
+    core_config.project.set_config(
+        "runtime.benchmark_key",
+        "[concurrent-1k-1k, multi-turn]",
+    )
+
+    run_specs = runtime_config.get_run_specs()
+
+    # 2 models x 2 profiles x 2 benchmarks = 8 specs
+    assert len(run_specs) == 8
+    assert all(spec.benchmark_key is not None for spec in run_specs)
+    assert all(spec.benchmark_slug is not None for spec in run_specs)
+
+    assert run_specs[0].model_name == "openai/gpt-oss-120b"
+    assert run_specs[0].deployment_profile_name == "distributed-default"
+    assert run_specs[0].benchmark_key == "concurrent-1k-1k"
+
+    # Verify all namespaces are unique
+    namespaces = [spec.namespace for spec in run_specs]
+    assert len(namespaces) == len(set(namespaces))
+
+    # Verify all artifact dirnames are unique
+    dirnames = [spec.artifact_dirname for spec in run_specs]
+    assert len(dirnames) == len(set(dirnames))
+
+
+def test_null_benchmark_key_produces_smoke_only_specs() -> None:
+    _init_project_config()
+
+    core_config.project.set_config("runtime.benchmark_key", None)
+
+    run_specs = runtime_config.get_run_specs()
+
+    assert len(run_specs) == 1
+    assert run_specs[0].benchmark_key is None
+    assert run_specs[0].benchmark_slug is None
+
+
+def test_single_benchmark_key_backward_compatible() -> None:
+    _init_project_config()
+
+    core_config.project.apply_preset("smoke")
+
+    run_specs = runtime_config.get_run_specs()
+
+    assert len(run_specs) == 1
+    assert run_specs[0].benchmark_key == "short"
+    assert run_specs[0].benchmark_slug == "short"
+    assert run_specs[0].artifact_dirname == "llmd_run"
+
+
+def test_activate_run_spec_sets_benchmark_key() -> None:
+    _init_project_config()
+
+    core_config.project.set_config(
+        "runtime.benchmark_key",
+        "[concurrent-1k-1k, multi-turn]",
+    )
+
+    run_specs = runtime_config.get_run_specs()
+
+    for run_spec in run_specs:
+        with runtime_config.activate_run_spec(run_spec):
+            keys = runtime_config.get_benchmark_keys()
+            assert keys == [run_spec.benchmark_key]
+            assert runtime_config.get_benchmark_config() is not None
+
+
+def test_benchmark_deployment_overrides() -> None:
+    _init_project_config()
+
+    core_config.project.set_config("runtime.benchmark_key", "concurrent-1k-1k")
+    core_config.project.config["workloads"]["benchmarks"]["concurrent-1k-1k"][
+        "deployment_overrides"
+    ] = {"vllm_args": ["--max-model-len=8192"]}
+
+    overrides = runtime_config.get_benchmark_deployment_overrides()
+    assert overrides == {"vllm_args": ["--max-model-len=8192"]}
+
+
+def test_benchmark_deployment_overrides_empty_when_not_set() -> None:
+    _init_project_config()
+
+    core_config.project.set_config("runtime.benchmark_key", "concurrent-1k-1k")
+
+    overrides = runtime_config.get_benchmark_deployment_overrides()
+    assert overrides == {}
+
+
+def test_benchmark_deployment_overrides_empty_when_no_benchmark() -> None:
+    _init_project_config()
+
+    core_config.project.set_config("runtime.benchmark_key", None)
+
+    overrides = runtime_config.get_benchmark_deployment_overrides()
+    assert overrides == {}
 
 
 def test_runtime_rejects_legacy_model_key_path() -> None:
@@ -665,12 +796,14 @@ def test_render_removes_scheduler_when_deployment_requests_null_scheduler() -> N
     assert "scheduler" not in manifest["spec"]["router"]
 
 
-def test_benchmark_job_names_collapse_shared_default() -> None:
+def test_benchmark_job_name_from_activated_spec() -> None:
     _init_project_config()
 
     core_config.project.apply_preset("gpt-oss-120b-inference-scheduling-release")
-    # Three benchmark_keys, all sharing the workload default job_name -> one entry.
-    assert runtime_config.get_benchmark_job_names() == ["guidellm-benchmark"]
+
+    for run_spec in runtime_config.get_run_specs():
+        with runtime_config.activate_run_spec(run_spec):
+            assert runtime_config.get_benchmark_job_name() == "guidellm-benchmark"
 
 
 def test_smoke_preset_benchmark_behavior() -> None:
@@ -679,7 +812,10 @@ def test_smoke_preset_benchmark_behavior() -> None:
     core_config.project.apply_preset("smoke")
     # The smoke preset enables the short benchmark
     assert runtime_config.get_benchmark_keys() == ["short"]
-    assert runtime_config.get_benchmark_job_names() == ["guidellm-benchmark"]
+
+    run_spec = runtime_config.get_run_specs()[0]
+    with runtime_config.activate_run_spec(run_spec):
+        assert runtime_config.get_benchmark_job_name() == "guidellm-benchmark"
 
 
 def test_run_spec_preserves_namespace_managed_flag() -> None:

--- a/projects/llm_d/toolbox/cleanup_test_resources/main.py
+++ b/projects/llm_d/toolbox/cleanup_test_resources/main.py
@@ -218,9 +218,15 @@ def wait_for_workload_pods_deletion(args, ctx):
 
 
 def _best_effort_delete(description: str, *oc_args: str) -> None:
-    """Best effort deletion of Kubernetes resources with timeout"""
+    """Best effort deletion of Kubernetes resources with timeout."""
     try:
-        oc(*oc_args, "--timeout=120s", check=False)
+        result = oc(*oc_args, "--timeout=300s", check=False)
+        if result.returncode != 0:
+            logger.warning(
+                "Failed to delete %s (rc=%d), capturing describe", description, result.returncode
+            )
+            describe_args = tuple(a for a in oc_args if a != "delete")
+            oc("describe", *describe_args, check=False)
     except subprocess.TimeoutExpired:
         logger.warning("Timed out deleting %s: oc %s", description, " ".join(oc_args))
 

--- a/projects/llm_d/toolbox/cleanup_test_resources/main.py
+++ b/projects/llm_d/toolbox/cleanup_test_resources/main.py
@@ -220,7 +220,7 @@ def wait_for_workload_pods_deletion(args, ctx):
 def _best_effort_delete(description: str, *oc_args: str) -> None:
     """Best effort deletion of Kubernetes resources with timeout"""
     try:
-        oc(*oc_args, check=False)
+        oc(*oc_args, "--timeout=120s", check=False)
     except subprocess.TimeoutExpired:
         logger.warning("Timed out deleting %s: oc %s", description, " ".join(oc_args))
 

--- a/projects/llm_d/toolbox/cleanup_test_resources/main.py
+++ b/projects/llm_d/toolbox/cleanup_test_resources/main.py
@@ -6,7 +6,7 @@ import logging
 import subprocess
 
 from projects.core.dsl import entrypoint, execute_tasks, retry, shell, task
-from projects.core.dsl.utils.k8s import oc, oc_get_json, oc_resource_exists
+from projects.core.dsl.utils.k8s import oc, oc_get_json
 
 logger = logging.getLogger("DSL")
 
@@ -164,33 +164,36 @@ def delete_llm_d_labeled_resources(args, ctx):
 def delete_inference_service(args, ctx):
     """Delete the LLM inference service"""
 
-    _best_effort_delete(
-        "llminferenceservice",
+    result = oc(
         "delete",
         "llminferenceservice",
         args.inference_service_name,
         "-n",
         args.namespace,
         "--ignore-not-found=true",
+        "--timeout=30s",
+        check=False,
     )
+    if result.returncode != 0:
+        logger.error(
+            "Failed to delete llminferenceservice/%s (rc=%d), capturing describe",
+            args.inference_service_name,
+            result.returncode,
+        )
+        oc(
+            "describe",
+            "llminferenceservice",
+            args.inference_service_name,
+            "-n",
+            args.namespace,
+            check=False,
+        )
+        raise RuntimeError(
+            f"Failed to delete llminferenceservice/{args.inference_service_name} "
+            f"in {args.namespace} (rc={result.returncode})"
+        )
 
     return f"Deleted llminferenceservice {args.inference_service_name}"
-
-
-@retry(attempts=90, delay=10, backoff=1.0)
-@task
-def wait_for_inference_service_deletion(args, ctx):
-    """Wait for the llminferenceservice to be deleted"""
-
-    if not oc_resource_exists(
-        "llminferenceservice", args.inference_service_name, namespace=args.namespace
-    ):
-        return f"llminferenceservice/{args.inference_service_name} deleted from {args.namespace}"
-
-    return (
-        False,
-        f"Waiting for llminferenceservice/{args.inference_service_name} deletion in {args.namespace}",
-    )
 
 
 @retry(attempts=90, delay=10, backoff=1.0)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added benchmark isolation per workload using fresh inference service deployments, dedicated namespaces/artifacts, smoke tests, runs, and teardown.
  - Extended run planning to support model × deployment profile × benchmark combinations with workload-specific deployment overrides and required runtime environment settings.
  - Kept backward compatibility for benchmark-disabled, single, and multi-benchmark modes.
- **Bug Fixes**
  - Updated CI/test orchestration to execute once per configured run spec and aggregate results.
  - Refined cleanup and benchmark job handling to align with the active run spec.
  - Improved Kubernetes resource deletion with explicit timeouts and better failure diagnostics.
- **Documentation**
  - Added a new benchmark isolation guide covering architecture and the 3D run matrix.
- **Tests**
  - Expanded validation for run-spec generation/activation, override merging, naming uniqueness, and benchmark job-name behavior.
- **Chores**
  - Made Kubernetes name truncation collision-resistant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->