### PR TITLE
Add rampup parameter to RHAIIS workload profiles

### DIFF
--- a/projects/rhaiis/orchestration/config.d/workloads.yaml
+++ b/projects/rhaiis/orchestration/config.d/workloads.yaml
@@ -7,20 +7,24 @@ profile1:
   data: "prompt_tokens=1000,output_tokens=1000"
   rates: [1,50,100,200,300]
   max_seconds: 450
+  rampup: 10
 
 profile2:
   data: "prompt_tokens=512,prompt_tokens_stdev=128,prompt_tokens_min=1,prompt_tokens_max=1024,output_tokens=2048,output_tokens_stdev=512,output_tokens_min=1,output_tokens_max=4096"
   rates: [1,50,100,200,300]
   max_seconds: 450
+  rampup: 10
 
 profile3:
   data: "prompt_tokens=2048,output_tokens=128"
   rates: [1, 50, 100, 200, 300]
   max_seconds: 450
+  rampup: 10
 
 profile4:
   data: "prompt_tokens=8000,output_tokens=1000"
   rates: [1,25,50,75,100]
   max_seconds: 450
+  rampup: 10
   samples: 50
 

--- a/projects/rhaiis/orchestration/runtime_config.py
+++ b/projects/rhaiis/orchestration/runtime_config.py
@@ -168,6 +168,7 @@ def build_guidellm_args(
     data: str,
     rates: list[int],
     max_seconds: int,
+    rampup: int | None = None,
 ) -> list[str]:
     guidellm_args = []
     for key, value in benchmark_cfg.get("args", {}).items():
@@ -178,6 +179,8 @@ def build_guidellm_args(
     guidellm_args.append(f"--data={data}")
     guidellm_args.append(f"--rate={_format_arg_value(rates)}")
     guidellm_args.append(f"--max-seconds={max_seconds}")
+    if rampup is not None:
+        guidellm_args.append(f"--rampup={rampup}")
     return guidellm_args
 
 

--- a/projects/rhaiis/orchestration/test_phase.py
+++ b/projects/rhaiis/orchestration/test_phase.py
@@ -394,6 +394,7 @@ def _run_workload_benchmark(
     workload = runtime_config.get_workload(workload_key)
     rates = workload.get("rates", [1])
     max_seconds = workload.get("max_seconds", 180)
+    rampup = workload.get("rampup")
 
     from projects.core.library import config
     from projects.guidellm.toolbox.run_guidellm_benchmark.main import (
@@ -443,6 +444,7 @@ def _run_workload_benchmark(
                 data=workload["data"],
                 rates=rates,
                 max_seconds=max_seconds,
+                rampup=rampup,
             )
 
             run_guidellm_benchmark(


### PR DESCRIPTION
## Summary
- Adds a `rampup` parameter to RHAIIS workload profiles in `workloads.yaml` (default: 10)
- Wires the parameter through `build_guidellm_args()` in `runtime_config.py` and the benchmark call in `test_phase.py`
- When set, appends `--rampup=<value>` to the GuideLLM CLI arguments

## Test plan
- [ ] Run a benchmark with `rampup` set and verify `--rampup=10` appears in the GuideLLM job args
- [ ] Run a benchmark with `rampup` overridden via `configOverrides` and verify the override takes effect


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable ramp-up behavior for benchmark workloads.
  * Included a default ramp-up setting across the standard workload profiles.
  * Benchmark runs now pass ramp-up configuration to the underlying benchmarking tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->