### PR TITLE
Implement KPI regression analysis engine - #1

### DIFF
--- a/projects/caliper/engine/kpi/analyze.py
+++ b/projects/caliper/engine/kpi/analyze.py
@@ -1,14 +1,248 @@
-"""Generic KPI analysis against historical baselines."""
+"""Generic KPI regression analysis against historical baselines."""
 
 from __future__ import annotations
 
 import json
 import logging
 import time
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+import yaml
+
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class AnalysisConfig:
+    """Configuration for KPI regression analysis.
+
+    comparison_keys: Label keys that define what we compare against.
+        Records must differ on at least one comparison key to be distinct baselines.
+        E.g. ["version"] means we test the current version against other versions.
+    ignored_keys: Label keys excluded when matching current to baseline records.
+        E.g. ["os"] means we match across operating systems.
+    sorting_keys: Label keys used to order entries in the output report.
+    max_relative_regression: Fraction threshold for flagging regression (0.1 = 10%).
+    min_baseline_points: Minimum number of baseline data points required to run a test.
+    """
+
+    comparison_keys: list[str] = field(default_factory=list)
+    ignored_keys: list[str] = field(default_factory=list)
+    sorting_keys: list[str] = field(default_factory=list)
+    max_relative_regression: float = 0.1
+    min_baseline_points: int = 1
+
+
+@dataclass
+class KpiTestResult:
+    """Result of a single KPI regression test."""
+
+    kpi_id: str
+    labels: dict[str, Any]
+    current_value: float
+    baseline_mean: float
+    relative_change: float
+    higher_is_better: bool
+    regression: bool
+    baseline_count: int
+
+
+@dataclass
+class AnalysisReport:
+    """Full analysis report."""
+
+    status: str  # "success", "no_regression", "regression_detected", "error"
+    processed: dict[str, Any]
+    tested: list[dict[str, Any]]
+    results: list[dict[str, Any]]
+    overall: dict[str, Any]
+
+
+def _load_analysis_config(plugin_module: str) -> AnalysisConfig:
+    """Load analysis config from plugin module if available, else use defaults.
+
+    Plugins can expose an `analysis_config` dict or `get_analysis_config()` callable.
+    """
+    try:
+        mod = __import__(plugin_module, fromlist=[""])
+        if hasattr(mod, "get_analysis_config"):
+            raw = mod.get_analysis_config()
+        elif hasattr(mod, "analysis_config"):
+            raw = mod.analysis_config
+        else:
+            return AnalysisConfig()
+
+        if isinstance(raw, AnalysisConfig):
+            return raw
+        if isinstance(raw, dict):
+            return AnalysisConfig(
+                **{k: v for k, v in raw.items() if k in AnalysisConfig.__dataclass_fields__}
+            )
+    except (ImportError, Exception) as exc:
+        logger.debug("Could not load analysis config from plugin %s: %s", plugin_module, exc)
+
+    return AnalysisConfig()
+
+
+def _match_key(
+    labels: dict[str, Any], ignored_keys: list[str], comparison_keys: list[str]
+) -> tuple:
+    """Build a hashable match key from labels, excluding ignored and comparison keys."""
+    excluded = set(ignored_keys) | set(comparison_keys)
+    return tuple(sorted((k, str(v)) for k, v in labels.items() if k not in excluded))
+
+
+def _extract_kpi_records_from_hierarchical(data: dict[str, Any]) -> list[dict[str, Any]]:
+    """Extract flat KPI records from a schema_version=2 hierarchical document."""
+    records = []
+    for test in data.get("tests", []):
+        test_labels = test.get("labels", {})
+        for kpi in test.get("kpis", []):
+            records.append(
+                {
+                    "kpi_id": kpi.get("id"),
+                    "value": kpi.get("value"),
+                    "unit": kpi.get("unit"),
+                    "higher_is_better": kpi.get("higher_is_better", True),
+                    "labels": test_labels,
+                    "run_id": test.get("run_id"),
+                    "metadata": test.get("metadata", {}),
+                }
+            )
+    return records
+
+
+def _build_baseline_index(
+    baseline_kpi_data: dict[Path, dict[str, Any]],
+    config: AnalysisConfig,
+) -> dict[tuple, list[dict[str, Any]]]:
+    """Index baseline records by (kpi_id, match_key) for fast lookup.
+
+    Returns mapping from (kpi_id, match_key) -> list of baseline records.
+    """
+    index: dict[tuple, list[dict[str, Any]]] = {}
+    for _path, data in baseline_kpi_data.items():
+        records = _extract_kpi_records_from_hierarchical(data)
+        for rec in records:
+            kpi_id = rec.get("kpi_id")
+            labels = rec.get("labels", {})
+            mk = _match_key(labels, config.ignored_keys, config.comparison_keys)
+            key = (kpi_id, mk)
+            index.setdefault(key, []).append(rec)
+    return index
+
+
+def _run_regression_test(
+    current: dict[str, Any],
+    baselines: list[dict[str, Any]],
+    config: AnalysisConfig,
+) -> KpiTestResult:
+    """Run a regression test for a single KPI record against its baselines."""
+    current_value = float(current["value"])
+    higher_is_better = current.get("higher_is_better", True)
+    baseline_values = [float(b["value"]) for b in baselines if b.get("value") is not None]
+    baseline_mean = sum(baseline_values) / len(baseline_values)
+
+    if baseline_mean == 0:
+        relative_change = 0.0
+    else:
+        relative_change = (current_value - baseline_mean) / abs(baseline_mean)
+
+    # Determine regression: if higher is better, a negative change is regression.
+    # If lower is better, a positive change is regression.
+    if higher_is_better:
+        regression = relative_change < -config.max_relative_regression
+    else:
+        regression = relative_change > config.max_relative_regression
+
+    return KpiTestResult(
+        kpi_id=current["kpi_id"],
+        labels=current.get("labels", {}),
+        current_value=current_value,
+        baseline_mean=round(baseline_mean, 6),
+        relative_change=round(relative_change, 6),
+        higher_is_better=higher_is_better,
+        regression=regression,
+        baseline_count=len(baseline_values),
+    )
+
+
+def _sort_results(results: list[KpiTestResult], sorting_keys: list[str]) -> list[KpiTestResult]:
+    """Sort results by sorting keys extracted from labels, then by kpi_id."""
+
+    def sort_key(r: KpiTestResult):
+        label_key = tuple(str(r.labels.get(k, "")) for k in sorting_keys)
+        return (*label_key, r.kpi_id)
+
+    return sorted(results, key=sort_key)
+
+
+def _build_yaml_report(
+    results: list[KpiTestResult],
+    config: AnalysisConfig,
+    current_source: str,
+    baseline_sources: list[str],
+    skipped: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Build the final YAML-serializable report structure."""
+    regressions = [r for r in results if r.regression]
+    improvements = [r for r in results if not r.regression and r.relative_change != 0]
+
+    if regressions:
+        overall_status = "REGRESSION_DETECTED"
+    else:
+        overall_status = "PASS"
+
+    report = {
+        "analysis": {
+            "status": overall_status,
+            "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "config": {
+                "comparison_keys": config.comparison_keys,
+                "ignored_keys": config.ignored_keys,
+                "sorting_keys": config.sorting_keys,
+                "max_relative_regression": config.max_relative_regression,
+                "min_baseline_points": config.min_baseline_points,
+            },
+        },
+        "processed": {
+            "current_source": current_source,
+            "baseline_sources": baseline_sources,
+            "baseline_source_count": len(baseline_sources),
+        },
+        "tested": {
+            "total_kpis": len(results),
+            "regressions": len(regressions),
+            "passes": len(results) - len(regressions),
+            "skipped": len(skipped),
+        },
+        "results": [
+            {
+                "kpi_id": r.kpi_id,
+                "labels": r.labels,
+                "current_value": r.current_value,
+                "baseline_mean": r.baseline_mean,
+                "relative_change_pct": round(r.relative_change * 100, 2),
+                "higher_is_better": r.higher_is_better,
+                "verdict": "REGRESSION" if r.regression else "PASS",
+                "baseline_count": r.baseline_count,
+            }
+            for r in results
+        ],
+        "overall": {
+            "verdict": overall_status,
+            "regression_count": len(regressions),
+            "total_tested": len(results),
+            "total_skipped": len(skipped),
+        },
+    }
+
+    if skipped:
+        report["skipped"] = skipped
+
+    return report
 
 
 def run_kpi_analysis(
@@ -17,102 +251,154 @@ def run_kpi_analysis(
     output_file: Path,
     plugin_module: str,
 ) -> int:
-    """Run KPI analysis and generate output file.
+    """Run KPI regression analysis and generate a YAML report.
 
     Args:
-        current_kpi_file: Path to current KPI JSON file
-        historical_data_dir: Directory containing historical KPI files
-        output_file: Path where analysis results will be written
-        plugin_module: Plugin module name for analysis
+        current_kpi_file: Path to current KPI JSON file (hierarchical schema v2)
+        historical_data_dir: Directory containing historical KPI files (kpis.json)
+        output_file: Path where YAML analysis report will be written
+        plugin_module: Plugin module name (for loading analysis config)
 
     Returns:
-        Exit code (0 for success, non-zero for failure)
+        Exit code: 0=pass, 1=error, 2=warning (no baseline), 3=regression detected
     """
     try:
-        logger.info(f"Running KPI analysis for: {current_kpi_file}")
-        logger.info(f"Historical data directory: {historical_data_dir}")
-        logger.info(f"Output file: {output_file}")
-        logger.info(f"Plugin module: {plugin_module}")
+        logger.info("Running KPI regression analysis")
+        logger.info("  current_kpi_file: %s", current_kpi_file)
+        logger.info("  historical_data_dir: %s", historical_data_dir)
+        logger.info("  output_file: %s", output_file)
+        logger.info("  plugin_module: %s", plugin_module)
 
-        # Check if current KPI file exists
         if not current_kpi_file.exists():
-            logger.error(f"Current KPI file not found: {current_kpi_file}")
+            logger.error("Current KPI file not found: %s", current_kpi_file)
             return 1
 
-        # Check if historical data directory exists
         if not historical_data_dir.exists():
-            logger.error(f"Historical data directory not found: {historical_data_dir}")
+            logger.error("Historical data directory not found: %s", historical_data_dir)
             return 1
 
-        # Find all historical KPI files
-        historical_kpi_files = []
-        for kpi_file in historical_data_dir.rglob("kpis.json"):
-            historical_kpi_files.append(str(kpi_file))
-            logger.info(f"Found historical KPI file: {kpi_file}")
+        config = _load_analysis_config(plugin_module)
+        logger.info(
+            "  config: comparison_keys=%s, ignored_keys=%s",
+            config.comparison_keys,
+            config.ignored_keys,
+        )
 
-        if not historical_kpi_files:
-            logger.warning("No historical KPI files found for analysis")
-            # Return special exit code 2 to indicate warning (no historical data)
-            analysis_result = {
-                "status": "warning",
-                "message": "no historical KPI found for regression testing",
-                "current_kpi_file": str(current_kpi_file),
-                "historical_kpi_files": historical_kpi_files,
-                "baseline_files_count": 0,
-                "plugin_module": plugin_module,
-                "completed_at": time.time(),
-            }
-            # Write warning result to output file
-            output_file.parent.mkdir(parents=True, exist_ok=True)
-            with open(output_file, "w") as f:
-                json.dump(analysis_result, f, indent=2)
-            return 2  # Special exit code for warning
+        # Load current KPIs
+        with open(current_kpi_file) as f:
+            current_data = json.load(f)
 
-        logger.info(f"Found {len(historical_kpi_files)} historical KPI files for analysis")
+        if current_data.get("schema_version") != "2":
+            logger.error("Current KPI file must be schema_version 2 (hierarchical)")
+            return 1
 
-        # Create analysis result
-        analysis_result = {
-            "status": "success (stub)",
-            "current_kpi_file": str(current_kpi_file),
-            "historical_kpi_files": historical_kpi_files,
-            "baseline_files_count": len(historical_kpi_files),
-            "plugin_module": plugin_module,
-            "completed_at": time.time(),
-        }
+        current_records = _extract_kpi_records_from_hierarchical(current_data)
+        if not current_records:
+            logger.warning("No KPI records found in current file")
+            return 1
 
-        # Create output directory if needed
+        # Load baseline KPIs
+        baseline_kpi_data = find_baseline_kpis(historical_data_dir)
+        if not baseline_kpi_data:
+            _write_warning_report(output_file, current_kpi_file, plugin_module)
+            return 2
+
+        # Build baseline index
+        baseline_index = _build_baseline_index(baseline_kpi_data, config)
+
+        # Run regression tests
+        results: list[KpiTestResult] = []
+        skipped: list[dict[str, Any]] = []
+
+        for rec in current_records:
+            kpi_id = rec.get("kpi_id")
+            value = rec.get("value")
+
+            # Skip non-scalar values (2D KPIs, lists, etc.)
+            if not isinstance(value, (int, float)):
+                skipped.append({"kpi_id": kpi_id, "reason": "non-scalar value"})
+                continue
+
+            labels = rec.get("labels", {})
+            mk = _match_key(labels, config.ignored_keys, config.comparison_keys)
+            key = (kpi_id, mk)
+
+            baselines = baseline_index.get(key, [])
+            # Filter to only scalar baselines
+            scalar_baselines = [b for b in baselines if isinstance(b.get("value"), (int, float))]
+
+            if len(scalar_baselines) < config.min_baseline_points:
+                skipped.append(
+                    {
+                        "kpi_id": kpi_id,
+                        "labels": labels,
+                        "reason": f"insufficient baselines ({len(scalar_baselines)} < {config.min_baseline_points})",
+                    }
+                )
+                continue
+
+            result = _run_regression_test(rec, scalar_baselines, config)
+            results.append(result)
+
+        # Sort results
+        results = _sort_results(results, config.sorting_keys)
+
+        # Build report
+        baseline_sources = [str(p) for p in baseline_kpi_data.keys()]
+        report = _build_yaml_report(
+            results=results,
+            config=config,
+            current_source=str(current_kpi_file),
+            baseline_sources=baseline_sources,
+            skipped=skipped,
+        )
+
+        # Write YAML report
         output_file.parent.mkdir(parents=True, exist_ok=True)
-
-        # Write analysis results to output file
         with open(output_file, "w") as f:
-            json.dump(analysis_result, f, indent=2)
-            f.write("\n")  # Add EOL at EOF
+            yaml.dump(report, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
 
-        logger.info(f"Analysis completed successfully, results written to: {output_file}")
-        return 0
+        regressions = report["overall"]["regression_count"]
+        total = report["overall"]["total_tested"]
+        logger.info(
+            "Analysis complete: %d/%d KPIs tested, %d regressions",
+            total,
+            len(current_records),
+            regressions,
+        )
 
-    except Exception as e:
+        return 3 if regressions > 0 else 0
+
+    except Exception:
         logger.exception("KPI analysis failed")
-
-        # Create failure result
-        failure_result = {
-            "status": "failed",
-            "error": str(e),
-            "current_kpi_file": str(current_kpi_file) if current_kpi_file else None,
-            "completed_at": time.time(),
-        }
-
-        try:
-            # Attempt to write failure result
-            if output_file:
-                output_file.parent.mkdir(parents=True, exist_ok=True)
-                with open(output_file, "w") as f:
-                    json.dump(failure_result, f, indent=2)
-                    f.write("\n")  # Add EOL at EOF
-        except Exception:
-            logger.exception("Failed to write error result to output file")
-
         return 1
+
+
+def _write_warning_report(output_file: Path, current_kpi_file: Path, plugin_module: str) -> None:
+    """Write a warning-level report when no baselines are available."""
+    report = {
+        "analysis": {
+            "status": "NO_BASELINE",
+            "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        },
+        "processed": {
+            "current_source": str(current_kpi_file),
+            "baseline_sources": [],
+            "baseline_source_count": 0,
+        },
+        "tested": {"total_kpis": 0, "regressions": 0, "passes": 0, "skipped": 0},
+        "results": [],
+        "overall": {
+            "verdict": "NO_BASELINE",
+            "message": "No historical KPI files found for regression testing",
+            "regression_count": 0,
+            "total_tested": 0,
+            "total_skipped": 0,
+        },
+    }
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_file, "w") as f:
+        yaml.dump(report, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
 
 
 def analyze_kpis(
@@ -129,19 +415,15 @@ def analyze_kpis(
     if not postprocess_config.analyze.enabled:
         return {"status": "disabled", "reason": "analyze disabled"}
 
-    # Determine paths for analysis
     analyze_config = postprocess_config.analyze
 
-    # Historical KPIs directory path
     historical_kpis_dir = Path(analyze_config.historical_kpis)
     if not historical_kpis_dir.is_absolute():
         historical_kpis_dir = output_dir / historical_kpis_dir
 
-    # Output path for analysis results
     output_path = output_dir / analyze_config.output
 
     try:
-        # Check if required files exist
         if not current_kpis_file.exists():
             return {
                 "status": "failed",
@@ -156,7 +438,6 @@ def analyze_kpis(
                 "completed_at": time.time(),
             }
 
-        # Call the core analysis function
         exit_code = run_kpi_analysis(
             current_kpi_file=current_kpis_file,
             historical_data_dir=historical_kpis_dir,
@@ -165,123 +446,71 @@ def analyze_kpis(
         )
 
         if exit_code == 0:
-            # Read the results from the output file
-            if output_path.exists():
-                with open(output_path) as f:
-                    result_data = json.load(f)
-
-                # Return success with output file path for notifications
-                return {
-                    "status": "success",
-                    "output_file": str(output_path),
-                    "baseline_files_count": result_data.get("baseline_files_count", 0),
-                    "completed_at": time.time(),
-                }
-            else:
-                return {
-                    "status": "failed",
-                    "error": "Analysis completed but no output file was generated",
-                    "completed_at": time.time(),
-                }
+            return {
+                "status": "success",
+                "output_file": str(output_path),
+                "completed_at": time.time(),
+            }
         elif exit_code == 2:
-            # Warning: no historical data found
-            if output_path.exists():
-                with open(output_path) as f:
-                    result_data = json.load(f)
-
-                # Return warning status with message
-                return {
-                    "status": "warning",
-                    "message": result_data.get(
-                        "message", "no historical KPI found for regression testing"
-                    ),
-                    "output_file": str(output_path),
-                    "baseline_files_count": result_data.get("baseline_files_count", 0),
-                    "completed_at": time.time(),
-                }
-            else:
-                return {
-                    "status": "warning",
-                    "message": "no historical KPI found for regression testing",
-                    "baseline_files_count": 0,
-                    "completed_at": time.time(),
-                }
+            return {
+                "status": "warning",
+                "message": "no historical KPI found for regression testing",
+                "output_file": str(output_path),
+                "completed_at": time.time(),
+            }
+        elif exit_code == 3:
+            return {
+                "status": "regression_detected",
+                "output_file": str(output_path),
+                "completed_at": time.time(),
+            }
         else:
-            # Read error from output file if it exists
-            error_msg = f"Analysis failed with exit code {exit_code}"
-            if output_path.exists():
-                try:
-                    with open(output_path) as f:
-                        result_data = json.load(f)
-                    error_msg = result_data.get("error", error_msg)
-                except Exception:
-                    pass
-
             return {
                 "status": "failed",
-                "error": error_msg,
+                "error": f"Analysis failed with exit code {exit_code}",
                 "completed_at": time.time(),
             }
 
     except Exception as e:
-        error_msg = f"{type(e).__name__}: {str(e)}"
-        logger.exception(f"Analysis step failed with {error_msg}")
-
-        # Don't suppress the exception - provide detailed error info and re-raise
-        import traceback
-
-        full_traceback = traceback.format_exc()
-        logger.error(f"Full traceback for analyze_kpis failure:\n{full_traceback}")
-
-        # Re-raise the original exception so the caller can see the full details
-        raise RuntimeError(f"KPI analysis failed: {error_msg}") from e
+        logger.exception("Analysis step failed")
+        raise RuntimeError(f"KPI analysis failed: {e}") from e
 
 
 def find_baseline_kpis(historical_dir: Path) -> dict[Path, dict[str, Any]]:
-    """Load all kpis.json files from historical directory and return a mapping of path to loaded JSON object.
+    """Load all kpis.json files from historical directory.
 
-    Args:
-        historical_dir: Directory to search for historical kpis.json files
-
-    Returns:
-        Dictionary mapping file paths to loaded KPI JSON objects
+    Returns mapping of file paths to loaded hierarchical KPI data (schema v2 only).
     """
-    baseline_kpis = {}
+    baseline_kpis: dict[Path, dict[str, Any]] = {}
     kpi_files = list(historical_dir.rglob("kpis.json"))
 
     if not kpi_files:
-        logger.warning(f"No kpis.json files found in historical directory: {historical_dir}")
+        logger.warning("No kpis.json files found in: %s", historical_dir)
         return baseline_kpis
 
-    logger.info(f"Found {len(kpi_files)} historical KPI files to load")
+    logger.info("Found %d historical KPI files to load", len(kpi_files))
 
     for kpi_file in kpi_files:
         try:
             with open(kpi_file) as f:
                 kpi_data = json.load(f)
 
-            # Validate that it's a hierarchical format (schema_version 2)
             schema_version = kpi_data.get("schema_version", "unknown")
             if schema_version != "2":
                 logger.warning(
-                    f"Skipping {kpi_file}: unsupported schema version {schema_version} (only version 2 supported)"
+                    "Skipping %s: unsupported schema version %s", kpi_file, schema_version
                 )
                 continue
 
             baseline_kpis[kpi_file] = kpi_data
-            logger.debug(f"Loaded KPI file: {kpi_file}")
+            logger.debug("Loaded baseline: %s", kpi_file)
 
         except json.JSONDecodeError as e:
-            logger.error(f"Failed to parse JSON in {kpi_file}: {e}")
-            continue
-        except FileNotFoundError as e:
-            logger.error(f"KPI file not found: {kpi_file}: {e}")
-            continue
+            logger.error("Failed to parse JSON in %s: %s", kpi_file, e)
         except Exception as e:
-            logger.error(f"Failed to load KPI file {kpi_file}: {e}")
-            continue
+            logger.error("Failed to load %s: %s", kpi_file, e)
 
-    logger.info(f"Successfully loaded {len(baseline_kpis)} historical KPI files")
+    logger.info("Successfully loaded %d historical KPI files", len(baseline_kpis))
     return baseline_kpis
 
 
@@ -293,52 +522,33 @@ def run_analyze(
     plugin: Any = None,
 ) -> dict[str, Any]:
     """Run KPI analysis against ALL baseline files (CLI interface)."""
-    # For CLI use, we need to extract the baseline directory from the dict
-    # This is a bit of a hack, but the CLI interface expects a directory
-    if baseline_kpis:
-        # Get the parent directory of the first baseline file
-        first_baseline_path = next(iter(baseline_kpis.keys()))
-        historical_dir = first_baseline_path.parent
-
-        # Extract plugin module name if available
-        plugin_module = getattr(plugin, "__module__", "unknown") if plugin else "unknown"
-
-        # Call the core analysis function
-        exit_code = run_kpi_analysis(
-            current_kpi_file=Path(current_path),
-            historical_data_dir=historical_dir,
-            output_file=Path(output_path),
-            plugin_module=plugin_module,
-        )
-
-        if exit_code == 0:
-            # Read results and convert to expected format for CLI
-            try:
-                with open(Path(output_path)) as f:
-                    result_data = json.load(f)
-                return {
-                    "status": "success",
-                    "baseline_files_count": result_data.get("baseline_files_count", 0),
-                    "completed_at": result_data.get("completed_at", time.time()),
-                }
-            except Exception as e:
-                return {
-                    "status": "failed",
-                    "error": f"Failed to read analysis results: {e}",
-                    "completed_at": time.time(),
-                }
-        else:
-            return {
-                "status": "failed",
-                "error": f"Analysis failed with exit code {exit_code}",
-                "completed_at": time.time(),
-            }
-    else:
+    if not baseline_kpis:
         return {
             "status": "failed",
             "error": "No baseline KPI files provided",
             "completed_at": time.time(),
         }
+
+    first_baseline_path = next(iter(baseline_kpis.keys()))
+    historical_dir = first_baseline_path.parent
+
+    plugin_module = getattr(plugin, "__module__", "unknown") if plugin else "unknown"
+
+    exit_code = run_kpi_analysis(
+        current_kpi_file=Path(current_path),
+        historical_data_dir=historical_dir,
+        output_file=Path(output_path),
+        plugin_module=plugin_module,
+    )
+
+    if exit_code == 0:
+        return {"status": "success", "completed_at": time.time()}
+    elif exit_code == 2:
+        return {"status": "warning", "message": "no baselines found", "completed_at": time.time()}
+    elif exit_code == 3:
+        return {"status": "regression_detected", "completed_at": time.time()}
+    else:
+        return {"status": "failed", "error": f"exit code {exit_code}", "completed_at": time.time()}
 
 
 # EOF

--- a/projects/caliper/tests/test_kpi_analyze.py
+++ b/projects/caliper/tests/test_kpi_analyze.py
@@ -1,0 +1,442 @@
+"""Tests for KPI regression analysis (analyze.py)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from projects.caliper.engine.kpi.analyze import (
+    AnalysisConfig,
+    _build_baseline_index,
+    _extract_kpi_records_from_hierarchical,
+    _match_key,
+    _run_regression_test,
+    run_kpi_analysis,
+)
+
+
+def _make_hierarchical_kpi(
+    tests: list[dict],
+) -> dict:
+    """Helper to build a schema_version=2 hierarchical KPI doc."""
+    return {"schema_version": "2", "tests": tests}
+
+
+def _make_test_entry(
+    run_id: str,
+    labels: dict,
+    kpis: list[dict],
+) -> dict:
+    return {
+        "run_id": run_id,
+        "labels": labels,
+        "metadata": {"timestamp": "2025-01-01T00:00:00Z"},
+        "kpis": kpis,
+    }
+
+
+def _make_kpi(kpi_id: str, value, unit: str = "tokens/s", higher_is_better: bool = True) -> dict:
+    return {"id": kpi_id, "value": value, "unit": unit, "higher_is_better": higher_is_better}
+
+
+class TestMatchKey:
+    def test_basic_match_key(self):
+        labels = {"platform": "A100", "version": "1.0", "os": "linux"}
+        key = _match_key(labels, ignored_keys=["os"], comparison_keys=["version"])
+        assert ("os", "linux") not in key
+        assert ("version", "1.0") not in key
+        assert ("platform", "A100") in key
+
+    def test_empty_config(self):
+        labels = {"a": "1", "b": "2"}
+        key = _match_key(labels, ignored_keys=[], comparison_keys=[])
+        assert key == tuple(sorted([("a", "1"), ("b", "2")]))
+
+
+class TestExtractRecords:
+    def test_extracts_flat_records(self):
+        data = _make_hierarchical_kpi(
+            [
+                _make_test_entry(
+                    "run1",
+                    {"platform": "A100"},
+                    [
+                        _make_kpi("throughput", 100.0),
+                        _make_kpi("latency", 0.5, unit="s", higher_is_better=False),
+                    ],
+                ),
+            ]
+        )
+        records = _extract_kpi_records_from_hierarchical(data)
+        assert len(records) == 2
+        assert records[0]["kpi_id"] == "throughput"
+        assert records[0]["labels"] == {"platform": "A100"}
+        assert records[1]["value"] == 0.5
+
+    def test_empty_tests(self):
+        data = _make_hierarchical_kpi([])
+        assert _extract_kpi_records_from_hierarchical(data) == []
+
+
+class TestBuildBaselineIndex:
+    def test_indexes_by_kpi_and_match_key(self):
+        data = _make_hierarchical_kpi(
+            [
+                _make_test_entry(
+                    "run1",
+                    {"platform": "A100", "version": "1.0"},
+                    [
+                        _make_kpi("throughput", 95.0),
+                    ],
+                ),
+                _make_test_entry(
+                    "run2",
+                    {"platform": "A100", "version": "2.0"},
+                    [
+                        _make_kpi("throughput", 100.0),
+                    ],
+                ),
+            ]
+        )
+        config = AnalysisConfig(comparison_keys=["version"])
+        baseline_data = {Path("/fake/kpis.json"): data}
+        index = _build_baseline_index(baseline_data, config)
+
+        mk = _match_key({"platform": "A100"}, [], ["version"])
+        key = ("throughput", mk)
+        assert key in index
+        assert len(index[key]) == 2
+
+
+class TestRegressionTest:
+    def test_no_regression_higher_is_better(self):
+        current = {"kpi_id": "throughput", "value": 100.0, "higher_is_better": True, "labels": {}}
+        baselines = [{"value": 95.0}, {"value": 100.0}]
+        config = AnalysisConfig(max_relative_regression=0.1)
+        result = _run_regression_test(current, baselines, config)
+        assert not result.regression
+        assert result.relative_change > 0
+
+    def test_regression_higher_is_better(self):
+        current = {"kpi_id": "throughput", "value": 80.0, "higher_is_better": True, "labels": {}}
+        baselines = [{"value": 100.0}, {"value": 100.0}]
+        config = AnalysisConfig(max_relative_regression=0.1)
+        result = _run_regression_test(current, baselines, config)
+        assert result.regression
+        assert result.relative_change < -0.1
+
+    def test_regression_lower_is_better(self):
+        current = {"kpi_id": "latency", "value": 1.5, "higher_is_better": False, "labels": {}}
+        baselines = [{"value": 1.0}, {"value": 1.0}]
+        config = AnalysisConfig(max_relative_regression=0.1)
+        result = _run_regression_test(current, baselines, config)
+        assert result.regression
+        assert result.relative_change > 0.1
+
+    def test_no_regression_lower_is_better(self):
+        current = {"kpi_id": "latency", "value": 0.9, "higher_is_better": False, "labels": {}}
+        baselines = [{"value": 1.0}]
+        config = AnalysisConfig(max_relative_regression=0.1)
+        result = _run_regression_test(current, baselines, config)
+        assert not result.regression
+
+
+class TestEndToEnd:
+    """Full end-to-end test of run_kpi_analysis."""
+
+    def _write_hierarchical_kpi(self, path: Path, data: dict) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w") as f:
+            json.dump(data, f)
+
+    def test_pass_no_regression(self, tmp_path):
+        current_dir = tmp_path / "current"
+        historical_dir = tmp_path / "historical"
+        output_file = tmp_path / "report.yaml"
+
+        # Current KPIs: throughput=100
+        current = _make_hierarchical_kpi(
+            [
+                _make_test_entry(
+                    "current_run",
+                    {"platform": "A100"},
+                    [
+                        _make_kpi("throughput", 100.0),
+                    ],
+                ),
+            ]
+        )
+        self._write_hierarchical_kpi(current_dir / "kpis.json", current)
+
+        # Historical: throughput=95, 98 (within 10% threshold)
+        baseline1 = _make_hierarchical_kpi(
+            [
+                _make_test_entry(
+                    "old_run_1",
+                    {"platform": "A100"},
+                    [
+                        _make_kpi("throughput", 95.0),
+                    ],
+                ),
+            ]
+        )
+        baseline2 = _make_hierarchical_kpi(
+            [
+                _make_test_entry(
+                    "old_run_2",
+                    {"platform": "A100"},
+                    [
+                        _make_kpi("throughput", 98.0),
+                    ],
+                ),
+            ]
+        )
+        self._write_hierarchical_kpi(historical_dir / "run1" / "kpis.json", baseline1)
+        self._write_hierarchical_kpi(historical_dir / "run2" / "kpis.json", baseline2)
+
+        exit_code = run_kpi_analysis(
+            current_kpi_file=current_dir / "kpis.json",
+            historical_data_dir=historical_dir,
+            output_file=output_file,
+            plugin_module="nonexistent_plugin",
+        )
+
+        assert exit_code == 0
+        assert output_file.exists()
+
+        with open(output_file) as f:
+            report = yaml.safe_load(f)
+
+        assert report["analysis"]["status"] == "PASS"
+        assert report["overall"]["verdict"] == "PASS"
+        assert report["overall"]["regression_count"] == 0
+        assert report["tested"]["total_kpis"] == 1
+
+    def test_regression_detected(self, tmp_path):
+        current_dir = tmp_path / "current"
+        historical_dir = tmp_path / "historical"
+        output_file = tmp_path / "report.yaml"
+
+        # Current: throughput dropped from 100 to 70 (30% regression)
+        current = _make_hierarchical_kpi(
+            [
+                _make_test_entry(
+                    "current_run",
+                    {"platform": "A100"},
+                    [
+                        _make_kpi("throughput", 70.0),
+                    ],
+                ),
+            ]
+        )
+        self._write_hierarchical_kpi(current_dir / "kpis.json", current)
+
+        baseline = _make_hierarchical_kpi(
+            [
+                _make_test_entry(
+                    "old_run",
+                    {"platform": "A100"},
+                    [
+                        _make_kpi("throughput", 100.0),
+                    ],
+                ),
+            ]
+        )
+        self._write_hierarchical_kpi(historical_dir / "run1" / "kpis.json", baseline)
+
+        exit_code = run_kpi_analysis(
+            current_kpi_file=current_dir / "kpis.json",
+            historical_data_dir=historical_dir,
+            output_file=output_file,
+            plugin_module="nonexistent_plugin",
+        )
+
+        assert exit_code == 3
+        with open(output_file) as f:
+            report = yaml.safe_load(f)
+
+        assert report["analysis"]["status"] == "REGRESSION_DETECTED"
+        assert report["overall"]["regression_count"] == 1
+        assert report["results"][0]["verdict"] == "REGRESSION"
+        assert report["results"][0]["relative_change_pct"] == pytest.approx(-30.0)
+
+    def test_no_historical_data(self, tmp_path):
+        current_dir = tmp_path / "current"
+        historical_dir = tmp_path / "historical"
+        historical_dir.mkdir(parents=True)
+        output_file = tmp_path / "report.yaml"
+
+        current = _make_hierarchical_kpi(
+            [
+                _make_test_entry(
+                    "run",
+                    {"platform": "A100"},
+                    [
+                        _make_kpi("throughput", 100.0),
+                    ],
+                ),
+            ]
+        )
+        self._write_hierarchical_kpi(current_dir / "kpis.json", current)
+
+        exit_code = run_kpi_analysis(
+            current_kpi_file=current_dir / "kpis.json",
+            historical_data_dir=historical_dir,
+            output_file=output_file,
+            plugin_module="nonexistent_plugin",
+        )
+
+        assert exit_code == 2
+        with open(output_file) as f:
+            report = yaml.safe_load(f)
+        assert report["overall"]["verdict"] == "NO_BASELINE"
+
+    def test_mixed_regression_and_pass(self, tmp_path):
+        current_dir = tmp_path / "current"
+        historical_dir = tmp_path / "historical"
+        output_file = tmp_path / "report.yaml"
+
+        current = _make_hierarchical_kpi(
+            [
+                _make_test_entry(
+                    "run",
+                    {"platform": "A100"},
+                    [
+                        _make_kpi("throughput", 100.0, higher_is_better=True),
+                        _make_kpi("latency", 2.0, unit="s", higher_is_better=False),
+                    ],
+                ),
+            ]
+        )
+        self._write_hierarchical_kpi(current_dir / "kpis.json", current)
+
+        baseline = _make_hierarchical_kpi(
+            [
+                _make_test_entry(
+                    "old",
+                    {"platform": "A100"},
+                    [
+                        _make_kpi("throughput", 100.0, higher_is_better=True),
+                        _make_kpi("latency", 1.0, unit="s", higher_is_better=False),
+                    ],
+                ),
+            ]
+        )
+        self._write_hierarchical_kpi(historical_dir / "run1" / "kpis.json", baseline)
+
+        exit_code = run_kpi_analysis(
+            current_kpi_file=current_dir / "kpis.json",
+            historical_data_dir=historical_dir,
+            output_file=output_file,
+            plugin_module="nonexistent_plugin",
+        )
+
+        assert exit_code == 3
+        with open(output_file) as f:
+            report = yaml.safe_load(f)
+
+        assert report["overall"]["regression_count"] == 1
+        latency_result = next(r for r in report["results"] if r["kpi_id"] == "latency")
+        assert latency_result["verdict"] == "REGRESSION"
+        throughput_result = next(r for r in report["results"] if r["kpi_id"] == "throughput")
+        assert throughput_result["verdict"] == "PASS"
+
+    def test_skips_non_scalar_kpis(self, tmp_path):
+        current_dir = tmp_path / "current"
+        historical_dir = tmp_path / "historical"
+        output_file = tmp_path / "report.yaml"
+
+        current = _make_hierarchical_kpi(
+            [
+                _make_test_entry(
+                    "run",
+                    {"platform": "A100"},
+                    [
+                        _make_kpi("throughput", 100.0),
+                        _make_kpi("curve_data", [1.0, 2.0, 3.0]),  # non-scalar
+                    ],
+                ),
+            ]
+        )
+        self._write_hierarchical_kpi(current_dir / "kpis.json", current)
+
+        baseline = _make_hierarchical_kpi(
+            [
+                _make_test_entry(
+                    "old",
+                    {"platform": "A100"},
+                    [
+                        _make_kpi("throughput", 95.0),
+                    ],
+                ),
+            ]
+        )
+        self._write_hierarchical_kpi(historical_dir / "run1" / "kpis.json", baseline)
+
+        exit_code = run_kpi_analysis(
+            current_kpi_file=current_dir / "kpis.json",
+            historical_data_dir=historical_dir,
+            output_file=output_file,
+            plugin_module="nonexistent_plugin",
+        )
+
+        assert exit_code == 0
+        with open(output_file) as f:
+            report = yaml.safe_load(f)
+
+        assert report["tested"]["skipped"] == 1
+        assert report["tested"]["total_kpis"] == 1
+
+    def test_comparison_keys_separate_baselines(self, tmp_path):
+        """Records that differ on comparison_keys should still be matched."""
+        current_dir = tmp_path / "current"
+        historical_dir = tmp_path / "historical"
+        output_file = tmp_path / "report.yaml"
+
+        # Current: version=2.0 on platform=A100
+        current = _make_hierarchical_kpi(
+            [
+                _make_test_entry(
+                    "run",
+                    {"platform": "A100", "version": "2.0"},
+                    [
+                        _make_kpi("throughput", 100.0),
+                    ],
+                ),
+            ]
+        )
+        self._write_hierarchical_kpi(current_dir / "kpis.json", current)
+
+        # Baseline: version=1.0 on platform=A100 (different comparison key value)
+        baseline = _make_hierarchical_kpi(
+            [
+                _make_test_entry(
+                    "old",
+                    {"platform": "A100", "version": "1.0"},
+                    [
+                        _make_kpi("throughput", 95.0),
+                    ],
+                ),
+            ]
+        )
+        self._write_hierarchical_kpi(historical_dir / "run1" / "kpis.json", baseline)
+
+        # With version as comparison_key, both match on platform=A100
+        # (plugin would expose this config; here we test the core logic directly)
+        exit_code = run_kpi_analysis(
+            current_kpi_file=current_dir / "kpis.json",
+            historical_data_dir=historical_dir,
+            output_file=output_file,
+            plugin_module="nonexistent_plugin",
+        )
+
+        # Without plugin config, default AnalysisConfig has no comparison_keys,
+        # so version must also match → no baselines found → skip
+        assert exit_code == 0 or exit_code == 2
+        with open(output_file) as f:
+            report = yaml.safe_load(f)
+        # The version label differs, so with empty comparison_keys they don't match
+        assert report["tested"]["total_kpis"] == 0 or report["overall"]["verdict"] == "NO_BASELINE"


### PR DESCRIPTION
## Summary

- Replaces the stub `run_kpi_analysis` in `projects/caliper/engine/kpi/analyze.py` with a working regression analysis engine
- Matches current KPIs to historical baselines using configurable `comparison_keys` / `ignored_keys` on record labels
- Runs per-KPI regression tests with a relative threshold (default 10%), respecting `higher_is_better` directionality
- Produces a structured YAML report with `analysis`, `processed`, `tested`, `results`, and `overall` sections
- Plugins can expose an `analysis_config` dict or `get_analysis_config()` to customize keys and thresholds per-project
- Exit codes: 0=pass, 1=error, 2=no-baseline-warning, 3=regression-detected

## Design decisions

- **Generic** — no RHAIIS-specific concepts; works with any Caliper plugin's hierarchical KPI data (schema v2)
- **Label-based matching** — uses the same labels already attached to KPI records; comparison/ignored keys filter the match
- **Preserves orchestration interface** — `analyze_kpis()` and `run_analyze()` wrappers remain compatible with the existing CLI builder and `CaliperPostprocessOrchestrator`
- **YAML output** — human-readable report format (vs the prior JSON stub) with per-KPI verdicts and percentage changes

## Test plan

- [x] 15 unit tests covering match-key logic, baseline indexing, regression detection (both directions), mixed results, non-scalar skipping, and no-baseline warning path
- [ ] Integration test with rhaiis plugin KPI data against S3-imported historical baselines
- [ ] Validate YAML report format is consumable by downstream notification/dashboard tooling