### PR TITLE
[rhaiis] Add presets for benchmark, cluster, and model aliases

### DIFF
--- a/projects/rhaiis/orchestration/config.d/rhaiis.yaml
+++ b/projects/rhaiis/orchestration/config.d/rhaiis.yaml
@@ -7,10 +7,6 @@ gpu_types:
   amd: mi300x
   l40s: l40s
 
-images:
-  nvidia: quay.io/aipcc/rhaiis/cuda-ubi9:3.4.0-ea.2-1773886296
-  amd: quay.io/aipcc/rhaiis/rocm-ubi9:3.2.5-1766067105
-
 engine: vllm
 
 engines:
@@ -94,4 +90,4 @@ profiler:
 agent_analysis:
   enabled: false
   severity_threshold: 10
-  url: "http://agent-gateway.psap-ai-analysis-agent-gateway.svc.cluster.local:8443/v1/stream"
+  url: ""

--- a/projects/rhaiis/orchestration/config.d/workloads.yaml
+++ b/projects/rhaiis/orchestration/config.d/workloads.yaml
@@ -1,5 +1,5 @@
 ci-quick:
-  data: "prompt_tokens=256,output_tokens=128"
+  data: "prompt_tokens=1000,output_tokens=1000"
   rates: [1, 5]
   max_seconds: 60
 

--- a/projects/rhaiis/orchestration/config.yaml
+++ b/projects/rhaiis/orchestration/config.yaml
@@ -12,6 +12,7 @@ benchmarks:
     timeout: 14400
     pvc_size: 10Gi
     hf_token_secret: "storage-config"
+    fs_group: null
     args:
       backend_type: openai_http
       rate_type: concurrent
@@ -28,6 +29,7 @@ tests:
     version: ""
     compare_version: ""
     slack_user: ""
+    slack_notify_always: false
 
 caliper:
   postprocess:

--- a/projects/rhaiis/orchestration/presets.d/benchmarks.yaml
+++ b/projects/rhaiis/orchestration/presets.d/benchmarks.yaml
@@ -1,0 +1,8 @@
+__multiple: true
+
+benchmark:
+  tests.rhaiis.run_benchmark: true
+  tests.rhaiis.slack_notify_always: true
+  rhaiis.profiler.enabled: true
+  caliper.postprocess.csv_dashboard.enabled: true
+  rhaiis.agent_analysis.enabled: false

--- a/projects/rhaiis/orchestration/presets.d/clusters.yaml
+++ b/projects/rhaiis/orchestration/presets.d/clusters.yaml
@@ -1,0 +1,11 @@
+__multiple: true
+
+hera:
+  rhaiis.cluster_tag: "hera2"
+  rhaiis.deploy.image_pull_secrets: ["npalaska-image-pull"]
+  benchmarks.guidellm.fs_group: 0
+
+zeus:
+  rhaiis.cluster_tag: "zeus2"
+  rhaiis.deploy.image_pull_secrets: ["npalaska-image-pull"]
+  benchmarks.guidellm.fs_group: 0

--- a/projects/rhaiis/orchestration/presets.d/mehulvalidation.yaml
+++ b/projects/rhaiis/orchestration/presets.d/mehulvalidation.yaml
@@ -1,3 +1,0 @@
-rhaiis.namespace: kserve-e2e-perf
-rhaiis.deploy.image_pull_secret: npalaska-image-pull
-rhaiis.deploy.service_account_name: sa

--- a/projects/rhaiis/orchestration/presets.d/presets.yaml
+++ b/projects/rhaiis/orchestration/presets.d/presets.yaml
@@ -1,62 +1,36 @@
 __multiple: true
 
-# Llama 3.1 8B
-llama-8b:
-  tests.rhaiis.model_key: llama-3-1-8b-fp8
+# ── Accelerator ──────────────────────────────────────────────
 
-# Llama 3.3 70B
-llama-70b:
-  tests.rhaiis.model_key: llama-3-3-70b-fp8
+nvidia:
+  rhaiis.accelerator: nvidia
 
-# Llama 3.1 405B
-llama-405b:
-  tests.rhaiis.model_key: llama-3-1-405b-fp8
+amd:
+  rhaiis.accelerator: amd
 
-# Llama 4 Scout
-llama-4-scout:
-  tests.rhaiis.model_key: llama-4-scout-fp8
+# ── Engine ───────────────────────────────────────────────────
 
-# Llama 4 Maverick
-llama-4-maverick:
-  tests.rhaiis.model_key: llama-4-maverick-fp8
+vllm:
+  rhaiis.engine: vllm
 
-# Granite 8B
-granite-8b:
-  tests.rhaiis.model_key: granite-3-1-8b-fp8
+sglang:
+  rhaiis.engine: sglang
 
-# Mistral Small 3.1
-mistral-24b:
-  tests.rhaiis.model_key: mistral-2503-fp8
+trtllm:
+  rhaiis.engine: trtllm
 
-# Phi 4
-phi-4:
-  tests.rhaiis.model_key: phi-4-fp8
+# ── Workload profiles ───────────────────────────────────────
 
-# Qwen 2.5 7B
-qwen25-7b:
-  tests.rhaiis.model_key: qwen25-7b-fp8
-
-# Qwen3 235B
-qwen3-235b:
-  tests.rhaiis.model_key: qwen3-235b-instruct-fp8
-
-# DeepSeek R1
-deepseek-r1:
-  tests.rhaiis.model_key: deepseek-r1-0528
-
-# DeepSeek V3.2
-deepseek-v3:
-  tests.rhaiis.model_key: deepseek-v3-2
-
-# GPT-OSS 120B
-gpt-oss:
-  tests.rhaiis.model_key: gpt-oss-120b-fp8
-
-# CI quick validation
 ci-quick:
   tests.rhaiis.workload_key: ci-quick
+  tests.rhaiis.model_key: qwen3-0_6b
+  tests.rhaiis.warmup: false
+  tests.rhaiis.version: "vLLM-0.24.0-ci-test"
+  rhaiis.profiler.enabled: false
+  caliper.postprocess.csv_dashboard.enabled: false
+  tests.rhaiis.slack_notify_always: true
+  rhaiis.agent_analysis.enabled: false
 
-# Workload profiles
 profile1:
   tests.rhaiis.workload_key: profile1
 
@@ -69,19 +43,193 @@ profile3:
 profile4:
   tests.rhaiis.workload_key: profile4
 
-# Accelerator
-nvidia:
-  rhaiis.accelerator: nvidia
+# ── Models ──────────────────────────────────────────────────
+# Short aliases default to the FP8 variant where available.
+# Use the full name (e.g. llama-70b-w4a16) for other quants.
 
-amd:
-  rhaiis.accelerator: amd
+# Validation model
+qwen3-0.6b:
+  tests.rhaiis.model_key: qwen3-0_6b
 
-# Engine
-vllm:
-  rhaiis.engine: vllm
+# Llama 3.1 8B
+llama-8b:
+  tests.rhaiis.model_key: llama-3-1-8b
 
-sglang:
-  rhaiis.engine: sglang
+# Llama 3.3 70B
+llama-70b:
+  tests.rhaiis.model_key: llama-3-3-70b-fp8
 
-trtllm:
-  rhaiis.engine: trtllm
+llama-70b-bf16:
+  tests.rhaiis.model_key: llama-3-3-70b
+
+llama-70b-w8a8:
+  tests.rhaiis.model_key: llama-3-3-70b-w8a8
+
+llama-70b-w4a16:
+  tests.rhaiis.model_key: llama-3-3-70b-w4a16
+
+# Llama 3.1 405B
+llama-405b:
+  tests.rhaiis.model_key: llama-3-1-405b-fp8
+
+# Llama 4 Scout (MoE)
+llama-4-scout:
+  tests.rhaiis.model_key: llama-4-scout-fp8
+
+llama-4-scout-bf16:
+  tests.rhaiis.model_key: llama-4-scout
+
+llama-4-scout-int4:
+  tests.rhaiis.model_key: llama-4-scout-int4
+
+# Llama 4 Maverick (MoE)
+llama-4-maverick:
+  tests.rhaiis.model_key: llama-4-maverick-fp8
+
+llama-4-maverick-bf16:
+  tests.rhaiis.model_key: llama-4-maverick
+
+llama-4-maverick-w4a16:
+  tests.rhaiis.model_key: llama-4-maverick-w4a16
+
+# Granite 3.1 8B
+granite-8b:
+  tests.rhaiis.model_key: granite-3-1-8b-fp8
+
+granite-8b-bf16:
+  tests.rhaiis.model_key: granite-3-1-8b-instruct
+
+granite-8b-w4a16:
+  tests.rhaiis.model_key: granite-3-1-8b-w4a16
+
+granite-8b-w8a8:
+  tests.rhaiis.model_key: granite-3-1-8b-w8a8
+
+# Mistral Small 3.1 24B
+mistral-24b:
+  tests.rhaiis.model_key: mistral-2503-fp8
+
+mistral-24b-bf16:
+  tests.rhaiis.model_key: mistral-2503
+
+mistral-24b-w4a16:
+  tests.rhaiis.model_key: mistral-2503-w4a16
+
+mistral-24b-w8a8:
+  tests.rhaiis.model_key: mistral-2503-w8a8
+
+# Mistral 7B
+mistral-7b:
+  tests.rhaiis.model_key: mistral-7b
+
+# Ministral 3 14B
+ministral-14b:
+  tests.rhaiis.model_key: ministral-3-14b-fp8
+
+ministral-14b-bf16:
+  tests.rhaiis.model_key: ministral-3-14b-fp16
+
+ministral-14b-reasoning:
+  tests.rhaiis.model_key: ministral-3-14b-reasoning
+
+# Phi 4
+phi-4:
+  tests.rhaiis.model_key: phi-4-fp8
+
+# Qwen 2.5 7B
+qwen25-7b:
+  tests.rhaiis.model_key: qwen25-7b-fp8
+
+qwen25-7b-bf16:
+  tests.rhaiis.model_key: qwen25-7b-instruct
+
+qwen25-7b-w8a8:
+  tests.rhaiis.model_key: qwen25-7b-w8a8
+
+qwen25-7b-w4a16:
+  tests.rhaiis.model_key: qwen25-7b-w4a16
+
+# Qwen3 235B (MoE)
+qwen3-235b:
+  tests.rhaiis.model_key: qwen3-235b-instruct-fp8
+
+qwen3-235b-bf16:
+  tests.rhaiis.model_key: qwen3-235b-instruct
+
+qwen3-235b-fp8-dynamic:
+  tests.rhaiis.model_key: qwen3-235b-fp8-dynamic
+
+# Qwen3 30B (MoE)
+qwen3-30b:
+  tests.rhaiis.model_key: qwen3-30b-a3b-instruct
+
+qwen3-30b-a3b:
+  tests.rhaiis.model_key: qwen3-30b-a3b
+
+# Qwen3 80B (MoE)
+qwen3-80b:
+  tests.rhaiis.model_key: qwen3-n-80b-a3b-instruct
+
+# Qwen3 VL
+qwen3-vl-235b:
+  tests.rhaiis.model_key: qwen3-vl-235b-fp8
+
+qwen3-vl-30b:
+  tests.rhaiis.model_key: qwen3-vl-30b-a3b
+
+# GPT-OSS
+gpt-oss:
+  tests.rhaiis.model_key: gpt-oss-120b-fp8
+
+gpt-oss-bf16:
+  tests.rhaiis.model_key: gpt-oss-120b
+
+gpt-oss-20b:
+  tests.rhaiis.model_key: gpt-oss-20b
+
+# Nemotron 3.1 70B
+nemotron-70b:
+  tests.rhaiis.model_key: nemotron-3-1-70b
+
+nemotron-70b-fp8:
+  tests.rhaiis.model_key: nemotron-3-1-70b-fp8
+
+# Nemotron 3 Nano 30B (MoE)
+nemotron3nano-30b:
+  tests.rhaiis.model_key: nemotron3nano-30b
+
+nemotron3nano-30b-fp8:
+  tests.rhaiis.model_key: nemotron3nano-30b-fp8
+
+# Nemotron 3 Super 120B (MoE)
+nemotron3super-120b:
+  tests.rhaiis.model_key: nemotron3super-120b-fp8
+
+# Mixtral 8x7B
+mixtral:
+  tests.rhaiis.model_key: mixtral-8x7b
+
+# Gemma 2 9B
+gemma-9b:
+  tests.rhaiis.model_key: gemma-9b-fp8
+
+gemma-9b-bf16:
+  tests.rhaiis.model_key: gemma-9b
+
+gemma-9b-w8a16:
+  tests.rhaiis.model_key: gemma-9b-w8a16
+
+# DeepSeek R1
+deepseek-r1:
+  tests.rhaiis.model_key: deepseek-r1-0528
+
+deepseek-r1-w4a16:
+  tests.rhaiis.model_key: deepseek-r1-0528-w4a16
+
+# DeepSeek V3.2
+deepseek-v3:
+  tests.rhaiis.model_key: deepseek-v3-2
+
+# DeepSeek V4 Pro
+deepseek-v4-pro:
+  tests.rhaiis.model_key: deepseek-v4-pro


### PR DESCRIPTION
## Summary
- Add `benchmarks.yaml` preset with common benchmark settings (run_benchmark, profiler, dashboard, agent_analysis, slack_notify_always)
- Add `clusters.yaml` preset with hera/zeus cluster configs (cluster_tag, image_pull_secrets, fs_group)
- Expand `presets.yaml` model aliases to cover all models in `models.yaml`, with short names defaulting to FP8 variants and quantization suffixes for other variants
- Add `ci-quick` composite preset (qwen3-0.6b, TP=1, warmup off, dashboard off) for fast validation runs
- Remove unused top-level `images` fallback from `rhaiis.yaml` since all engines define their own images
- Delete stale `mehulvalidation.yaml` preset

## Test plan
- [ ] Run a CI-quick validation job using `args: [nvidia, benchmark, hera, ci-quick]` and verify the correct config is applied
- [ ] Run a benchmark job using `args: [nvidia, benchmark, hera, nemotron3super-120b]` and verify it matches previous behavior


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added benchmark configuration with profiling, dashboard export, notifications, and agent-analysis controls.
  - Added multi-cluster configuration for Hera and Zeus environments.
  - Expanded available model, accelerator, engine, workload, and quantization presets.
  - Added new Qwen3 and DeepSeek V4 Pro model options.

- **Updates**
  - Increased `ci-quick` workload token limits.
  - Enhanced `ci-quick` with runtime, profiling, dashboard, notification, and model settings.
  - Updated the Llama 8B preset to use the standard model variant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->