### PR TITLE
[rhaiis] Rename engine_args to vllm_args and add explicit TP to all models

### DIFF
--- a/projects/caliper/tests/test_kpi_analyze.py
+++ b/projects/caliper/tests/test_kpi_analyze.py
@@ -197,7 +197,7 @@ class TestEndToEnd:
         self._write_hierarchical_kpi(historical_dir / "run1" / "kpis.json", baseline1)
         self._write_hierarchical_kpi(historical_dir / "run2" / "kpis.json", baseline2)
 
-        test_status = run_kpi_analysis(
+        test_status, _ = run_kpi_analysis(
             current_kpi_file=current_dir / "kpis.json",
             historical_data_dir=historical_dir,
             output_file=output_file,
@@ -247,7 +247,7 @@ class TestEndToEnd:
         )
         self._write_hierarchical_kpi(historical_dir / "run1" / "kpis.json", baseline)
 
-        test_status = run_kpi_analysis(
+        test_status, _ = run_kpi_analysis(
             current_kpi_file=current_dir / "kpis.json",
             historical_data_dir=historical_dir,
             output_file=output_file,
@@ -282,7 +282,7 @@ class TestEndToEnd:
         )
         self._write_hierarchical_kpi(current_dir / "kpis.json", current)
 
-        test_status = run_kpi_analysis(
+        test_status, _ = run_kpi_analysis(
             current_kpi_file=current_dir / "kpis.json",
             historical_data_dir=historical_dir,
             output_file=output_file,
@@ -327,7 +327,7 @@ class TestEndToEnd:
         )
         self._write_hierarchical_kpi(historical_dir / "run1" / "kpis.json", baseline)
 
-        test_status = run_kpi_analysis(
+        test_status, _ = run_kpi_analysis(
             current_kpi_file=current_dir / "kpis.json",
             historical_data_dir=historical_dir,
             output_file=output_file,
@@ -376,7 +376,7 @@ class TestEndToEnd:
         )
         self._write_hierarchical_kpi(historical_dir / "run1" / "kpis.json", baseline)
 
-        test_status = run_kpi_analysis(
+        test_status, _ = run_kpi_analysis(
             current_kpi_file=current_dir / "kpis.json",
             historical_data_dir=historical_dir,
             output_file=output_file,
@@ -426,7 +426,7 @@ class TestEndToEnd:
 
         # With version as comparison_key, both match on platform=A100
         # (plugin would expose this config; here we test the core logic directly)
-        test_status = run_kpi_analysis(
+        test_status, _ = run_kpi_analysis(
             current_kpi_file=current_dir / "kpis.json",
             historical_data_dir=historical_dir,
             output_file=output_file,

--- a/projects/rhaiis/README.md
+++ b/projects/rhaiis/README.md
@@ -70,7 +70,7 @@ Key sections:
 | `rhaiis.deploy` | Deploy settings (replicas, CPU/memory, image_pull_secrets list, storage) |
 | `rhaiis.s3` | S3 bucket, vault, and credentials for dashboard CSV and profiler trace uploads |
 | `rhaiis.profiler` | PyTorch profiler settings (enable, S3 prefix, rates, labels) |
-| `models` | Model definitions (hf_model_id, per-model `engine_args` overrides) |
+| `models` | Model definitions (hf_model_id, per-model `vllm_args` overrides) |
 | `workloads` | Benchmark profiles (data shape, rates, max_seconds) |
 | `benchmarks.guidellm` | GuideLLM image, backend, timeout, PVC size, HF token secret, fs_group |
 | `tests` | CI test mapping (model_key, workload_keys, version) |
@@ -86,12 +86,12 @@ rhaiis supports three inference engines via a generic abstraction:
 | SGLang | `rhaiis.engine: sglang` | `rhaiis.engines.sglang.images` | `tp-size` | No root required, uses `sglang serve` entrypoint |
 | TRT-LLM | `rhaiis.engine: trtllm` | `rhaiis.engines.trtllm.images` | `tp_size` | Requires root (`anyuid` SCC), NGC pull secret |
 
-Models define `engine_args` with vLLM-style keys (e.g. `tensor-parallel-size`).
+Models define `vllm_args` with vLLM-style keys (e.g. `tensor-parallel-size`).
 When running with SGLang or TRT-LLM, arguments are automatically translated
 (e.g. `tensor-parallel-size` → `tp-size` for SGLang, `tp_size` for TRT-LLM).
 
 Engine-specific args can also be set directly via `rhaiis.engines.<engine>.args.*`
-in FournosJob `configOverrides`, which take precedence over model-level `engine_args`.
+in FournosJob `configOverrides`, which take precedence over model-level `vllm_args`.
 
 TRT-LLM additionally supports a `trtllm_config` block for server-side configuration
 (KV cache, CUDA graphs, MoE backend, etc.) that is serialized as a JSON config file

--- a/projects/rhaiis/orchestration/analysis.py
+++ b/projects/rhaiis/orchestration/analysis.py
@@ -182,6 +182,7 @@ def run_regression_check(
                     compare_version,
                     run_uuid,
                     severity_threshold=agent_cfg.get("severity_threshold", 10),
+                    engine_args=engine_args,
                 )
 
             from projects.rhaiis.postprocess.regression import send_regression_notification
@@ -228,6 +229,7 @@ def run_agent_analysis(
     run_uuid: str,
     *,
     severity_threshold: int = 10,
+    engine_args: dict | None = None,
 ) -> str:
     """Request AI agent analysis for severe regressions. Returns report URL or empty string."""
     from projects.core.library import config
@@ -257,7 +259,7 @@ def run_agent_analysis(
         logger.warning("Agent not reachable, skipping analysis: %s", detail)
         return ""
 
-    ea = model_cfg.get("vllm_args", {})
+    ea = engine_args or {}
     tp = str(ea.get("tensor-parallel-size") or ea.get("tp-size") or ea.get("tp_size") or 1)
     model = model_cfg.get("hf_model_id", "")
     improvements = analysis.get("improvements", [])

--- a/projects/rhaiis/orchestration/analysis.py
+++ b/projects/rhaiis/orchestration/analysis.py
@@ -257,7 +257,7 @@ def run_agent_analysis(
         logger.warning("Agent not reachable, skipping analysis: %s", detail)
         return ""
 
-    ea = model_cfg.get("engine_args", {})
+    ea = model_cfg.get("vllm_args", {})
     tp = str(ea.get("tensor-parallel-size") or ea.get("tp-size") or ea.get("tp_size") or 1)
     model = model_cfg.get("hf_model_id", "")
     improvements = analysis.get("improvements", [])

--- a/projects/rhaiis/orchestration/ci.py
+++ b/projects/rhaiis/orchestration/ci.py
@@ -95,9 +95,13 @@ def resolve_hardware_request(hardware_spec: dict) -> dict:
     if hardware_spec.get("gpuType"):
         return hardware_spec
 
+    from projects.core.library import config as _cfg
+
     model_key = runtime_config.get_test_model_key()
     model = runtime_config.get_model(model_key)
-    ea = model.get("vllm_args", {})
+    engine = runtime_config.get_engine()
+    engine_defaults = _cfg.project.get_config(f"rhaiis.engines.{engine}.args") or {}
+    ea = runtime_config.merge_engine_args(engine_defaults, model, {}, engine)
     tp_size = int(ea.get("tensor-parallel-size") or ea.get("tp-size") or ea.get("tp_size") or 1)
 
     accelerator = runtime_config.get_accelerator()

--- a/projects/rhaiis/orchestration/ci.py
+++ b/projects/rhaiis/orchestration/ci.py
@@ -97,7 +97,7 @@ def resolve_hardware_request(hardware_spec: dict) -> dict:
 
     model_key = runtime_config.get_test_model_key()
     model = runtime_config.get_model(model_key)
-    ea = model.get("engine_args", {})
+    ea = model.get("vllm_args", {})
     tp_size = int(ea.get("tensor-parallel-size") or ea.get("tp-size") or ea.get("tp_size") or 1)
 
     accelerator = runtime_config.get_accelerator()

--- a/projects/rhaiis/orchestration/config.d/models.yaml
+++ b/projects/rhaiis/orchestration/config.d/models.yaml
@@ -315,6 +315,14 @@ nemotron3super-120b-fp8:
   hf_model_id: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8
   vllm_args:
     tensor-parallel-size: 2
+  sglang_args:
+    tp-size: 2
+    disable-radix-cache: true
+    max-running-requests: 512
+    cuda-graph-max-bs: 512
+    mem-fraction-static: 0.90
+    context-length: 8192
+    trust-remote-code: true
 
 # Ministral
 ministral-3-14b-reasoning:

--- a/projects/rhaiis/orchestration/config.d/models.yaml
+++ b/projects/rhaiis/orchestration/config.d/models.yaml
@@ -2,46 +2,47 @@
 qwen3-0_6b:
   name: Qwen3-0.6B
   hf_model_id: Qwen/Qwen3-0.6B
-  engine_args: {}
+  vllm_args:
+    tensor-parallel-size: 1
 
 # Llama-4 Scout (MoE)
 llama-4-scout:
   name: Llama-4-Scout-17B-16E-Instruct
   hf_model_id: meta-llama/Llama-4-Scout-17B-16E-Instruct
-  engine_args:
+  vllm_args:
     tensor-parallel-size: 4
 
 llama-4-scout-fp8:
   name: Llama-4-Scout-17B-16E-Instruct-FP8
   hf_model_id: RedHatAI/Llama-4-Scout-17B-16E-Instruct-FP8-dynamic
-  engine_args:
+  vllm_args:
     tensor-parallel-size: 2
     kv-cache-dtype: fp8
 
 llama-4-scout-int4:
   name: Llama-4-Scout-17B-16E-Instruct-INT4
   hf_model_id: RedHatAI/Llama-4-Scout-17B-16E-Instruct-quantized.w4a16
-  engine_args:
+  vllm_args:
     tensor-parallel-size: 2
 
 # Llama-4 Maverick (MoE)
 llama-4-maverick:
   name: Llama-4-Maverick-17B-128E-Instruct
   hf_model_id: meta-llama/Llama-4-Maverick-17B-128E-Instruct
-  engine_args:
+  vllm_args:
     tensor-parallel-size: 8
 
 llama-4-maverick-fp8:
   name: Llama-4-Maverick-17B-128E-Instruct-FP8
   hf_model_id: RedHatAI/Llama-4-Maverick-17B-128E-Instruct-FP8
-  engine_args:
+  vllm_args:
     tensor-parallel-size: 8
     kv-cache-dtype: fp8
 
 llama-4-maverick-w4a16:
   name: Llama-4-Maverick-17B-128E-Instruct-W4A16
   hf_model_id: RedHatAI/Llama-4-Maverick-17B-128E-Instruct-quantized.w4a16
-  engine_args:
+  vllm_args:
     tensor-parallel-size: 8
     enable-expert-parallel: true
 
@@ -49,99 +50,125 @@ llama-4-maverick-w4a16:
 mistral-2503:
   name: Mistral-Small-3.1-24B-Instruct-2503
   hf_model_id: mistralai/Mistral-Small-3.1-24B-Instruct-2503
+  vllm_args:
+    tensor-parallel-size: 1
 
 mistral-2503-w4a16:
   name: Mistral-Small-3.1-24B-W4A16
   hf_model_id: RedHatAI/Mistral-Small-3.1-24B-Instruct-2503-quantized.w4a16
+  vllm_args:
+    tensor-parallel-size: 1
 
 mistral-2503-w8a8:
   name: Mistral-Small-3.1-24B-W8A8
   hf_model_id: RedHatAI/Mistral-Small-3.1-24B-Instruct-2503-quantized.w8a8
+  vllm_args:
+    tensor-parallel-size: 1
 
 mistral-2503-fp8:
   name: Mistral-Small-3.1-24B-FP8
   hf_model_id: RedHatAI/Mistral-Small-3.1-24B-Instruct-2503-FP8-dynamic
+  vllm_args:
+    tensor-parallel-size: 1
 
 # Llama-3.3-70B
 llama-3-3-70b:
   name: Llama-3.3-70B-Instruct
   hf_model_id: meta-llama/Llama-3.3-70B-Instruct
-  engine_args:
+  vllm_args:
     tensor-parallel-size: 4
 
 llama-3-3-70b-fp8:
   name: Llama-3.3-70B-Instruct-FP8
   hf_model_id: RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic
-  engine_args:
+  vllm_args:
     tensor-parallel-size: 4
 
 llama-3-3-70b-w8a8:
   name: Llama-3.3-70B-Instruct-W8A8
   hf_model_id: RedHatAI/Llama-3.3-70B-Instruct-quantized.w8a8
-  engine_args:
+  vllm_args:
     tensor-parallel-size: 4
 
 llama-3-3-70b-w4a16:
   name: Llama-3.3-70B-Instruct-W4A16
   hf_model_id: RedHatAI/Llama-3.3-70B-Instruct-quantized.w4a16
-  engine_args:
+  vllm_args:
     tensor-parallel-size: 4
 
 # Granite 3.1 8B
 granite-3-1-8b-instruct:
   name: Granite-3.1-8B-Instruct
   hf_model_id: ibm-granite/granite-3.1-8b-instruct
+  vllm_args:
+    tensor-parallel-size: 1
 
 granite-3-1-8b-fp8:
   name: Granite-3.1-8B-FP8
   hf_model_id: RedHatAI/granite-3.1-8b-instruct-fp8-dynamic
+  vllm_args:
+    tensor-parallel-size: 1
 
 granite-3-1-8b-w4a16:
   name: Granite-3.1-8B-W4A16
   hf_model_id: RedHatAI/granite-3.1-8b-instruct-quantized.w4a16
+  vllm_args:
+    tensor-parallel-size: 1
 
 granite-3-1-8b-w8a8:
   name: Granite-3.1-8B-W8A8
   hf_model_id: RedHatAI/granite-3.1-8b-instruct-quantized.w8a8
+  vllm_args:
+    tensor-parallel-size: 1
 
 # Qwen 2.5 7B
 qwen25-7b-instruct:
   name: Qwen2.5-7B-Instruct
   hf_model_id: Qwen/Qwen2.5-7B-Instruct
+  vllm_args:
+    tensor-parallel-size: 1
 
 qwen25-7b-fp8:
   name: Qwen2.5-7B-FP8
   hf_model_id: RedHatAI/Qwen2.5-7B-Instruct-FP8-dynamic
+  vllm_args:
+    tensor-parallel-size: 1
 
 qwen25-7b-w8a8:
   name: Qwen2.5-7B-W8A8
   hf_model_id: RedHatAI/Qwen2.5-7B-Instruct-quantized.w8a8
+  vllm_args:
+    tensor-parallel-size: 1
 
 qwen25-7b-w4a16:
   name: Qwen2.5-7B-W4A16
   hf_model_id: RedHatAI/Qwen2.5-7B-Instruct-quantized.w4a16
+  vllm_args:
+    tensor-parallel-size: 1
 
 # Qwen3 models
 qwen3-n-80b-a3b-instruct:
   name: Qwen3-Next-80B-A3B-Instruct
   hf_model_id: Qwen/Qwen3-Next-80B-A3B-Instruct
-  engine_args:
+  vllm_args:
     tensor-parallel-size: 4
 
 qwen3-30b-a3b-instruct:
   name: Qwen3-30B-A3B-Instruct
   hf_model_id: Qwen/Qwen3-30B-A3B-Instruct-2507
+  vllm_args:
+    tensor-parallel-size: 1
 
 qwen3-30b-a3b:
   name: Qwen3-30B-A3B
   hf_model_id: Qwen/Qwen3-30B-A3B
-  engine_args:
+  vllm_args:
     tensor-parallel-size: 4
 
 qwen3-235b-instruct:
   name: Qwen3-235B-A22B-Instruct
   hf_model_id: Qwen/Qwen3-235B-A22B-Instruct-2507
-  engine_args:
+  vllm_args:
     tensor-parallel-size: 4
   env_vars:
     VLLM_ROCM_USE_AITER: "0"
@@ -149,7 +176,7 @@ qwen3-235b-instruct:
 qwen3-235b-instruct-fp8:
   name: Qwen3-235B-A22B-Instruct-FP8
   hf_model_id: Qwen/Qwen3-235B-A22B-Instruct-2507-FP8
-  engine_args:
+  vllm_args:
     tensor-parallel-size: 4
     enable-expert-parallel: true
     kv-cache-dtype: fp8
@@ -157,131 +184,153 @@ qwen3-235b-instruct-fp8:
 qwen3-235b-fp8-dynamic:
   name: Qwen3-235B-A22B-FP8-dynamic
   hf_model_id: RedHatAI/Qwen3-235B-A22B-FP8-dynamic
-  engine_args:
+  vllm_args:
     tensor-parallel-size: 4
     enable-expert-parallel: true
 
 qwen3-vl-235b-fp8:
   name: Qwen3-VL-235B-A22B-FP8
   hf_model_id: Qwen/Qwen3-VL-235B-A22B-Instruct-FP8
-  engine_args:
+  vllm_args:
     tensor-parallel-size: 4
 
 qwen3-vl-30b-a3b:
   name: Qwen3-VL-30B-A3B-Instruct
   hf_model_id: Qwen/Qwen3-VL-30B-A3B-Instruct
-  engine_args:
+  vllm_args:
     tensor-parallel-size: 4
 
 # GPT-OSS
 gpt-oss-120b:
   name: GPT-OSS-120B
   hf_model_id: openai/gpt-oss-120b
+  vllm_args:
+    tensor-parallel-size: 1
 
 gpt-oss-20b:
   name: GPT-OSS-20B
   hf_model_id: openai/gpt-oss-20b
+  vllm_args:
+    tensor-parallel-size: 1
 
 gpt-oss-120b-fp8:
   name: GPT-OSS-120B-FP8
   hf_model_id: RedHatAI/gpt-oss-120b-FP8-dynamic
+  vllm_args:
+    tensor-parallel-size: 1
 
 # Llama-3.1-8B
 llama-3-1-8b:
   name: Llama-3.1-8B-Instruct
   hf_model_id: meta-llama/Llama-3.1-8B-Instruct
+  vllm_args:
+    tensor-parallel-size: 1
 
 # Mixtral
 mixtral-8x7b:
   name: Mixtral-8x7B-Instruct
   hf_model_id: mistralai/Mixtral-8x7B-Instruct-v0.1
+  vllm_args:
+    tensor-parallel-size: 1
 
 # Nemotron
 nemotron-3-1-70b:
   name: Nemotron-70B-Instruct
   hf_model_id: nvidia/Llama-3.1-Nemotron-70B-Instruct-HF
-  engine_args:
+  vllm_args:
     tensor-parallel-size: 2
 
 nemotron-3-1-70b-fp8:
   name: Nemotron-70B-Instruct-FP8
   hf_model_id: RedHatAI/Llama-3.1-Nemotron-70B-Instruct-HF-FP8-dynamic
+  vllm_args:
+    tensor-parallel-size: 1
 
 # Gemma 2
 gemma-9b:
   name: Gemma-2-9B-IT
   hf_model_id: google/gemma-2-9b-it
+  vllm_args:
+    tensor-parallel-size: 1
 
 gemma-9b-fp8:
   name: Gemma-2-9B-IT-FP8
   hf_model_id: RedHatAI/gemma-2-9b-it-FP8
+  vllm_args:
+    tensor-parallel-size: 1
 
 gemma-9b-w8a16:
   name: Gemma-2-9B-IT-W8A16
   hf_model_id: RedHatAI/gemma-2-9b-it-quantized.w8a16
+  vllm_args:
+    tensor-parallel-size: 1
 
 # DeepSeek
 deepseek-v4-pro:
   name: DeepSeek-V4-Pro
   hf_model_id: deepseek-ai/DeepSeek-V4-Pro
-  engine_args:
+  vllm_args:
     tensor-parallel-size: 8
 
 deepseek-r1-0528:
   name: DeepSeek-R1-0528
   hf_model_id: deepseek-ai/DeepSeek-R1-0528
-  engine_args:
+  vllm_args:
     tensor-parallel-size: 8
 
 deepseek-r1-0528-w4a16:
   name: DeepSeek-R1-0528-W4A16
   hf_model_id: RedHatAI/DeepSeek-R1-0528-quantized.w4a16
-  engine_args:
+  vllm_args:
     tensor-parallel-size: 8
 
 deepseek-v3-2:
   name: DeepSeek-V3.2
   hf_model_id: deepseek-ai/DeepSeek-V3.2
-  engine_args:
+  vllm_args:
     tensor-parallel-size: 8
 
 # Mistral 7B
 mistral-7b:
   name: Mistral-7B-Instruct
   hf_model_id: mistralai/Mistral-7B-Instruct-v0.3
+  vllm_args:
+    tensor-parallel-size: 1
 
 # Nemotron 3 Nano
 nemotron3nano-30b:
   name: Nemotron-3-Nano-30B-A3B
   hf_model_id: nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16
+  vllm_args:
+    tensor-parallel-size: 1
 
 nemotron3nano-30b-fp8:
   name: Nemotron-3-Nano-30B-A3B-FP8
   hf_model_id: nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8
-  engine_args:
-    tensor-parallel-size: 4
+  vllm_args:
+    tensor-parallel-size: 1
 
 nemotron3super-120b-fp8:
   name: Nemotron-3-Super-120B-A12B-FP8
   hf_model_id: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8
-  engine_args:
-    tensor-parallel-size: 4
+  vllm_args:
+    tensor-parallel-size: 2
 
 # Ministral
 ministral-3-14b-reasoning:
   name: Ministral-3-14B-Reasoning
   hf_model_id: mistralai/Ministral-3-14B-Reasoning-2512
-  engine_args:
-    tensor-parallel-size: 4
+  vllm_args:
+    tensor-parallel-size: 1
 
 ministral-3-14b-fp16:
   name: Ministral-3-14B-Instruct
   hf_model_id: mistralai/Ministral-3-14B-Instruct-2512
-  engine_args:
-    tensor-parallel-size: 4
+  vllm_args:
+    tensor-parallel-size: 1
 
 ministral-3-14b-fp8:
   name: Ministral-3-14B-FP8
   hf_model_id: RedHatAI/Ministral-3-14B-Instruct-2512
-  engine_args:
-    tensor-parallel-size: 4
+  vllm_args:
+    tensor-parallel-size: 1

--- a/projects/rhaiis/orchestration/notifications.py
+++ b/projects/rhaiis/orchestration/notifications.py
@@ -52,6 +52,7 @@ def _send_alert(
         version=_cfg.project.get_config("tests.rhaiis.version", ""),
         workload_keys=workload_keys,
         cluster=cluster_tag,
+        engine=engine,
     )
 
 

--- a/projects/rhaiis/orchestration/presets.d/presets.yaml
+++ b/projects/rhaiis/orchestration/presets.d/presets.yaml
@@ -33,6 +33,13 @@ ci-test:
 
 ci-quick:
   tests.rhaiis.workload_key: ci-quick
+  tests.rhaiis.warmup: false
+  tests.rhaiis.version: "vLLM-ci-quick"
+  rhaiis.profiler.enabled: false
+  caliper.postprocess.csv_dashboard.enabled: false
+  tests.rhaiis.slack_notify_always: true
+  rhaiis.agent_analysis.enabled: false
+
 
 
 profile1:

--- a/projects/rhaiis/orchestration/presets.d/presets.yaml
+++ b/projects/rhaiis/orchestration/presets.d/presets.yaml
@@ -21,7 +21,7 @@ trtllm:
 
 # ── Workload profiles ───────────────────────────────────────
 
-ci-quick:
+ci-test:
   tests.rhaiis.workload_key: ci-quick
   tests.rhaiis.model_key: qwen3-0_6b
   tests.rhaiis.warmup: false
@@ -30,6 +30,10 @@ ci-quick:
   caliper.postprocess.csv_dashboard.enabled: false
   tests.rhaiis.slack_notify_always: true
   rhaiis.agent_analysis.enabled: false
+
+ci-quick:
+  tests.rhaiis.workload_key: ci-quick
+
 
 profile1:
   tests.rhaiis.workload_key: profile1

--- a/projects/rhaiis/orchestration/runtime_config.py
+++ b/projects/rhaiis/orchestration/runtime_config.py
@@ -102,7 +102,7 @@ _COMMON_ARG_TRANSLATIONS: dict[str, dict[str, str]] = {
 
 
 def _translate_args(args: dict, engine: str) -> dict:
-    """Translate vLLM-style engine_args to another engine's arg naming.
+    """Translate vLLM-style args to another engine's arg naming.
 
     Only shared args (TP, DP) are translated; vLLM-specific args are dropped.
     """
@@ -124,11 +124,11 @@ def merge_engine_args(
     engine = engine or get_engine()
     engine_key = f"{engine}_args"
 
-    # Use engine-specific block if present, otherwise fall back to engine_args
+    # Use engine-specific block if present, otherwise fall back to vllm_args
     # and auto-translate common args when the engine isn't vLLM
     model_args = model.get(engine_key) if engine != "vllm" else None
     if model_args is None:
-        base = dict(model.get("engine_args", {}))
+        base = dict(model.get("vllm_args", {}))
         if engine != "vllm":
             base = _translate_args(base, engine)
     else:
@@ -136,7 +136,7 @@ def merge_engine_args(
 
     wl_args = workload.get(engine_key) if engine != "vllm" else None
     if wl_args is None:
-        wl = dict(workload.get("engine_args", {}))
+        wl = dict(workload.get("vllm_args", {}))
         if engine != "vllm":
             wl = _translate_args(wl, engine)
     else:

--- a/projects/rhaiis/orchestration/test_phase.py
+++ b/projects/rhaiis/orchestration/test_phase.py
@@ -672,6 +672,7 @@ def _maybe_send_success_notification(model_key: str, workload_keys: list[str]) -
         version=version,
         workload_keys=workload_keys,
         cluster=config.project.get_config("rhaiis.cluster_tag", ""),
+        engine=engine,
     )
 
 

--- a/projects/rhaiis/orchestration/test_phase.py
+++ b/projects/rhaiis/orchestration/test_phase.py
@@ -202,7 +202,12 @@ def _run_test(
         mlflow_destination = None
 
     if mlflow_destination:
-        write_test_labels(env.ARTIFACT_DIR, {}, mlflow_destination=mlflow_destination)
+        import yaml as _yaml
+
+        mlflow_marker = env.ARTIFACT_DIR / "_mlflow_destination.yaml"
+        mlflow_marker.write_text(
+            _yaml.safe_dump(mlflow_destination, sort_keys=False)
+        )
 
     try:
         isvc_labels = {"opendatahub.io/dashboard": "true"}

--- a/projects/rhaiis/orchestration/test_phase.py
+++ b/projects/rhaiis/orchestration/test_phase.py
@@ -205,9 +205,7 @@ def _run_test(
         import yaml as _yaml
 
         mlflow_marker = env.ARTIFACT_DIR / "_mlflow_destination.yaml"
-        mlflow_marker.write_text(
-            _yaml.safe_dump(mlflow_destination, sort_keys=False)
-        )
+        mlflow_marker.write_text(_yaml.safe_dump(mlflow_destination, sort_keys=False))
 
     try:
         isvc_labels = {"opendatahub.io/dashboard": "true"}

--- a/projects/rhaiis/orchestration/test_phase.py
+++ b/projects/rhaiis/orchestration/test_phase.py
@@ -194,6 +194,17 @@ def _run_test(
     wait_guidellm_benchmark_task._retry_config["attempts"] = max(1, benchmark_timeout // 10)
 
     try:
+        from projects.caliper.orchestration.export import precreate_mlflow_run_if_configured
+
+        mlflow_destination = precreate_mlflow_run_if_configured()
+    except Exception:
+        logger.warning("MLflow run pre-creation failed; continuing", exc_info=True)
+        mlflow_destination = None
+
+    if mlflow_destination:
+        write_test_labels(env.ARTIFACT_DIR, {}, mlflow_destination=mlflow_destination)
+
+    try:
         isvc_labels = {"opendatahub.io/dashboard": "true"}
         if profiler_enabled and engine == "vllm":
             isvc_labels["vllm-profiler/enabled"] = "true"
@@ -297,14 +308,6 @@ def _run_test(
             except Exception:
                 logger.exception("Profiler trace upload failed")
                 _warnings.append("Profiler trace upload failed")
-
-        try:
-            from projects.caliper.orchestration.export import precreate_mlflow_run_if_configured
-
-            mlflow_destination = precreate_mlflow_run_if_configured()
-        except Exception:
-            logger.warning("MLflow run pre-creation failed; continuing", exc_info=True)
-            mlflow_destination = None
 
         # Phase 2: benchmark + post-processing for ALL workloads
         trtllm_cfg = runtime_config.get_trtllm_config() if engine == "trtllm" else None

--- a/projects/rhaiis/postprocess/regression.py
+++ b/projects/rhaiis/postprocess/regression.py
@@ -368,7 +368,9 @@ def _build_mlflow_run_url() -> str:
             return ""
 
         vault_name = _cfg.project.get_config("caliper.export.backend.mlflow.secrets.vault.name", "")
-        vault_key = _cfg.project.get_config("caliper.export.backend.mlflow.secrets.vault.mlflow_secret", "")
+        vault_key = _cfg.project.get_config(
+            "caliper.export.backend.mlflow.secrets.vault.mlflow_secret", ""
+        )
         if not vault_name or not vault_key:
             return ""
         secrets_path = vault_lib.get_vault_content_path(vault_name, vault_key)

--- a/projects/rhaiis/postprocess/regression.py
+++ b/projects/rhaiis/postprocess/regression.py
@@ -590,6 +590,7 @@ def send_success_notification(
     version: str = "",
     workload_keys: list[str] | None = None,
     cluster: str = "",
+    engine: str = "",
 ) -> bool:
     """Send a Slack notification when the RHAIIS pipeline succeeds with no regressions.
 
@@ -618,6 +619,7 @@ def send_success_notification(
 
     cluster_line = f"*Cluster:* {cluster}\n" if cluster else ""
     version_line = f"*Version:* {version}\n" if version else ""
+    engine_line = f"*Engine:* {engine}\n" if engine else ""
 
     dashboard_line = ""
     try:
@@ -645,6 +647,7 @@ def send_success_notification(
         f"*Model:* {model}\n"
         f"*Accelerator:* {accelerator}\n"
         f"{parallelism_line}"
+        f"{engine_line}"
         f"{version_line}"
         f"{cluster_line}"
         f"{profiles_line}"
@@ -675,6 +678,7 @@ def send_failure_notification(
     version: str = "",
     workload_keys: list[str] | None = None,
     cluster: str = "",
+    engine: str = "",
 ) -> bool:
     """Send a Slack alert when the RHAIIS pipeline fails.
 
@@ -717,6 +721,7 @@ def send_failure_notification(
 
     cluster_line = f"*Cluster:* {cluster}\n" if cluster else ""
     version_line = f"*Version:* {version}\n" if version else ""
+    engine_line = f"*Engine:* {engine}\n" if engine else ""
 
     error_text = error if len(error) <= 500 else error[:500] + "..."
 
@@ -730,6 +735,7 @@ def send_failure_notification(
         f"*Model:* {model}\n"
         f"*Accelerator:* {accelerator}\n"
         f"{parallelism_line}"
+        f"{engine_line}"
         f"{version_line}"
         f"{cluster_line}"
         f"{profiles_line}"

--- a/projects/rhaiis/postprocess/regression.py
+++ b/projects/rhaiis/postprocess/regression.py
@@ -337,9 +337,54 @@ def _build_mlflow_run_url() -> str:
     from projects.caliper.orchestration.export import build_mlflow_run_url_from_config
 
     try:
-        return build_mlflow_run_url_from_config()
+        url = build_mlflow_run_url_from_config()
+        if url:
+            return url
     except Exception:
-        logger.warning("Failed to build MLflow run URL", exc_info=True)
+        logger.warning("Failed to build MLflow run URL from test labels", exc_info=True)
+
+    # Fallback: check pre-created marker written before deployment
+    try:
+        from pathlib import Path
+        from urllib.parse import quote
+
+        import yaml
+
+        from projects.caliper.public.file_export import load_mlflow_secrets_yaml
+        from projects.core.library import config as _cfg
+        from projects.core.library import env
+        from projects.core.library import vault as vault_lib
+
+        marker = Path(env.ARTIFACT_DIR) / "_mlflow_destination.yaml"
+        if not marker.exists():
+            return ""
+        dest = yaml.safe_load(marker.read_text())
+        if not isinstance(dest, dict) or not dest.get("run_id"):
+            return ""
+
+        run_id = dest["run_id"]
+        experiment_id = dest.get("experiment_id", "")
+        if not experiment_id:
+            return ""
+
+        vault_name = _cfg.project.get_config("caliper.export.backend.mlflow.secrets.vault.name", "")
+        vault_key = _cfg.project.get_config("caliper.export.backend.mlflow.secrets.vault.mlflow_secret", "")
+        if not vault_name or not vault_key:
+            return ""
+        secrets_path = vault_lib.get_vault_content_path(vault_name, vault_key)
+        if not secrets_path or not secrets_path.exists():
+            return ""
+
+        secrets_data = load_mlflow_secrets_yaml(secrets_path)
+        tracking_uri = secrets_data.get("tracking_uri", "").rstrip("/")
+        if not tracking_uri.startswith(("http://", "https://")):
+            return ""
+
+        workspace = _cfg.project.get_config("caliper.export.backend.mlflow.config.workspace", "")
+        qs = f"?workspace={quote(workspace, safe='')}" if workspace else ""
+        return f"{tracking_uri}/#/experiments/{experiment_id}/runs/{run_id}/artifacts{qs}"
+    except Exception:
+        logger.warning("Failed to build MLflow run URL from marker", exc_info=True)
         return ""
 
 


### PR DESCRIPTION
## Summary
- Rename `engine_args` to `vllm_args` in model definitions to clarify that these
  are vLLM-specific flags, not engine-agnostic configuration.
- Add explicit `tensor-parallel-size` to every model entry (placeholder `0` where
  the correct value needs to be filled in).
- Update all Python references (`runtime_config.py`, `ci.py`, `analysis.py`) and
  README documentation to use the new field name.

## Motivation
The `engine_args` name was misleading — these are vLLM CLI flags that get
auto-translated for other engines (SGLang, TRT-LLM) via `_translate_args`.
Renaming makes the engine-specificity explicit and reduces confusion when
adding support for engine-native arguments.

## Testing
- CI quick test pass with the renamed field.
- No behavioral change — `merge_engine_args` reads from `vllm_args` with the
  same fallback/merge semantics as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * Updated model and workload settings to use `vllm_args` for runtime overrides.
  * Added and refined tensor-parallel settings across supported models for improved hardware configuration.
* **Bug Fixes**
  * Ensured analysis, hardware resolution, and runtime configuration consistently apply overrides.
  * Preserved automatic handling of non-vLLM configuration arguments.
* **Workflow Improvements**
  * MLflow runs are now created earlier, with initial test labels recorded before deployment and benchmarking.
* **Presets**
  * Renamed the existing `ci-quick` preset to `ci-test`.
  * Added a streamlined `ci-quick` preset for quick validation runs.
* **Documentation**
  * Updated configuration guidance to describe `vllm_args` and its precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->