### PR TITLE
[llm-d] Add dry-run capability

### DIFF
--- a/projects/guidellm/toolbox/run_smoke_request/main.py
+++ b/projects/guidellm/toolbox/run_smoke_request/main.py
@@ -238,7 +238,7 @@ def capture_smoke_pod_debug_info(args, ctx):
 
     try:
         # Capture pod YAML
-        yaml_result = oc(
+        oc(
             "get",
             "pod",
             ctx.pod_name,
@@ -248,20 +248,17 @@ def capture_smoke_pod_debug_info(args, ctx):
             "yaml",
             check=False,
         )
-        if yaml_result.returncode == 0 and yaml_result.stdout:
-            write_text(artifacts_dir / f"{ctx.pod_name}.yaml", yaml_result.stdout)
 
         # Capture pod description
-        desc_result = oc(
+        oc(
             "describe",
             "pod",
             ctx.pod_name,
             "-n",
             args.namespace,
             check=False,
+            stdout_dest=artifacts_dir / f"{ctx.pod_name}.description.txt",
         )
-        if desc_result.returncode == 0 and desc_result.stdout:
-            write_text(artifacts_dir / f"{ctx.pod_name}.description.txt", desc_result.stdout)
 
         return f"Captured debug info for pod {ctx.pod_name}"
 

--- a/projects/kserve/toolbox/deploy_llmisvc/main.py
+++ b/projects/kserve/toolbox/deploy_llmisvc/main.py
@@ -6,7 +6,15 @@ from pathlib import Path
 
 import yaml
 
-from projects.core.dsl import always, entrypoint, execute_tasks, on_failure, retry, task
+from projects.core.dsl import (
+    EarlyReturn,
+    always,
+    entrypoint,
+    execute_tasks,
+    on_failure,
+    retry,
+    task,
+)
 from projects.core.dsl.utils import write_text
 from projects.core.dsl.utils.k8s import (
     oc,
@@ -28,6 +36,7 @@ def run(
     namespace: str,
     inference_service_manifest_path: str,
     gateway_status_address_name: str = "gateway-external",
+    dry_run: bool = False,
 ) -> str:
     """
     Deploy an LLMInferenceService and wait for its endpoint.
@@ -36,6 +45,7 @@ def run(
         namespace: Namespace used by llm_d
         inference_service_manifest_path: Path to the InferenceService YAML manifest file
         gateway_status_address_name: Gateway status address name for endpoint resolution
+        dry_run: If True, only prepare the manifest without deploying
     """
 
     # Load manifest to extract the service name
@@ -48,8 +58,12 @@ def run(
         "inference_service_manifest_path": inference_service_manifest_path,
         "inference_service_name": inference_service_name,
         "gateway_status_address_name": gateway_status_address_name,
+        "dry_run": dry_run,
     }
     context = execute_tasks(task_args)
+
+    if dry_run:
+        return "<dry_run>"
 
     # Ensure endpoint_url is available
     endpoint_url = getattr(context, "endpoint_url", None)
@@ -84,6 +98,16 @@ def copy_manifest_to_src(args, ctx):
     ctx.src_manifest_path = str(src_path)
 
     return f"Copied manifest from {original_path} to {src_path}"
+
+
+@task
+def check_dry_run(args, ctx):
+    """Check if dry-run mode is enabled and return early if so"""
+    if args.dry_run:
+        return EarlyReturn(
+            f"Dry-run completed: Prepared manifest for {args.inference_service_name}"
+        )
+    return "Proceeding with full deployment"
 
 
 @task
@@ -154,6 +178,9 @@ def wait_pods_appear(args, ctx):
 def capture_llmisv_description(args, ctx):
     """Capture LLMISV description with events and status for failure analysis"""
 
+    if args.dry_run:
+        return "Dry-run, nothing to do"
+
     try:
         # Ensure artifacts directory exists
         artifacts_dir = args.artifact_dir / "artifacts"
@@ -187,6 +214,9 @@ def capture_llmisv_description(args, ctx):
 @task
 def capture_replicaset_description(args, ctx):
     """Capture ReplicaSet description for pod creation failure analysis"""
+
+    if args.dry_run:
+        return "Dry-run, nothing to do"
 
     try:
         # Ensure artifacts directory exists

--- a/projects/kserve/toolbox/deploy_llmisvc/main.py
+++ b/projects/kserve/toolbox/deploy_llmisvc/main.py
@@ -48,43 +48,31 @@ def run(
         dry_run: If True, only prepare the manifest without deploying
     """
 
-    # Load manifest to extract the service name
-    manifest = load_yaml(Path(inference_service_manifest_path))
-    inference_service_name = manifest["metadata"]["name"]
-
-    # Pass only the required arguments to avoid including manifest content in logs
-    task_args = {
-        "namespace": namespace,
-        "inference_service_manifest_path": inference_service_manifest_path,
-        "inference_service_name": inference_service_name,
-        "gateway_status_address_name": gateway_status_address_name,
-        "dry_run": dry_run,
-    }
-    context = execute_tasks(task_args)
+    ctx = execute_tasks(locals())
 
     if dry_run:
-        return "<dry_run>"
+        return ctx.src_manifest_path
 
     # Ensure endpoint_url is available
-    endpoint_url = getattr(context, "endpoint_url", None)
+    endpoint_url = getattr(ctx, "endpoint_url", None)
     if not endpoint_url:
         raise RuntimeError("Failed to resolve gateway endpoint URL after deployment")
-
-    # Log service description for visibility
-    service_description = getattr(context, "service_description", None)
-    if service_description:
-        print(f"Deployed: {service_description}")
 
     return endpoint_url
 
 
 @task
 def copy_manifest_to_src(args, ctx):
-    """Copy inference service manifest to src directory for inspection and use"""
+    """Copy inference service manifest to src directory and extract service name"""
     import shutil
 
     # Get the original manifest path
     original_path = Path(args.inference_service_manifest_path)
+
+    # Load manifest to extract the service name
+    manifest = load_yaml(original_path)
+    ctx.inference_service_name = manifest["metadata"]["name"]
+    ctx.selector = f"app.kubernetes.io/name={ctx.inference_service_name}"
 
     # Ensure the src directory exists
     src_dir = args.artifact_dir / "src"
@@ -97,16 +85,14 @@ def copy_manifest_to_src(args, ctx):
     # Store the src path in context for other tasks to use
     ctx.src_manifest_path = str(src_path)
 
-    return f"Copied manifest from {original_path} to {src_path}"
+    return f"Copied manifest from {original_path} to {src_path} (service: {ctx.inference_service_name})"
 
 
 @task
 def check_dry_run(args, ctx):
     """Check if dry-run mode is enabled and return early if so"""
     if args.dry_run:
-        return EarlyReturn(
-            f"Dry-run completed: Prepared manifest for {args.inference_service_name}"
-        )
+        return EarlyReturn(f"Dry-run completed: Prepared manifest for {ctx.inference_service_name}")
     return "Proceeding with full deployment"
 
 
@@ -114,7 +100,7 @@ def check_dry_run(args, ctx):
 def delete_existing_service(args, ctx):
     """Delete existing LLMInferenceService"""
 
-    name = args.inference_service_name
+    name = ctx.inference_service_name
     oc(
         "delete",
         "llminferenceservice",
@@ -124,8 +110,7 @@ def delete_existing_service(args, ctx):
         "--ignore-not-found=true",
         check=False,
     )
-    ctx.service_name = name
-    ctx.selector = f"app.kubernetes.io/name={name}"
+
     return f"Deleted existing LLMInferenceService {name}"
 
 
@@ -134,13 +119,11 @@ def delete_existing_service(args, ctx):
 def wait_old_pods_gone(args, ctx):
     """Wait for old llm-d pods to disappear"""
 
-    # Use service name and selector from context (if set) or create from args
-    service_name = getattr(ctx, "service_name", args.inference_service_name)
-    selector = getattr(ctx, "selector", f"app.kubernetes.io/name={service_name}")
-
-    pods = oc_get_json("pods", namespace=args.namespace, selector=selector, ignore_not_found=True)
+    pods = oc_get_json(
+        "pods", namespace=args.namespace, selector=ctx.selector, ignore_not_found=True
+    )
     if not pods or not pods.get("items"):
-        return f"Old pods gone for {service_name}"
+        return f"Old pods gone for {ctx.inference_service_name}"
     return False  # Retry
 
 
@@ -154,7 +137,7 @@ def apply_inference_service(args, ctx):
     # Load and apply the manifest from src
     manifest = load_yaml(Path(src_manifest_path))
     oc_apply(src_manifest_path, manifest)
-    return f"Applied LLMInferenceService manifest from {src_manifest_path} for {ctx.service_name}"
+    return f"Applied LLMInferenceService manifest from {src_manifest_path} for {ctx.inference_service_name}"
 
 
 @on_failure(on_wait_pods_appear_failure)
@@ -163,13 +146,11 @@ def apply_inference_service(args, ctx):
 def wait_pods_appear(args, ctx):
     """Wait for llm-d pods to appear"""
 
-    # Use service name and selector from context (if set) or create from args
-    service_name = getattr(ctx, "service_name", args.inference_service_name)
-    selector = getattr(ctx, "selector", f"app.kubernetes.io/name={service_name}")
-
-    pods = oc_get_json("pods", namespace=args.namespace, selector=selector, ignore_not_found=True)
+    pods = oc_get_json(
+        "pods", namespace=args.namespace, selector=ctx.selector, ignore_not_found=True
+    )
     if pods and pods.get("items"):
-        return f"Pods appeared for {service_name}"
+        return f"Pods appeared for {ctx.inference_service_name}"
     return False  # Retry
 
 
@@ -186,8 +167,10 @@ def capture_llmisv_description(args, ctx):
         artifacts_dir = args.artifact_dir / "artifacts"
         artifacts_dir.mkdir(parents=True, exist_ok=True)
 
-        # Use service name from args (available) or context (if set)
-        service_name = getattr(ctx, "service_name", args.inference_service_name)
+        # Use LLMInferenceService name from context
+        service_name = getattr(ctx, "inference_service_name", None)
+        if not service_name:
+            return "No service name available"
 
         # Capture LLMISV description
         result = oc(
@@ -223,16 +206,17 @@ def capture_replicaset_description(args, ctx):
         artifacts_dir = args.artifact_dir / "artifacts"
         artifacts_dir.mkdir(parents=True, exist_ok=True)
 
-        # Use service name from args (available) or context (if set)
-        service_name = getattr(ctx, "service_name", args.inference_service_name)
-        selector = getattr(ctx, "selector", f"app.kubernetes.io/name={service_name}")
+        # Use LLMInferenceService name from context
+        service_name = getattr(ctx, "inference_service_name", None)
+        if not service_name:
+            return "No service name available"
 
         # Get replicasets for the service
         rs_result = oc(
             "get",
             "replicaset",
             "-l",
-            selector,
+            ctx.selector,
             "-n",
             args.namespace,
             "-o",
@@ -246,16 +230,18 @@ def capture_replicaset_description(args, ctx):
         if rs_result.stdout.strip():
             # Describe each replicaset
             for rs_name in rs_result.stdout.strip().split("\n"):
-                if rs_name.strip():
-                    rs_desc_result = oc(
-                        "describe",
-                        rs_name.strip(),
-                        "-n",
-                        args.namespace,
-                        log_stdout=False,
-                        check=False,
-                    )
-                    replicaset_descriptions.append(rs_desc_result.stdout)
+                if not rs_name.strip():
+                    continue
+
+                rs_desc_result = oc(
+                    "describe",
+                    rs_name.strip(),
+                    "-n",
+                    args.namespace,
+                    log_stdout=False,
+                    check=False,
+                )
+                replicaset_descriptions.append(rs_desc_result.stdout)
 
         # Save all replicaset descriptions
         rs_desc_path = artifacts_dir / "replicaset_description.txt"
@@ -275,7 +261,7 @@ def capture_replicaset_description(args, ctx):
 def query_service_status(args, ctx):
     """Query the status of the LLMInferenceService"""
 
-    service_name = getattr(ctx, "service_name", args.inference_service_name)
+    service_name = ctx.inference_service_name
 
     # Query only the Ready condition status
     result = oc(
@@ -302,7 +288,7 @@ def query_service_status(args, ctx):
 def query_service_message(args, ctx):
     """Query detailed message from LLMInferenceService"""
 
-    service_name = getattr(ctx, "service_name", args.inference_service_name)
+    service_name = ctx.inference_service_name
 
     # Query the Ready condition details
     result = oc(
@@ -339,8 +325,7 @@ def query_service_message(args, ctx):
 def wait_service_ready(args, ctx):
     """Wait for LLMInferenceService to be ready"""
 
-    service_name = getattr(ctx, "service_name", args.inference_service_name)
-    selector = getattr(ctx, "selector", f"app.kubernetes.io/name={service_name}")
+    service_name = ctx.inference_service_name
 
     # Query the current status and show diagnostic info
     result = oc(
@@ -359,7 +344,7 @@ def wait_service_ready(args, ctx):
         "get",
         "pods",
         "-l",
-        selector,
+        ctx.selector,
         "-n",
         args.namespace,
         log_stdout=True,  # Show pod status in logs
@@ -395,7 +380,7 @@ def resolve_endpoint_task(args, ctx):
 
     endpoint_url = try_resolve_endpoint_url(
         namespace=args.namespace,
-        inference_service_name=args.inference_service_name,
+        inference_service_name=ctx.inference_service_name,
         gateway_status_address_name=args.gateway_status_address_name,
     )
     if endpoint_url:
@@ -403,19 +388,6 @@ def resolve_endpoint_task(args, ctx):
         write_text(args.artifact_dir / "artifacts" / "endpoint.url", f"{endpoint_url}\n")
         return f"Endpoint resolved: {endpoint_url}"
     return False  # Retry
-
-
-@task
-def deploy_llmisvc_task(args, ctx):
-    """Deploy the llm_d inference service and resolve its endpoint"""
-
-    # All work is done by the individual tasks
-    service_info = getattr(
-        ctx, "service_description", f"LLM Service '{args.inference_service_name}'"
-    )
-    return (
-        f"LLMInferenceService deployment completed: {service_info} - Endpoint: {ctx.endpoint_url}"
-    )
 
 
 def try_resolve_endpoint_url(

--- a/projects/llm_d/orchestration/config.d/runtime.yaml
+++ b/projects/llm_d/orchestration/config.d/runtime.yaml
@@ -5,3 +5,4 @@ smoke_request_key: default
 benchmark_key: null
 job_name: null
 namespace_override: null
+kserve_dry_run: false

--- a/projects/llm_d/orchestration/test_phase.py
+++ b/projects/llm_d/orchestration/test_phase.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from projects.core.dsl import shell
 from projects.core.dsl.utils import slugify_identifier
-from projects.core.library import env
+from projects.core.library import config, env
 from projects.core.library.postprocess import run_and_postprocess, write_test_labels
 from projects.core.library.run import SignalInterrupt
 from projects.core.orchestration.utils.k8s import ensure_namespace
@@ -17,6 +17,7 @@ from projects.guidellm.toolbox.run_smoke_request import main as run_smoke_reques
 from projects.kserve.toolbox.capture_llmisvc_state import main as capture_llmisvc_state
 from projects.kserve.toolbox.deploy_llmisvc import main as deploy_llmisvc
 from projects.kserve.toolbox.wait_kserve_ready import main as wait_kserve_ready
+from projects.llm_d.orchestration import runtime_config
 from projects.llm_d.orchestration.prepare_phase import prepare_model_cache
 from projects.llm_d.orchestration.render_inference_service import (
     render_inference_service_from_parts,
@@ -29,7 +30,6 @@ logger = logging.getLogger(__name__)
 
 def create_test_labels() -> None:
     """Create __test_labels__.yaml with model name and guidellm configuration."""
-    from projects.llm_d.orchestration import runtime_config
 
     model_name = runtime_config.get_model_name()
     deployment_profile = runtime_config.get_deployment_profile_name()
@@ -52,6 +52,13 @@ def create_test_labels() -> None:
 
 def run() -> int:
     """Main test function that wraps do_test() with outcome postprocessing."""
+
+    dry_run = config.project.get_config("runtime.kserve_dry_run", False)
+    if dry_run:
+        ret = do_test()
+        logger.info("Kserve dry-run mode enabled - Skipping caliper post-processing")
+        return ret
+
     return run_and_postprocess(do_test)
 
 
@@ -73,8 +80,6 @@ def run_finalizers(
                 return finalizer_exc or sys.exc_info()
             logger.exception("Ignoring %s failure after primary test failure", description)
         return finalizer_exc
-
-    from projects.llm_d.orchestration import runtime_config
 
     namespace = runtime_config.get_namespace()
     platform = runtime_config.get_platform_config()
@@ -107,18 +112,19 @@ def run_finalizers(
 
 def do_test() -> int:
     # Load minimal config needed for orchestration flow
-    from projects.llm_d.orchestration import runtime_config
 
     namespace = runtime_config.get_namespace()
+    dry_run = config.project.get_config("runtime.kserve_dry_run", False)
 
-    # Ensure namespace exists before starting any deployments
-    ensure_namespace(
-        namespace,
-        labels={
-            "app.kubernetes.io/managed-by": "forge",
-            "forge.openshift.io/project": "llm_d",
-        },
-    )
+    if not dry_run:
+        # Ensure namespace exists before starting any deployments
+        ensure_namespace(
+            namespace,
+            labels={
+                "app.kubernetes.io/managed-by": "forge",
+                "forge.openshift.io/project": "llm_d",
+            },
+        )
 
     endpoint_url: str | None = None
     primary_exc: tuple[type[BaseException], BaseException, Any] | None = None
@@ -130,6 +136,10 @@ def do_test() -> int:
             create_test_labels()
 
             endpoint_url = deploy_inference_service()
+
+            if dry_run:
+                logging.warning("Running in dry-run mode, skipping the rest of the test steps")
+                return 0
 
             if not endpoint_url:
                 raise ValueError("Failed to extract the endpoint_url from the LLMISVC deployment")
@@ -144,6 +154,9 @@ def do_test() -> int:
             do_finalizers = True
             if primary_exc and isinstance(primary_exc[1], SignalInterrupt):
                 logging.warning("Caught a SignalInterrupt, skipping the finalizers")
+                do_finalizers = False
+
+            if dry_run:
                 do_finalizers = False
 
             if do_finalizers:
@@ -169,29 +182,43 @@ def deploy_inference_service() -> str:
     logger.info("Starting LLMInferenceService deployment")
 
     # Load config where it's consumed
-    from projects.llm_d.orchestration import runtime_config
 
     namespace = runtime_config.get_namespace()
     platform = runtime_config.get_platform_config()
     gateway = platform["gateway"]
 
-    # Step 1: Ensure model cache is ready
-    _prepare_model_cache()
+    # Check if dry-run mode is enabled early
+    dry_run = config.project.get_config("runtime.kserve_dry_run", False)
+
+    # Step 1: Ensure model cache is ready (skip in dry-run)
+    if not dry_run:
+        _prepare_model_cache()
+    else:
+        logger.info("Skipping model cache preparation - dry-run mode enabled")
 
     # Step 2: Wait for the serving control plane to settle before creating the service.
-    rhoai_namespace = platform["rhoai"]["namespace"]
-    wait_kserve_ready.run(namespace=rhoai_namespace)
+    if not dry_run:
+        rhoai_namespace = platform["rhoai"]["namespace"]
+        wait_kserve_ready.run(namespace=rhoai_namespace)
 
     # Step 3: Build and write inference service manifest
     manifest_path = _build_inference_service_manifest()
 
     # Step 4: Deploy the service and wait for endpoint
     logger.info("Deploying LLMInferenceService from manifest: %s", manifest_path)
+
     endpoint_url = deploy_llmisvc.run(
         namespace=namespace,
         inference_service_manifest_path=str(manifest_path),
         gateway_status_address_name=gateway["status_address_name"],
+        dry_run=dry_run,
     )
+
+    if dry_run:
+        llmisvc_manifest_path = endpoint_url
+        logger.info("Dry-run completed: LLMInferenceService manifest prepared:")
+        logger.info(llmisvc_manifest_path)
+        return llmisvc_manifest_path
 
     logger.info("LLMInferenceService deployed successfully, endpoint: %s", endpoint_url)
     return endpoint_url
@@ -199,7 +226,6 @@ def deploy_inference_service() -> str:
 
 def _prepare_model_cache() -> None:
     """Ensure model cache PVC is ready for deployment."""
-    from projects.llm_d.orchestration import runtime_config
 
     model_name = runtime_config.get_model_name()
     logger.info("Preparing model cache for model: %s", model_name)
@@ -211,7 +237,6 @@ def _prepare_model_cache() -> None:
 
 def _build_inference_service_manifest() -> Path:
     """Build and write the LLMInferenceService manifest."""
-    from projects.llm_d.orchestration import runtime_config
 
     config_dir = runtime_config.get_config_dir()
     namespace = runtime_config.get_namespace()
@@ -245,7 +270,6 @@ def _build_inference_service_manifest() -> Path:
 
 def run_smoke_request(*, endpoint_url: str) -> dict[str, object]:
     # Load config where it's consumed
-    from projects.llm_d.orchestration import runtime_config
 
     namespace = runtime_config.get_namespace()
     platform = runtime_config.get_platform_config()
@@ -267,9 +291,6 @@ def run_smoke_request(*, endpoint_url: str) -> dict[str, object]:
 
 
 def run_guidellm_benchmark(*, endpoint_url: str) -> None:
-    # Load config where it's consumed
-    from projects.llm_d.orchestration import runtime_config
-
     namespace = runtime_config.get_namespace()
     benchmark_configs = runtime_config.get_benchmark_configs()
 
@@ -295,7 +316,6 @@ def run_guidellm_benchmark(*, endpoint_url: str) -> None:
 
 def capture_inference_service_state() -> None:
     # Load config where it's consumed
-    from projects.llm_d.orchestration import runtime_config
 
     namespace = runtime_config.get_namespace()
     platform = runtime_config.get_platform_config()
@@ -318,8 +338,12 @@ def write_endpoint_url(*, artifact_dir: Path, endpoint_url: str | None) -> None:
 
 def cleanup_test_resources() -> None:
     """Cleanup test resources using the toolbox script"""
-    # Load config where it's consumed
-    from projects.llm_d.orchestration import runtime_config
+
+    # Skip cleanup when in dry-run mode
+    dry_run = config.project.get_config("runtime.kserve_dry_run", False)
+    if dry_run:
+        logger.info("Skipping cleanup_test_resources - dry-run mode enabled")
+        return
 
     namespace = runtime_config.get_namespace()
     platform = runtime_config.get_platform_config()


### PR DESCRIPTION
First step to be able to compare LLMISVCs with reference files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a KServe dry-run mode that prepares deployment manifests without deploying services or contacting the cluster.
  * Added runtime configuration to enable or disable dry-run behavior.

* **Bug Fixes**
  * Improved consistency when deriving service and selector information from deployment manifests.
  * Simplified pod diagnostic capture and direct file output handling.

* **Tests**
  * Updated test workflows to skip deployment, benchmarking, endpoint checks, and cleanup during dry runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->