### PR TITLE
Add .txt extension to FAILURE/FAILURES artifact files for MLflow preview

### DIFF
--- a/projects/cluster/toolbox/set_scale/main.py
+++ b/projects/cluster/toolbox/set_scale/main.py
@@ -431,7 +431,7 @@ def wait_for_compute_nodes_ready(args, ctx):
                 failure_content += f"**Parent:** machineset/{ctx.target_machineset}\n"
                 failure_content += f"**Error:** {detail['error']}\n\n"
 
-            failure_file = args.artifact_dir / "FAILURE"
+            failure_file = args.artifact_dir / "FAILURE.txt"
             with open(failure_file, "w") as f:
                 f.write(failure_content)
 

--- a/projects/core/agentic/artifact_processing.py
+++ b/projects/core/agentic/artifact_processing.py
@@ -144,7 +144,7 @@ def find_failure_files(base_artifact_dir: Path) -> list[Path]:
     """
     failure_files = []
 
-    for failure_file in base_artifact_dir.rglob("FAILURE"):
+    for failure_file in base_artifact_dir.rglob("FAILURE.txt"):
         if not failure_file.exists():
             continue
         if failure_file.parent == base_artifact_dir:
@@ -153,7 +153,7 @@ def find_failure_files(base_artifact_dir: Path) -> list[Path]:
         logger.debug(f"Found FAILURE file: {failure_file}")
 
     if not failure_files:
-        base_failure = base_artifact_dir / "FAILURE"
+        base_failure = base_artifact_dir / "FAILURE.txt"
         if base_failure.exists():
             failure_files.append(base_failure)
 

--- a/projects/core/agentic/on_failure/__init__.py
+++ b/projects/core/agentic/on_failure/__init__.py
@@ -427,7 +427,7 @@ def analyze_single_failure_multi_query(
         file_lower = file_path.lower()
 
         # Skip the main failure file and task.log as they're already included
-        if file_path.endswith("FAILURE") or file_path.endswith("task.log"):
+        if file_path.endswith("FAILURE.txt") or file_path.endswith("task.log"):
             continue
 
         if any(pattern in file_lower for pattern in high_priority_patterns):

--- a/projects/core/ci_entrypoint/prepare_ci.py
+++ b/projects/core/ci_entrypoint/prepare_ci.py
@@ -367,7 +367,7 @@ def system_prechecks() -> bool:
     artifact_path = Path(artifact_dir)
 
     # Check for existing failures
-    failures_file = artifact_path / "FAILURES"
+    failures_file = artifact_path / "FAILURES.txt"
     if failures_file.exists() and not os.environ.get("FORGE_IGNORE_FAILURES_FILE"):
         raise ValueError(
             f"File '{failures_file}' already exists, cannot continue. Set FORGE_IGNORE_FAILURES_FILE=1 to ignore this."
@@ -386,7 +386,7 @@ def system_prechecks() -> bool:
                 os.environ["FORGE_OPENSHIFT_CI_STEP_DIR"] = step_dir
 
     # Remove any old failure markers
-    old_failure = artifact_path / "FAILURE"
+    old_failure = artifact_path / "FAILURE.txt"
     if old_failure.exists():
         old_failure.unlink()
 
@@ -801,8 +801,8 @@ def postchecks(
         pass
     elif finish_reason == FinishReason.ERROR:
         # Find all FAILURE files and consolidate them
-        failure_files = list(artifact_path.glob("**/FAILURE"))
-        failures_file = artifact_path / "FAILURES"
+        failure_files = list(artifact_path.glob("**/FAILURE.txt"))
+        failures_file = artifact_path / "FAILURES.txt"
 
         with failures_file.open("w") as f:
             for failure_file in sorted(failure_files):
@@ -822,7 +822,7 @@ def postchecks(
     duration_str = generate_duration_and_timing_file(start_time, artifact_path)
 
     # Check if there were failures
-    failures_file = artifact_path / "FAILURES"
+    failures_file = artifact_path / "FAILURES.txt"
     if finish_reason != FinishReason.SUCCESS or (
         failures_file.exists() and failures_file.stat().st_size > 0
     ):

--- a/projects/core/dsl/runtime.py
+++ b/projects/core/dsl/runtime.py
@@ -665,7 +665,7 @@ def _generate_failure_file_for_agent(exception: Exception) -> None:
             logger.warning("No ARTIFACT_DIR available - cannot generate FAILURE file for agent")
             return
 
-        failure_file_path = artifact_dir / "FAILURE"
+        failure_file_path = artifact_dir / "FAILURE.txt"
 
         # Generate failure content
         failure_content = _format_failure_content_for_agent(exception)

--- a/projects/core/library/ci.py
+++ b/projects/core/library/ci.py
@@ -124,7 +124,7 @@ def _display_error_summary(e: Exception) -> None:
 
 def _write_error_summary_to_file(summary_lines: list) -> None:
     """Write the error summary to FAILURE file."""
-    failures_file = env.ARTIFACT_DIR / "FAILURE"
+    failures_file = env.ARTIFACT_DIR / "FAILURE.txt"
 
     try:
         content = "\n".join(summary_lines)

--- a/projects/core/notifications/send.py
+++ b/projects/core/notifications/send.py
@@ -214,7 +214,7 @@ def _get_notification_content(artifact_dir: pathlib.Path, get_link, get_bold) ->
         Formatted notification content string
     """
     notifications_dir = ci_lib.get_ci_metadata_dir() / "notifications"
-    failures_file = artifact_dir / "FAILURES"
+    failures_file = artifact_dir / "FAILURES.txt"
 
     # Guard: Check if notifications directory exists
     if not notifications_dir.exists():
@@ -279,7 +279,7 @@ def _get_notification_content(artifact_dir: pathlib.Path, get_link, get_bold) ->
     # Add link to FAILURES file if it exists (but don't include content)
     if failures_file.exists():
         content += f"""
-• {get_link("Raw failure details", "FAILURES", is_raw_file=True)}
+• {get_link("Raw failure details", "FAILURES.txt", is_raw_file=True)}
 """
 
     return content
@@ -318,7 +318,7 @@ def _get_fallback_failure_content(failures_file: pathlib.Path, get_link, get_bol
             head = DEFAULT_HEAD
 
         return f"""
-• {get_link("Failure indicator", "FAILURES", is_raw_file=True)}:
+• {get_link("Failure indicator", "FAILURES.txt", is_raw_file=True)}:
 ```
 {"".join(lines[:head])}
 {"[...]" if len(lines) > head else ""}

--- a/projects/guidellm/toolbox/run_guidellm_benchmark/main.py
+++ b/projects/guidellm/toolbox/run_guidellm_benchmark/main.py
@@ -260,7 +260,7 @@ def wait_guidellm_benchmark_task(args, ctx):
         return f"GuideLLM benchmark {ctx.benchmark_name} completed"
     if failed:
         # Write failure file
-        failure_file = args.artifact_dir / "FAILURE"
+        failure_file = args.artifact_dir / "FAILURE.txt"
         failure_message = f"""GuideLLM benchmark job '{ctx.benchmark_name}' failed.
 
 Check the job logs for detailed error information:

--- a/projects/legacy/library/ansible_toolbox.py
+++ b/projects/legacy/library/ansible_toolbox.py
@@ -397,7 +397,7 @@ class RunAnsibleRole:
 
             if ret != 0:
                 extra_dir_name = pathlib.Path(env["ARTIFACT_EXTRA_LOGS_DIR"]).name
-                with open(artifact_extra_logs_dir / "FAILURE", "a") as f:
+                with open(artifact_extra_logs_dir / "FAILURE.txt", "a") as f:
                     print(f"[{extra_dir_name}] {' '.join(sys.argv)} --> {ret}", file=f)
 
         raise SystemExit(ret)

--- a/projects/legacy/library/env.py
+++ b/projects/legacy/library/env.py
@@ -100,7 +100,7 @@ class TempArtifactDir:
 
         if ex_value:
             logging.error(f"Caught exception {ex_type.__name__}: {ex_value}")
-            with open(get_tls_artifact_dir() / "FAILURE", "a") as f:
+            with open(get_tls_artifact_dir() / "FAILURE.txt", "a") as f:
                 print(f"{ex_type.__name__}: {ex_value}", file=f)
                 print(
                     "".join(traceback.format_exception(None, value=ex_value, tb=exc_traceback)),

--- a/projects/matrix_benchmarking/library/matbenchmark.py
+++ b/projects/matrix_benchmarking/library/matbenchmark.py
@@ -126,7 +126,7 @@ def run_benchmark(args, dry_run=False):
     except Exception:
         msg = "MatrixBenchmark benchmark failed."
         logging.error(msg)
-        with open(env.ARTIFACT_DIR / "FAILURE", "w") as f:
+        with open(env.ARTIFACT_DIR / "FAILURE.txt", "w") as f:
             print(msg, file=f)
 
         return True  # failed

--- a/projects/matrix_benchmarking/library/visualize.py
+++ b/projects/matrix_benchmarking/library/visualize.py
@@ -328,7 +328,7 @@ def log_has_errors(log_file):
             if not has_errors:
                 continue
 
-            with open(env.ARTIFACT_DIR / "FAILURE", "a") as fail_f:
+            with open(env.ARTIFACT_DIR / "FAILURE.txt", "a") as fail_f:
                 print(line, end="", file=fail_f)
                 logging.error(line.strip())
 
@@ -389,7 +389,7 @@ def generate_visualization(
 
     if fatal_errors:
         msg = f"A fatal error happened during the results parsing, aborting the visualization ({', '.join(fatal_errors)})."
-        with open(env.ARTIFACT_DIR / "FAILURE", "w") as f:
+        with open(env.ARTIFACT_DIR / "FAILURE.txt", "w") as f:
             print(msg, file=f)
         logging.error(msg)
         raise RuntimeError(msg)
@@ -543,7 +543,7 @@ def generate_visualization(
         # if None, ignore
 
         logging.error(msg)
-        with open(env.ARTIFACT_DIR / "FAILURE", "w") as f:
+        with open(env.ARTIFACT_DIR / "FAILURE.txt", "w") as f:
             print(msg, file=f)
         raise RuntimeError(msg)
 

--- a/projects/matrix_benchmarking/subproject/matrix_benchmarking/analyze_lts.py
+++ b/projects/matrix_benchmarking/subproject/matrix_benchmarking/analyze_lts.py
@@ -99,7 +99,7 @@ def main(
 
             logging.info(f"The regression analyze finished with code {failures}.")
         except Exception as e:
-            with open(store_dir / "FAILURE", "a") as f:
+            with open(store_dir / "FAILURE.txt", "a") as f:
                 print(str(e), file=f)
                 import traceback
 


### PR DESCRIPTION
## Summary
- Renames `FAILURE` → `FAILURE.txt` and `FAILURES` → `FAILURES.txt` across the codebase
- MLflow cannot preview files without a recognized extension; this lets operators read failure details directly in the MLflow UI without downloading
- Purely mechanical rename, no logic changes

## Test plan
- [ ] Run a pipeline that produces a failure and verify the `FAILURE.txt` file is created and previewable in MLflow
- [ ] Verify `FAILURES.txt` consolidation still works in the CI entrypoint


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized failure report filenames to `FAILURE.txt` and `FAILURES.txt` across benchmark, CI, artifact, notification, and visualization workflows.
  * Updated failure detection, creation, prioritization, and notification links to consistently recognize the new `.txt` filenames.
  * Ensured failure details remain available when command execution, parsing, or report generation encounters an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->