### PR TITLE
feat: cluster toolbox add capture_prometheus toolbox for extracting time-bounded metrics

### DIFF
--- a/projects/cluster/toolbox/capture_prometheus/README.md
+++ b/projects/cluster/toolbox/capture_prometheus/README.md
@@ -25,8 +25,7 @@ Extracts cluster Prometheus metrics for a specific time window and saves them as
 ### Standalone (CLI)
 
 ```bash
-cd forge-prom/forge
-python3 -m projects.cluster.toolbox.capture_prometheus.main \
+./bin/run_toolbox cluster capture_prometheus \
     "2026-07-26T10:00:00+00:00" \
     "2026-07-26T10:20:00+00:00" \
     /path/to/output

--- a/projects/cluster/toolbox/capture_prometheus/README.md
+++ b/projects/cluster/toolbox/capture_prometheus/README.md
@@ -1,0 +1,80 @@
+# capture_prometheus
+
+Extracts cluster Prometheus metrics for a specific time window and saves them as a compressed OpenMetrics formated file. The output can later be imported into a local Prometheus instance for offline querying of any metric.
+
+## How it works
+
+1. **Symlink trick** — Creates a temporary directory on the Prometheus PVC containing only symlinks to `wal/` and `chunks_head/`. This limits `promtool` to scanning the recent in-memory data (~1-2 GB) instead of the full TSDB (which can be 20+ GB of persistent blocks).
+2. **Time-filtered dump** — Runs `promtool tsdb dump-openmetrics --min-time=X --max-time=Y` inside the Prometheus container against the temp directory. Only samples within the requested window are emitted.
+3. **Compress and copy** — The output is gzipped on the pod, then copied to the specified output directory via `oc cp`.
+4. **Cleanup** — Removes the temp directory and compressed file from the pod.
+
+
+
+## Limitations
+
+- **Max test duration: 2 hours.** The WAL + chunks_head holds approximately the last 2 hours of un-compacted data. Tests longer than 2 hours will fail with an error. Support for including persistent blocks that overlap with the test window can be added later.
+- **Data granularity:** The dump includes all metrics scraped by cluster monitoring (typically every 30s). For a 20-minute test this produces ~24M data points / ~130MB compressed.
+
+
+
+## Usage
+
+
+
+### Standalone (CLI)
+
+```bash
+cd forge-prom/forge
+python3 -m projects.cluster.toolbox.capture_prometheus.main \
+    "2026-07-26T10:00:00+00:00" \
+    "2026-07-26T10:20:00+00:00" \
+    /path/to/output
+```
+
+
+
+### From orchestration 
+
+```python
+from projects.cluster.toolbox.capture_prometheus import main as capture_prom
+
+prometheus_dir = env.ARTIFACT_DIR / "prometheus"
+prometheus_dir.mkdir(parents=True, exist_ok=True)
+
+capture_prom.run(
+    start_time=test_start_time,
+    end_time=test_end_time,
+    output_dir=str(prometheus_dir),
+)
+```
+
+
+
+## Querying the data locally
+
+To analyze the captured metrics offline:
+
+1. **Decompress** the archive to get a plain OpenMetrics text file.
+2. **Import** the file into a Prometheus TSDB using `promtool tsdb create-blocks-from openmetrics`.
+3. **Run a Prometheus container** (Docker, Podman, or any OCI runtime) with:
+   - The imported TSDB directory mounted at `/prometheus`
+   - A minimal config file (an empty `global: {}` is sufficient since no scraping is needed)
+   - Retention set high enough that the data won't be garbage-collected (e.g. `--storage.tsdb.retention.time=365d`)
+4. **Open the Prometheus UI** and query any metric using the time range from `metadata.json`.
+
+The output file (`metrics.openmetrics.gz`) follows the standard [OpenMetrics](https://openmetrics.io/) format and is compatible with any tool that can ingest it (Prometheus, Grafana via Prometheus data source, etc.).
+
+## Parameters
+
+
+| Parameter     | Required | Default                | Description                                      |
+| ------------- | -------- | ---------------------- | ------------------------------------------------ |
+| `start_time`  | yes      | —                      | Start of capture window (ISO 8601, UTC)          |
+| `end_time`    | yes      | —                      | End of capture window (ISO 8601, UTC)            |
+| `output_dir`  | yes      | —                      | Directory to write `metrics.openmetrics.gz` into |
+| `--pod-name`  | no       | `prometheus-k8s-0`     | Prometheus pod name                              |
+| `--namespace` | no       | `openshift-monitoring` | Namespace of Prometheus                          |
+| `--container` | no       | `prometheus`           | Container name in the pod                        |
+
+

--- a/projects/cluster/toolbox/capture_prometheus/main.py
+++ b/projects/cluster/toolbox/capture_prometheus/main.py
@@ -8,10 +8,10 @@ as a compressed OpenMetrics archive. The output can later be imported into a
 local Prometheus instance for offline querying.
 
 Can be run standalone:
-    python -m projects.cluster.toolbox.capture_prometheus.main \\
-        --start-time "2026-07-26T10:00:00+00:00" \\
-        --end-time "2026-07-26T10:20:00+00:00" \\
-        --output-dir /path/to/output
+    ./bin/run_toolbox cluster capture_prometheus \\
+        "2026-07-26T10:00:00+00:00" \\
+        "2026-07-26T10:20:00+00:00" \\
+        /path/to/output
 """
 
 from __future__ import annotations
@@ -58,6 +58,21 @@ def run(
     return 0
 
 
+def _oc_exec(ctx, command: str, **kwargs):
+    """Run a command inside the Prometheus container via oc exec."""
+    return shell.run(
+        f"oc -n {ctx.namespace} exec {ctx.pod_name} -c {ctx.container} -- {command}",
+        **kwargs,
+    )
+
+
+def _oc_cp_from_pod(ctx, remote_path: str, local_path):
+    """Copy a file from the Prometheus container to a local path."""
+    return shell.run(
+        f"oc cp {ctx.namespace}/{ctx.pod_name}:{remote_path} {local_path} -c {ctx.container}",
+    )
+
+
 def _parse_time(value) -> datetime:
     """Parse a datetime from string (ISO format) or pass through if already datetime.
 
@@ -86,13 +101,10 @@ def validate_parameters(args, ctx):
     max_duration_seconds = 2 * 3600
     duration = (ctx.end_time - ctx.start_time).total_seconds()
     if duration > max_duration_seconds:
-        logger.warning(
-            "Test duration (%ds) exceeds the 2-hour WAL window. "
-            "Skipping Prometheus capture (persistent block handling not yet implemented).",
-            int(duration),
+        raise ValueError(
+            f"Test duration ({int(duration)}s) exceeds the 2-hour WAL window. "
+            f"Tests longer than 2 hours require persistent block handling (not yet implemented)."
         )
-        ctx.skip_capture = True
-        return f"SKIPPED: duration {int(duration)}s exceeds 2-hour WAL window"
 
     ctx.output_dir = Path(args.output_dir)
     ctx.output_dir.mkdir(parents=True, exist_ok=True)
@@ -100,9 +112,9 @@ def validate_parameters(args, ctx):
     ctx.end_ms = int(ctx.end_time.timestamp() * 1000)
     ctx.duration_seconds = int((ctx.end_time - ctx.start_time).total_seconds())
 
-    ctx.namespace = args.namespace or PROMETHEUS_NAMESPACE
-    ctx.pod_name = args.pod_name or PROMETHEUS_POD
-    ctx.container = args.container or PROMETHEUS_CONTAINER
+    ctx.namespace = args.namespace
+    ctx.pod_name = args.pod_name
+    ctx.container = args.container
 
     return (
         f"Capture window: {ctx.start_time.isoformat()} → {ctx.end_time.isoformat()} "
@@ -113,9 +125,6 @@ def validate_parameters(args, ctx):
 @task
 def validate_prometheus_pod(args, ctx):
     """Verify the Prometheus pod is running and accessible."""
-
-    if getattr(ctx, "skip_capture", False):
-        return "SKIPPED"
 
     result = shell.run(
         f"oc -n {ctx.namespace} get pod {ctx.pod_name} -o jsonpath='{{.status.phase}}'",
@@ -138,17 +147,14 @@ def create_temp_tsdb_dir(args, ctx):
     instead of the full TSDB which can be tens of GB.
     """
 
-    if getattr(ctx, "skip_capture", False):
-        return "SKIPPED"
-
     ctx.temp_dir = f"{TSDB_PATH}/.capture-tmp-{ctx.start_ms}"
 
-    shell.run(
-        f"oc -n {ctx.namespace} exec {ctx.pod_name} -c {ctx.container} -- "
+    _oc_exec(
+        ctx,
         f"sh -c '"
-        f"mkdir -p {ctx.temp_dir} && "
-        f"ln -sf {TSDB_PATH}/wal {ctx.temp_dir}/wal && "
-        f"ln -sf {TSDB_PATH}/chunks_head {ctx.temp_dir}/chunks_head"
+        f"mkdir -p {ctx.temp_dir}"
+        f" && ln -sf {TSDB_PATH}/wal {ctx.temp_dir}/wal"
+        f" && ln -sf {TSDB_PATH}/chunks_head {ctx.temp_dir}/chunks_head"
         f"'",
     )
 
@@ -159,26 +165,20 @@ def create_temp_tsdb_dir(args, ctx):
 def dump_metrics(args, ctx):
     """Run promtool tsdb dump-openmetrics with time filtering against the temp dir."""
 
-    if getattr(ctx, "skip_capture", False):
-        return "SKIPPED"
-
     ctx.remote_raw = f"{TSDB_PATH}/.capture-metrics-{ctx.start_ms}"
     ctx.remote_output = f"{ctx.remote_raw}.gz"
 
-    shell.run(
-        f"oc -n {ctx.namespace} exec {ctx.pod_name} -c {ctx.container} -- "
+    _oc_exec(
+        ctx,
         f"sh -c '"
-        f"promtool tsdb dump-openmetrics "
-        f"--min-time={ctx.start_ms} --max-time={ctx.end_ms} "
-        f"{ctx.temp_dir} > {ctx.remote_raw} && gzip -f {ctx.remote_raw}"
+        f"promtool tsdb dump-openmetrics"
+        f" --min-time={ctx.start_ms} --max-time={ctx.end_ms}"
+        f" {ctx.temp_dir} > {ctx.remote_raw}"
+        f" && gzip -f {ctx.remote_raw}"
         f"'",
     )
 
-    size_result = shell.run(
-        f"oc -n {ctx.namespace} exec {ctx.pod_name} -c {ctx.container} -- "
-        f"stat -c %s {ctx.remote_output}",
-        check=False,
-    )
+    size_result = _oc_exec(ctx, f"stat -c %s {ctx.remote_output}", check=False)
 
     ctx.archive_size_bytes = int(size_result.stdout.strip()) if size_result.success else 0
 
@@ -189,15 +189,9 @@ def dump_metrics(args, ctx):
 def copy_to_output(args, ctx):
     """Copy the compressed metrics file from the pod to the output directory."""
 
-    if getattr(ctx, "skip_capture", False):
-        return "SKIPPED"
-
     ctx.output_file = ctx.output_dir / "metrics.openmetrics.gz"
 
-    shell.run(
-        f"oc cp {ctx.namespace}/{ctx.pod_name}:{ctx.remote_output} "
-        f"{ctx.output_file} -c {ctx.container}",
-    )
+    _oc_cp_from_pod(ctx, ctx.remote_output, ctx.output_file)
 
     return f"Copied metrics to {ctx.output_file}"
 
@@ -207,30 +201,13 @@ def copy_to_output(args, ctx):
 def cleanup_pod(args, ctx):
     """Remove temp files from the Prometheus pod."""
 
-    namespace = getattr(ctx, "namespace", None) or PROMETHEUS_NAMESPACE
-    pod_name = getattr(ctx, "pod_name", None) or PROMETHEUS_POD
-    container = getattr(ctx, "container", None) or PROMETHEUS_CONTAINER
     temp_dir = getattr(ctx, "temp_dir", None)
     remote_output = getattr(ctx, "remote_output", None)
-
-    if temp_dir:
-        shell.run(
-            f"oc -n {namespace} exec {pod_name} -c {container} -- rm -rf {temp_dir}",
-            check=False,
-        )
-
-    if remote_output:
-        shell.run(
-            f"oc -n {namespace} exec {pod_name} -c {container} -- rm -f {remote_output}",
-            check=False,
-        )
-
     remote_raw = getattr(ctx, "remote_raw", None)
-    if remote_raw:
-        shell.run(
-            f"oc -n {namespace} exec {pod_name} -c {container} -- rm -f {remote_raw}",
-            check=False,
-        )
+
+    for path in [temp_dir, remote_output, remote_raw]:
+        if path:
+            _oc_exec(ctx, f"rm -rf {path}", check=False)
 
     return "Cleaned up temp files on Prometheus pod"
 

--- a/projects/cluster/toolbox/capture_prometheus/main.py
+++ b/projects/cluster/toolbox/capture_prometheus/main.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+
+"""
+Capture Prometheus TSDB Toolbox
+
+Extracts cluster Prometheus metrics for a specific time window and saves them
+as a compressed OpenMetrics archive. The output can later be imported into a
+local Prometheus instance for offline querying.
+
+Can be run standalone:
+    python -m projects.cluster.toolbox.capture_prometheus.main \\
+        --start-time "2026-07-26T10:00:00+00:00" \\
+        --end-time "2026-07-26T10:20:00+00:00" \\
+        --output-dir /path/to/output
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+
+from projects.core.dsl import always, entrypoint, execute_tasks, shell, task
+
+logger = logging.getLogger("DSL")
+
+PROMETHEUS_NAMESPACE = "openshift-monitoring"
+PROMETHEUS_POD = "prometheus-k8s-0"
+PROMETHEUS_CONTAINER = "prometheus"
+TSDB_PATH = "/prometheus"
+
+
+@entrypoint
+def run(
+    start_time: datetime,
+    end_time: datetime,
+    output_dir: str | Path,
+    *,
+    pod_name: str = PROMETHEUS_POD,
+    namespace: str = PROMETHEUS_NAMESPACE,
+    container: str = PROMETHEUS_CONTAINER,
+) -> int:
+    """
+    Capture Prometheus metrics for a specific time window.
+
+    Extracts all metrics between start_time and end_time from the cluster's
+    Prometheus TSDB and writes them as a compressed OpenMetrics file to output_dir.
+
+    Args:
+        start_time: Start of the capture window (UTC)
+        end_time: End of the capture window (UTC)
+        output_dir: Directory to write the metrics archive into
+        pod_name: Prometheus pod to extract from
+        namespace: Namespace where Prometheus runs
+        container: Container name within the Prometheus pod
+    """
+    execute_tasks(locals())
+    return 0
+
+
+def _parse_time(value) -> datetime:
+    """Parse a datetime from string (ISO format) or pass through if already datetime."""
+    if isinstance(value, datetime):
+        return value
+    dt = datetime.fromisoformat(str(value))
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt
+
+
+@task
+def validate_parameters(args, ctx):
+    """Validate inputs and compute time bounds."""
+
+    ctx.start_time = _parse_time(args.start_time)
+    ctx.end_time = _parse_time(args.end_time)
+
+    if ctx.end_time <= ctx.start_time:
+        raise ValueError("end_time must be after start_time")
+
+    max_duration_seconds = 2 * 3600
+    duration = (ctx.end_time - ctx.start_time).total_seconds()
+    if duration > max_duration_seconds:
+        raise ValueError(
+            f"Test duration ({int(duration)}s) exceeds the 2-hour WAL window. "
+            f"Tests longer than 2 hours require persistent block handling (not yet implemented)."
+        )
+
+    ctx.output_dir = Path(args.output_dir)
+    ctx.output_dir.mkdir(parents=True, exist_ok=True)
+    ctx.start_ms = int(ctx.start_time.timestamp() * 1000)
+    ctx.end_ms = int(ctx.end_time.timestamp() * 1000)
+    ctx.duration_seconds = int((ctx.end_time - ctx.start_time).total_seconds())
+
+    ctx.namespace = args.namespace or PROMETHEUS_NAMESPACE
+    ctx.pod_name = args.pod_name or PROMETHEUS_POD
+    ctx.container = args.container or PROMETHEUS_CONTAINER
+
+    return (
+        f"Capture window: {ctx.start_time.isoformat()} → {ctx.end_time.isoformat()} "
+        f"({ctx.duration_seconds}s)"
+    )
+
+
+@task
+def validate_prometheus_pod(args, ctx):
+    """Verify the Prometheus pod is running and accessible."""
+
+    result = shell.run(
+        f"oc -n {ctx.namespace} get pod {ctx.pod_name} -o jsonpath='{{.status.phase}}'",
+    )
+
+    phase = result.stdout.strip()
+    if phase != "Running":
+        raise RuntimeError(
+            f"Prometheus pod {ctx.pod_name} is in phase '{phase}', expected 'Running'"
+        )
+
+    return f"Prometheus pod {ctx.pod_name} is running"
+
+
+@task
+def create_temp_tsdb_dir(args, ctx):
+    """Create a temp directory on the PVC with symlinks to WAL and chunks_head only.
+
+    This limits promtool to scanning only recent in-memory data (~1-2 GB)
+    instead of the full TSDB which can be tens of GB.
+    """
+
+    ctx.temp_dir = f"{TSDB_PATH}/.capture-tmp-{ctx.start_ms}"
+
+    shell.run(
+        f"oc -n {ctx.namespace} exec {ctx.pod_name} -c {ctx.container} -- "
+        f"sh -c '"
+        f"mkdir -p {ctx.temp_dir} && "
+        f"ln -sf {TSDB_PATH}/wal {ctx.temp_dir}/wal && "
+        f"ln -sf {TSDB_PATH}/chunks_head {ctx.temp_dir}/chunks_head"
+        f"'",
+    )
+
+    return f"Created temp TSDB dir at {ctx.temp_dir}"
+
+
+@task
+def dump_metrics(args, ctx):
+    """Run promtool tsdb dump-openmetrics with time filtering against the temp dir."""
+
+    ctx.remote_output = f"{TSDB_PATH}/.capture-metrics-{ctx.start_ms}.gz"
+
+    shell.run(
+        f"oc -n {ctx.namespace} exec {ctx.pod_name} -c {ctx.container} -- "
+        f"sh -c '"
+        f"promtool tsdb dump-openmetrics "
+        f"--min-time={ctx.start_ms} --max-time={ctx.end_ms} "
+        f"{ctx.temp_dir} | gzip > {ctx.remote_output}"
+        f"'",
+    )
+
+    size_result = shell.run(
+        f"oc -n {ctx.namespace} exec {ctx.pod_name} -c {ctx.container} -- "
+        f"stat -c %s {ctx.remote_output}",
+        check=False,
+    )
+
+    ctx.archive_size_bytes = int(size_result.stdout.strip()) if size_result.success else 0
+
+    return f"Dumped metrics ({ctx.archive_size_bytes} bytes compressed)"
+
+
+@task
+def copy_to_output(args, ctx):
+    """Copy the compressed metrics file from the pod to the output directory."""
+
+    ctx.output_file = ctx.output_dir / "metrics.openmetrics.gz"
+
+    shell.run(
+        f"oc cp {ctx.namespace}/{ctx.pod_name}:{ctx.remote_output} "
+        f"{ctx.output_file} -c {ctx.container}",
+    )
+
+    return f"Copied metrics to {ctx.output_file}"
+
+
+@always
+@task
+def cleanup_pod(args, ctx):
+    """Remove temp files from the Prometheus pod."""
+
+    namespace = getattr(ctx, "namespace", None) or PROMETHEUS_NAMESPACE
+    pod_name = getattr(ctx, "pod_name", None) or PROMETHEUS_POD
+    container = getattr(ctx, "container", None) or PROMETHEUS_CONTAINER
+    temp_dir = getattr(ctx, "temp_dir", None)
+    remote_output = getattr(ctx, "remote_output", None)
+
+    if temp_dir:
+        shell.run(
+            f"oc -n {namespace} exec {pod_name} -c {container} -- rm -rf {temp_dir}",
+            check=False,
+        )
+
+    if remote_output:
+        shell.run(
+            f"oc -n {namespace} exec {pod_name} -c {container} -- rm -f {remote_output}",
+            check=False,
+        )
+
+    return "Cleaned up temp files on Prometheus pod"
+
+
+if __name__ == "__main__":
+    run.main()

--- a/projects/cluster/toolbox/capture_prometheus/main.py
+++ b/projects/cluster/toolbox/capture_prometheus/main.py
@@ -20,7 +20,8 @@ import logging
 from datetime import UTC, datetime
 from pathlib import Path
 
-from projects.core.dsl import always, entrypoint, execute_tasks, shell, task
+from projects.core.dsl import always, entrypoint, execute_tasks, task
+from projects.core.dsl.utils.k8s import oc, oc_cp_from_pod, oc_exec
 
 logger = logging.getLogger("DSL")
 
@@ -58,19 +59,9 @@ def run(
     return 0
 
 
-def _oc_exec(ctx, command: str, **kwargs):
-    """Run a command inside the Prometheus container via oc exec."""
-    return shell.run(
-        f"oc -n {ctx.namespace} exec {ctx.pod_name} -c {ctx.container} -- {command}",
-        **kwargs,
-    )
-
-
-def _oc_cp_from_pod(ctx, remote_path: str, local_path):
-    """Copy a file from the Prometheus container to a local path."""
-    return shell.run(
-        f"oc cp {ctx.namespace}/{ctx.pod_name}:{remote_path} {local_path} -c {ctx.container}",
-    )
+def _pod_kwargs(ctx) -> dict:
+    """Return the common namespace/pod/container kwargs for oc_exec/oc_cp_from_pod."""
+    return {"namespace": ctx.namespace, "pod": ctx.pod_name, "container": ctx.container}
 
 
 def _parse_time(value) -> datetime:
@@ -126,8 +117,14 @@ def validate_parameters(args, ctx):
 def validate_prometheus_pod(args, ctx):
     """Verify the Prometheus pod is running and accessible."""
 
-    result = shell.run(
-        f"oc -n {ctx.namespace} get pod {ctx.pod_name} -o jsonpath='{{.status.phase}}'",
+    result = oc(
+        "-n",
+        ctx.namespace,
+        "get",
+        "pod",
+        ctx.pod_name,
+        "-o",
+        "jsonpath={.status.phase}",
     )
 
     phase = result.stdout.strip()
@@ -149,13 +146,13 @@ def create_temp_tsdb_dir(args, ctx):
 
     ctx.temp_dir = f"{TSDB_PATH}/.capture-tmp-{ctx.start_ms}"
 
-    _oc_exec(
-        ctx,
-        f"sh -c '"
+    oc_exec(
+        "sh",
+        "-c",
         f"mkdir -p {ctx.temp_dir}"
         f" && ln -sf {TSDB_PATH}/wal {ctx.temp_dir}/wal"
-        f" && ln -sf {TSDB_PATH}/chunks_head {ctx.temp_dir}/chunks_head"
-        f"'",
+        f" && ln -sf {TSDB_PATH}/chunks_head {ctx.temp_dir}/chunks_head",
+        **_pod_kwargs(ctx),
     )
 
     return f"Created temp TSDB dir at {ctx.temp_dir}"
@@ -168,17 +165,17 @@ def dump_metrics(args, ctx):
     ctx.remote_raw = f"{TSDB_PATH}/.capture-metrics-{ctx.start_ms}"
     ctx.remote_output = f"{ctx.remote_raw}.gz"
 
-    _oc_exec(
-        ctx,
-        f"sh -c '"
+    oc_exec(
+        "sh",
+        "-c",
         f"promtool tsdb dump-openmetrics"
         f" --min-time={ctx.start_ms} --max-time={ctx.end_ms}"
         f" {ctx.temp_dir} > {ctx.remote_raw}"
-        f" && gzip -f {ctx.remote_raw}"
-        f"'",
+        f" && gzip -f {ctx.remote_raw}",
+        **_pod_kwargs(ctx),
     )
 
-    size_result = _oc_exec(ctx, f"stat -c %s {ctx.remote_output}", check=False)
+    size_result = oc_exec("stat", "-c", "%s", ctx.remote_output, check=False, **_pod_kwargs(ctx))
 
     ctx.archive_size_bytes = int(size_result.stdout.strip()) if size_result.success else 0
 
@@ -191,7 +188,7 @@ def copy_to_output(args, ctx):
 
     ctx.output_file = ctx.output_dir / "metrics.openmetrics.gz"
 
-    _oc_cp_from_pod(ctx, ctx.remote_output, ctx.output_file)
+    oc_cp_from_pod(ctx.remote_output, ctx.output_file, **_pod_kwargs(ctx))
 
     return f"Copied metrics to {ctx.output_file}"
 
@@ -204,10 +201,11 @@ def cleanup_pod(args, ctx):
     temp_dir = getattr(ctx, "temp_dir", None)
     remote_output = getattr(ctx, "remote_output", None)
     remote_raw = getattr(ctx, "remote_raw", None)
+    kwargs = _pod_kwargs(ctx)
 
     for path in [temp_dir, remote_output, remote_raw]:
         if path:
-            _oc_exec(ctx, f"rm -rf {path}", check=False)
+            oc_exec("rm", "-rf", path, check=False, **kwargs)
 
     return "Cleaned up temp files on Prometheus pod"
 

--- a/projects/cluster/toolbox/capture_prometheus/main.py
+++ b/projects/cluster/toolbox/capture_prometheus/main.py
@@ -59,13 +59,18 @@ def run(
 
 
 def _parse_time(value) -> datetime:
-    """Parse a datetime from string (ISO format) or pass through if already datetime."""
+    """Parse a datetime from string (ISO format) or pass through if already datetime.
+
+    Naive datetimes are assumed UTC. Aware datetimes are normalized to UTC.
+    """
     if isinstance(value, datetime):
-        return value
+        if value.tzinfo is None:
+            return value.replace(tzinfo=UTC)
+        return value.astimezone(UTC)
     dt = datetime.fromisoformat(str(value))
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=UTC)
-    return dt
+    return dt.astimezone(UTC)
 
 
 @task
@@ -81,10 +86,13 @@ def validate_parameters(args, ctx):
     max_duration_seconds = 2 * 3600
     duration = (ctx.end_time - ctx.start_time).total_seconds()
     if duration > max_duration_seconds:
-        raise ValueError(
-            f"Test duration ({int(duration)}s) exceeds the 2-hour WAL window. "
-            f"Tests longer than 2 hours require persistent block handling (not yet implemented)."
+        logger.warning(
+            "Test duration (%ds) exceeds the 2-hour WAL window. "
+            "Skipping Prometheus capture (persistent block handling not yet implemented).",
+            int(duration),
         )
+        ctx.skip_capture = True
+        return f"SKIPPED: duration {int(duration)}s exceeds 2-hour WAL window"
 
     ctx.output_dir = Path(args.output_dir)
     ctx.output_dir.mkdir(parents=True, exist_ok=True)
@@ -105,6 +113,9 @@ def validate_parameters(args, ctx):
 @task
 def validate_prometheus_pod(args, ctx):
     """Verify the Prometheus pod is running and accessible."""
+
+    if getattr(ctx, "skip_capture", False):
+        return "SKIPPED"
 
     result = shell.run(
         f"oc -n {ctx.namespace} get pod {ctx.pod_name} -o jsonpath='{{.status.phase}}'",
@@ -127,6 +138,9 @@ def create_temp_tsdb_dir(args, ctx):
     instead of the full TSDB which can be tens of GB.
     """
 
+    if getattr(ctx, "skip_capture", False):
+        return "SKIPPED"
+
     ctx.temp_dir = f"{TSDB_PATH}/.capture-tmp-{ctx.start_ms}"
 
     shell.run(
@@ -145,14 +159,18 @@ def create_temp_tsdb_dir(args, ctx):
 def dump_metrics(args, ctx):
     """Run promtool tsdb dump-openmetrics with time filtering against the temp dir."""
 
-    ctx.remote_output = f"{TSDB_PATH}/.capture-metrics-{ctx.start_ms}.gz"
+    if getattr(ctx, "skip_capture", False):
+        return "SKIPPED"
+
+    ctx.remote_raw = f"{TSDB_PATH}/.capture-metrics-{ctx.start_ms}"
+    ctx.remote_output = f"{ctx.remote_raw}.gz"
 
     shell.run(
         f"oc -n {ctx.namespace} exec {ctx.pod_name} -c {ctx.container} -- "
         f"sh -c '"
         f"promtool tsdb dump-openmetrics "
         f"--min-time={ctx.start_ms} --max-time={ctx.end_ms} "
-        f"{ctx.temp_dir} | gzip > {ctx.remote_output}"
+        f"{ctx.temp_dir} > {ctx.remote_raw} && gzip -f {ctx.remote_raw}"
         f"'",
     )
 
@@ -170,6 +188,9 @@ def dump_metrics(args, ctx):
 @task
 def copy_to_output(args, ctx):
     """Copy the compressed metrics file from the pod to the output directory."""
+
+    if getattr(ctx, "skip_capture", False):
+        return "SKIPPED"
 
     ctx.output_file = ctx.output_dir / "metrics.openmetrics.gz"
 
@@ -201,6 +222,13 @@ def cleanup_pod(args, ctx):
     if remote_output:
         shell.run(
             f"oc -n {namespace} exec {pod_name} -c {container} -- rm -f {remote_output}",
+            check=False,
+        )
+
+    remote_raw = getattr(ctx, "remote_raw", None)
+    if remote_raw:
+        shell.run(
+            f"oc -n {namespace} exec {pod_name} -c {container} -- rm -f {remote_raw}",
             check=False,
         )
 

--- a/projects/core/dsl/cli.py
+++ b/projects/core/dsl/cli.py
@@ -216,6 +216,7 @@ def create_dynamic_parser(func, positional_args=None) -> argparse.ArgumentParser
                 cli_name,
                 type=arg_type,
                 required=not has_default,
+                default=param.default if has_default else None,
                 dest=param_name,
                 help=help_text,
             )

--- a/projects/core/dsl/utils/k8s.py
+++ b/projects/core/dsl/utils/k8s.py
@@ -289,6 +289,59 @@ def capture_pod_logs(*, namespace: str, output_dir: Path) -> None:
             )
 
 
+def oc_exec(
+    *command: str,
+    namespace: str,
+    pod: str,
+    container: str | None = None,
+    **kwargs,
+) -> shell.CommandResult:
+    """Exec a command inside a pod container.
+
+    Args:
+        *command: Command and arguments to run in the pod
+        namespace: Namespace of the pod
+        pod: Pod name
+        container: Container name (optional if pod has a single container)
+        **kwargs: Additional keyword arguments passed to oc()
+
+    Returns:
+        CommandResult with execution details
+    """
+    args = ["-n", namespace, "exec", pod]
+    if container:
+        args.extend(["-c", container])
+    args.append("--")
+    args.extend(command)
+    return oc(*args, **kwargs)
+
+
+def oc_cp_from_pod(
+    remote_path: str,
+    local_path: str | Path,
+    *,
+    namespace: str,
+    pod: str,
+    container: str | None = None,
+) -> shell.CommandResult:
+    """Copy a file from a pod to a local path.
+
+    Args:
+        remote_path: Absolute path inside the pod
+        local_path: Local destination path
+        namespace: Namespace of the pod
+        pod: Pod name
+        container: Container name (optional if pod has a single container)
+
+    Returns:
+        CommandResult with execution details
+    """
+    args = ["cp", f"{namespace}/{pod}:{remote_path}", str(local_path)]
+    if container:
+        args.extend(["-c", container])
+    return oc(*args)
+
+
 def best_effort_oc(*oc_args: str, description: str | None = None) -> None:
     """Run an oc command, swallowing timeout and other errors.
 


### PR DESCRIPTION
Adds a new toolbox under projects/cluster/toolbox/capture_prometheus that extracts Prometheus metrics for a specific time window from the cluster's monitoring stack and saves them as a compressed OpenMetrics file.

Uses a symlink to scan only WAL + chunks_head instead of the full TSDB, making extraction fast (~2 min for 20 min of metrics). Currently limited to tests under 2 hours.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new tool to capture a selected time window of Prometheus metrics from a cluster.
  * Exports compressed OpenMetrics archives for offline analysis.
  * Supports configurable time ranges, output locations, and target pod/namespace/container.
  * Validates parameters and pod availability, then cleans up temporary artifacts.
* **Documentation**
  * Added end-to-end setup and usage guidance, including offline import/query steps and the approximate two-hour maximum capture window.
* **Bug Fixes**
  * Improved CLI argument defaults so optional parameters behave consistently with function-defined defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->