### PR TITLE
feat: GuideLLM PVC storageClass support

### DIFF
--- a/projects/guidellm/toolbox/run_guidellm_benchmark/main.py
+++ b/projects/guidellm/toolbox/run_guidellm_benchmark/main.py
@@ -54,6 +54,7 @@ def run(
     image: str = "ghcr.io/vllm-project/guidellm:v0.6.0",
     timeout: int = 900,
     pvc_size: str = "1Gi",
+    pvc_storage_class: str | None = None,
     guidellm_args: list[str] | None = None,
     hf_token_secret: str = "",
     fs_group: int | None = None,
@@ -189,6 +190,7 @@ def create_guidellm_resources_task(args, ctx):
             namespace=ctx.target_namespace,
             name=ctx.benchmark_name,
             pvc_size=args.pvc_size,
+            pvc_storage_class=args.pvc_storage_class,
             owner_reference=owner_reference,
         ),
     )

--- a/projects/guidellm/toolbox/run_guidellm_benchmark/templates/guidellm_pvc.yaml.j2
+++ b/projects/guidellm/toolbox/run_guidellm_benchmark/templates/guidellm_pvc.yaml.j2
@@ -9,7 +9,10 @@ metadata:
     forge.openshift.io/project: llm_d
 spec:
   accessModes:
-    - ReadWriteOnce
+    - {{ "ReadWriteMany" if pvc_storage_class else "ReadWriteOnce" }}
+{% if pvc_storage_class %}
+  storageClassName: {{ pvc_storage_class }}
+{% endif %}
   resources:
     requests:
       storage: {{ pvc_size }}

--- a/projects/guidellm/toolbox/run_guidellm_benchmark/utils.py
+++ b/projects/guidellm/toolbox/run_guidellm_benchmark/utils.py
@@ -147,7 +147,12 @@ def _build_multi_run_script(*, endpoint_url: str, runs: list[GuideLLMRun]) -> st
 
 
 def render_guidellm_pvc_from_parts(
-    *, namespace: str, name: str, pvc_size: str, owner_reference: dict[str, Any] | None = None
+    *,
+    namespace: str,
+    name: str,
+    pvc_size: str,
+    pvc_storage_class: str | None = None,
+    owner_reference: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Render a GuideLL-M PVC manifest from individual components.
 
@@ -155,6 +160,7 @@ def render_guidellm_pvc_from_parts(
         namespace: Target namespace
         name: Name of the benchmark job and PVC
         pvc_size: Size of the PVC
+        pvc_storage_class: Optional storage class name for the PVC
         owner_reference: Optional owner reference to set (e.g., for job ownership)
 
     Returns:
@@ -166,6 +172,7 @@ def render_guidellm_pvc_from_parts(
             "namespace": namespace,
             "name": name,
             "pvc_size": pvc_size,
+            "pvc_storage_class": pvc_storage_class,
         },
     )
     manifest = yaml.safe_load(rendered_yaml)

--- a/projects/llm_d/orchestration/config.d/workloads.yaml
+++ b/projects/llm_d/orchestration/config.d/workloads.yaml
@@ -1,6 +1,7 @@
 job_name: guidellm-benchmark
 image: ghcr.io/vllm-project/guidellm:v0.5.4
 pvc_size: 1Gi
+pvc_storage_class: null
 timeout_seconds: 3600
 args: {}
 

--- a/projects/llm_d/orchestration/runtime_config.py
+++ b/projects/llm_d/orchestration/runtime_config.py
@@ -355,7 +355,7 @@ def _resolve_benchmark_config(benchmark_name: str) -> dict[str, Any]:
     )
     workload_defaults = copy.deepcopy(config.project.get_config("workloads", print=False))
 
-    default_keys = ("job_name", "image", "pvc_size", "timeout_seconds")
+    default_keys = ("job_name", "image", "pvc_size", "pvc_storage_class", "timeout_seconds")
     for key in default_keys:
         if key in workload_defaults and key not in benchmark:
             benchmark[key] = workload_defaults[key]
@@ -401,7 +401,7 @@ def get_workload_config() -> dict[str, Any] | None:
         return None
 
     # Apply same merging logic as _resolve_benchmark_config
-    default_keys = ("job_name", "image", "pvc_size", "timeout_seconds")
+    default_keys = ("job_name", "image", "pvc_size", "pvc_storage_class", "timeout_seconds")
     for key in default_keys:
         if key in workload_defaults and key not in default_benchmark:
             default_benchmark[key] = workload_defaults[key]

--- a/projects/llm_d/orchestration/test_phase.py
+++ b/projects/llm_d/orchestration/test_phase.py
@@ -715,6 +715,7 @@ def run_guidellm_benchmark(*, endpoint_url: str) -> None:
             image=benchmark.get("image"),
             timeout=benchmark.get("timeout_seconds"),
             pvc_size=benchmark.get("pvc_size"),
+            pvc_storage_class=benchmark.get("pvc_storage_class"),
             guidellm_args=guidellm_args,
         )
 


### PR DESCRIPTION
## Summary
- Adds `storageClass` support to the GuideLLM benchmark PVC template, allowing it to be configured via `workloads.pvc_storage_class`
- Passes the storage class through from llm_d test phase config to the GuideLLM benchmark toolbox