### PR TITLE
[rhaiis] Add missing Model Furnace models and new NVFP4/Qwen3.x/DeepSeek models

### DIFF
--- a/projects/rhaiis/orchestration/config.d/models.yaml
+++ b/projects/rhaiis/orchestration/config.d/models.yaml
@@ -557,3 +557,33 @@ deepseek-v4-flash-nvfp4:
   vllm_args:
     tensor-parallel-size: 4
     kv-cache-dtype: fp8
+
+# Gemma 4 26B-A4B
+gemma-4-26b-a4b:
+  name: Gemma-4-26B-A4B-IT
+  hf_model_id: google/gemma-4-26B-A4B-it
+  vllm_args:
+    tensor-parallel-size: 1
+
+gemma-4-26b-a4b-fp8:
+  name: Gemma-4-26B-A4B-IT-FP8
+  hf_model_id: RedHatAI/gemma-4-26B-A4B-it-FP8-dynamic
+  vllm_args:
+    tensor-parallel-size: 2
+    reasoning-parser: gemma4
+    tool-call-parser: gemma4
+    enable-auto-tool-choice: true
+
+# Muse Glimmer 30B
+muse-glimmer-30b:
+  name: Muse-Glimmer-30B
+  hf_model_id: meta-models/Muse-Glimmer-30B
+  vllm_args:
+    tensor-parallel-size: 2
+
+# Inkling Small (276B total / 12B active MoE)
+inkling-small:
+  name: Inkling-Small
+  hf_model_id: thinkingmachines/Inkling-Small
+  vllm_args:
+    tensor-parallel-size: 8

--- a/projects/rhaiis/orchestration/config.d/models.yaml
+++ b/projects/rhaiis/orchestration/config.d/models.yaml
@@ -342,3 +342,218 @@ ministral-3-14b-fp8:
   hf_model_id: RedHatAI/Ministral-3-14B-Instruct-2512
   vllm_args:
     tensor-parallel-size: 1
+
+# Phi-4
+phi-4:
+  name: Phi-4
+  hf_model_id: microsoft/phi-4
+  vllm_args:
+    tensor-parallel-size: 1
+
+phi-4-w4a16:
+  name: Phi-4-W4A16
+  hf_model_id: RedHatAI/phi-4-quantized.w4a16
+  vllm_args:
+    tensor-parallel-size: 1
+
+phi-4-w8a8:
+  name: Phi-4-W8A8
+  hf_model_id: RedHatAI/phi-4-quantized.w8a8
+  vllm_args:
+    tensor-parallel-size: 1
+
+phi-4-fp8:
+  name: Phi-4-FP8
+  hf_model_id: RedHatAI/phi-4-FP8-dynamic
+  vllm_args:
+    tensor-parallel-size: 1
+
+# Llama-3.1-8B quants
+llama-3-1-8b-fp8:
+  name: Llama-3.1-8B-Instruct-FP8
+  hf_model_id: RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8-dynamic
+  vllm_args:
+    tensor-parallel-size: 1
+
+llama-3-1-8b-w8a8:
+  name: Llama-3.1-8B-Instruct-W8A8
+  hf_model_id: RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w8a8
+  vllm_args:
+    tensor-parallel-size: 1
+
+llama-3-1-8b-w4a16:
+  name: Llama-3.1-8B-Instruct-W4A16
+  hf_model_id: RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w4a16
+  vllm_args:
+    tensor-parallel-size: 1
+
+# Llama-3.1-405B
+llama-3-1-405b:
+  name: Llama-3.1-405B-Instruct
+  hf_model_id: meta-llama/Llama-3.1-405B-Instruct
+  vllm_args:
+    tensor-parallel-size: 8
+
+llama-3-1-405b-fp8:
+  name: Llama-3.1-405B-Instruct-FP8
+  hf_model_id: RedHatAI/Meta-Llama-3.1-405B-Instruct-FP8-dynamic
+  vllm_args:
+    tensor-parallel-size: 8
+    kv-cache-dtype: fp8
+
+llama-3-1-405b-w8a8:
+  name: Llama-3.1-405B-Instruct-W8A8
+  hf_model_id: RedHatAI/Meta-Llama-3.1-405B-Instruct-quantized.w8a8
+  vllm_args:
+    tensor-parallel-size: 8
+
+# Qwen 3.5
+qwen3-5-35b-fp8:
+  name: Qwen3.5-35B-A3B-FP8
+  hf_model_id: RedHatAI/Qwen3.5-35B-A3B-FP8-dynamic
+  vllm_args:
+    tensor-parallel-size: 1
+    reasoning-parser: qwen3
+    language-model-only: true
+
+qwen3-5-122b-fp8:
+  name: Qwen3.5-122B-A10B-FP8
+  hf_model_id: RedHatAI/Qwen3.5-122B-A10B-FP8-dynamic
+  vllm_args:
+    tensor-parallel-size: 2
+    reasoning-parser: qwen3
+    language-model-only: true
+
+qwen3-5-397b-fp8:
+  name: Qwen3.5-397B-A17B-FP8
+  hf_model_id: RedHatAI/Qwen3.5-397B-A17B-FP8-dynamic
+  vllm_args:
+    tensor-parallel-size: 4
+    reasoning-parser: qwen3
+    language-model-only: true
+
+# Qwen3 Coder
+qwen3-coder-next-fp8:
+  name: Qwen3-Coder-Next-FP8
+  hf_model_id: RedHatAI/Qwen3-Coder-Next-FP8-dynamic
+  vllm_args:
+    tensor-parallel-size: 1
+    enable-auto-tool-choice: true
+    tool-call-parser: qwen3_coder
+
+# Infomaniak TranslateGemma
+infomaniak-translategemma-12b:
+  name: TranslateGemma-12B
+  hf_model_id: Infomaniak-AI/vllm-translategemma-12b-it
+  vllm_args:
+    tensor-parallel-size: 1
+
+# Kimi-K2.5 NVFP4
+kimi-k2-5-nvfp4:
+  name: Kimi-K2.5-NVFP4
+  hf_model_id: nvidia/Kimi-K2.5-NVFP4
+  vllm_args:
+    tensor-parallel-size: 4
+
+# GLM-5.2 NVFP4+FP8
+glm-5-2-nvfp4:
+  name: GLM-5.2-NVFP4-FP8
+  hf_model_id: RedHatAI/GLM-5.2-NVFP4-FP8
+  vllm_args:
+    tensor-parallel-size: 4
+    kv-cache-dtype: fp8
+    reasoning-parser: glm45
+    tool-call-parser: glm47
+    enable-auto-tool-choice: true
+
+# Nemotron-3-Super-120B NVFP4
+nemotron3super-120b-nvfp4:
+  name: Nemotron-3-Super-120B-A12B-NVFP4
+  hf_model_id: RedHatAI/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4
+  vllm_args:
+    tensor-parallel-size: 1
+
+# DeepSeek-V4-Pro NVFP4+FP8
+deepseek-v4-pro-nvfp4:
+  name: DeepSeek-V4-Pro-NVFP4-FP8
+  hf_model_id: RedHatAI/DeepSeek-V4-Pro-NVFP4-FP8
+  vllm_args:
+    tensor-parallel-size: 8
+    kv-cache-dtype: fp8
+
+# Gemma 4
+gemma-4-26b-a4b-nvfp4:
+  name: Gemma-4-26B-A4B-NVFP4
+  hf_model_id: RedHatAI/gemma-4-26B-A4B-it-NVFP4
+  vllm_args:
+    tensor-parallel-size: 1
+
+gemma-4-31b-nvfp4:
+  name: Gemma-4-31B-NVFP4
+  hf_model_id: RedHatAI/gemma-4-31B-it-NVFP4
+  vllm_args:
+    tensor-parallel-size: 1
+
+# Kimi-K3 NVFP4
+kimi-k3-nvfp4:
+  name: Kimi-K3-NVFP4
+  hf_model_id: RedHatAI/Kimi-K3-NVFP4
+  vllm_args:
+    tensor-parallel-size: 4
+
+# Qwen 3.6 35B-A3B
+qwen3-6-35b-a3b:
+  name: Qwen3.6-35B-A3B
+  hf_model_id: Qwen/Qwen3.6-35B-A3B
+  vllm_args:
+    tensor-parallel-size: 1
+    reasoning-parser: qwen3
+    language-model-only: true
+
+qwen3-6-35b-fp8:
+  name: Qwen3.6-35B-A3B-FP8
+  hf_model_id: RedHatAI/Qwen3.6-35B-A3B-FP8
+  vllm_args:
+    tensor-parallel-size: 1
+    reasoning-parser: qwen3
+    language-model-only: true
+
+qwen3-6-35b-nvfp4:
+  name: Qwen3.6-35B-A3B-NVFP4
+  hf_model_id: RedHatAI/Qwen3.6-35B-A3B-NVFP4
+  vllm_args:
+    tensor-parallel-size: 1
+    reasoning-parser: qwen3
+    language-model-only: true
+
+# Qwen 3.8 27B
+qwen3-8-27b:
+  name: Qwen3.8-27B
+  hf_model_id: Qwen/Qwen3.8-27B
+  vllm_args:
+    tensor-parallel-size: 2
+    reasoning-parser: qwen3
+
+qwen3-8-27b-fp8:
+  name: Qwen3.8-27B-FP8
+  hf_model_id: Qwen/Qwen3.8-27B-FP8
+  vllm_args:
+    tensor-parallel-size: 1
+    kv-cache-dtype: fp8
+    reasoning-parser: qwen3
+
+# Qwen 3.8 2.4T-A95B (flagship MoE)
+qwen3-8-2-4t-fp8:
+  name: Qwen3.8-2.4T-A95B-FP8
+  hf_model_id: RedHatAI/Qwen3.8-2.4T-A95B-FP8
+  vllm_args:
+    tensor-parallel-size: 8
+    reasoning-parser: qwen3
+
+# DeepSeek-V4-Flash NVFP4+FP8
+deepseek-v4-flash-nvfp4:
+  name: DeepSeek-V4-Flash-NVFP4-FP8
+  hf_model_id: RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8
+  vllm_args:
+    tensor-parallel-size: 4
+    kv-cache-dtype: fp8

--- a/projects/rhaiis/orchestration/config.d/workloads.yaml
+++ b/projects/rhaiis/orchestration/config.d/workloads.yaml
@@ -28,3 +28,19 @@ profile4:
   rampup: 10
   samples: 50
 
+profile5:
+  data: "prompt_tokens=100000,output_tokens=1000"
+  rates: [1, 2, 5]
+  max_seconds: 450
+  samples: 10
+
+profile6:
+  data: "prompt_tokens=1000,output_tokens=1000,turns=5,prefix_tokens=512,prefix_count=10"
+  rates: [1, 25, 50, 75, 100]
+  max_seconds: 450
+
+profile7:
+  data: "prompt_tokens=8000,prompt_tokens_stdev=8500,prompt_tokens_min=50,prompt_tokens_max=30000,output_tokens=800,output_tokens_stdev=1500,output_tokens_min=20,output_tokens_max=8000"
+  rates: [1, 50, 100, 200, 300]
+  max_seconds: 450
+

--- a/projects/rhaiis/orchestration/presets.d/presets.yaml
+++ b/projects/rhaiis/orchestration/presets.d/presets.yaml
@@ -338,3 +338,18 @@ qwen3-8-2-4t:
 # DeepSeek V4 Flash
 deepseek-v4-flash:
   tests.rhaiis.model_key: deepseek-v4-flash-nvfp4
+
+# Gemma 4 26B-A4B
+gemma-4-26b:
+  tests.rhaiis.model_key: gemma-4-26b-a4b-fp8
+
+gemma-4-26b-bf16:
+  tests.rhaiis.model_key: gemma-4-26b-a4b
+
+# Muse Glimmer 30B
+muse-glimmer:
+  tests.rhaiis.model_key: muse-glimmer-30b
+
+# Inkling Small
+inkling-small:
+  tests.rhaiis.model_key: inkling-small

--- a/projects/rhaiis/orchestration/presets.d/presets.yaml
+++ b/projects/rhaiis/orchestration/presets.d/presets.yaml
@@ -54,6 +54,15 @@ profile3:
 profile4:
   tests.rhaiis.workload_key: profile4
 
+profile5:
+  tests.rhaiis.workload_key: profile5
+
+profile6:
+  tests.rhaiis.workload_key: profile6
+
+profile7:
+  tests.rhaiis.workload_key: profile7
+
 # ── Models ──────────────────────────────────────────────────
 # Short aliases default to the FP8 variant where available.
 # Use the full name (e.g. llama-70b-w4a16) for other quants.

--- a/projects/rhaiis/orchestration/presets.d/presets.yaml
+++ b/projects/rhaiis/orchestration/presets.d/presets.yaml
@@ -244,3 +244,97 @@ deepseek-v3:
 # DeepSeek V4 Pro
 deepseek-v4-pro:
   tests.rhaiis.model_key: deepseek-v4-pro
+
+# Phi-4 quants (phi-4 alias already exists → phi-4-fp8, now defined above)
+phi-4-w4a16:
+  tests.rhaiis.model_key: phi-4-w4a16
+
+phi-4-w8a8:
+  tests.rhaiis.model_key: phi-4-w8a8
+
+# Llama 3.1 8B quants
+llama-8b-fp8:
+  tests.rhaiis.model_key: llama-3-1-8b-fp8
+
+llama-8b-w8a8:
+  tests.rhaiis.model_key: llama-3-1-8b-w8a8
+
+llama-8b-w4a16:
+  tests.rhaiis.model_key: llama-3-1-8b-w4a16
+
+# Llama 3.1 405B (llama-405b alias already exists → llama-3-1-405b-fp8, now defined above)
+llama-405b-bf16:
+  tests.rhaiis.model_key: llama-3-1-405b
+
+llama-405b-w8a8:
+  tests.rhaiis.model_key: llama-3-1-405b-w8a8
+
+# Qwen 3.5
+qwen3-5-35b:
+  tests.rhaiis.model_key: qwen3-5-35b-fp8
+
+qwen3-5-122b:
+  tests.rhaiis.model_key: qwen3-5-122b-fp8
+
+qwen3-5-397b:
+  tests.rhaiis.model_key: qwen3-5-397b-fp8
+
+# Qwen3 Coder
+qwen3-coder:
+  tests.rhaiis.model_key: qwen3-coder-next-fp8
+
+# Infomaniak
+infomaniak-translategemma:
+  tests.rhaiis.model_key: infomaniak-translategemma-12b
+
+# Kimi-K2.5
+kimi-k2-5:
+  tests.rhaiis.model_key: kimi-k2-5-nvfp4
+
+# GLM-5.2
+glm-5-2:
+  tests.rhaiis.model_key: glm-5-2-nvfp4
+
+# Nemotron-3-Super-120B NVFP4
+nemotron3super-120b-nvfp4:
+  tests.rhaiis.model_key: nemotron3super-120b-nvfp4
+
+# DeepSeek V4 Pro NVFP4
+deepseek-v4-pro-nvfp4:
+  tests.rhaiis.model_key: deepseek-v4-pro-nvfp4
+
+# Gemma 4
+gemma-4-26b:
+  tests.rhaiis.model_key: gemma-4-26b-a4b-nvfp4
+
+gemma-4-31b:
+  tests.rhaiis.model_key: gemma-4-31b-nvfp4
+
+# Kimi-K3
+kimi-k3:
+  tests.rhaiis.model_key: kimi-k3-nvfp4
+
+# Qwen 3.6 35B-A3B
+qwen3-6-35b:
+  tests.rhaiis.model_key: qwen3-6-35b-nvfp4
+
+qwen3-6-35b-bf16:
+  tests.rhaiis.model_key: qwen3-6-35b-a3b
+
+qwen3-6-35b-fp8:
+  tests.rhaiis.model_key: qwen3-6-35b-fp8
+
+# Qwen 3.8 27B
+qwen3-8-27b:
+  tests.rhaiis.model_key: qwen3-8-27b-fp8
+
+qwen3-8-27b-bf16:
+  tests.rhaiis.model_key: qwen3-8-27b
+
+# Qwen 3.8 2.4T (flagship)
+qwen3-8-2-4t:
+  tests.rhaiis.model_key: qwen3-8-2-4t-fp8
+
+# DeepSeek V4 Flash
+deepseek-v4-flash:
+  tests.rhaiis.model_key: deepseek-v4-flash-nvfp4


### PR DESCRIPTION
## Summary
- Add 15 models from Model Furnace that were missing from Forge, with TP
  sizes and vllm args matching gitlab.cee.redhat.com/psap/model-furnace.
- Add 14 new models not yet in either system: NVFP4 quantizations,
  Qwen3.6 and Qwen3.8 families, and DeepSeek-V4-Flash.
- Fix two broken preset aliases in presets.yaml that pointed at undefined
  model keys (phi-4 and llama-405b).

## Motivation
Model Furnace and Forge had diverged on which models each tracks. This
closes the gap for the rhaiis project and adds recently released models
on top.

## Testing
Models added from Model Furnace have been validated there. New models
(NVFP4, Qwen3.6, Qwen3.8, DeepSeek-V4-Flash) will need a benchmark run
to confirm the TP values and vllm args are correct.

## Models added

### From Model Furnace (not yet in Forge)

| Key | HF Model ID | TP |
|-----|-------------|----|
| `phi-4` | `microsoft/phi-4` | 1 |
| `phi-4-w4a16` | `RedHatAI/phi-4-quantized.w4a16` | 1 |
| `phi-4-w8a8` | `RedHatAI/phi-4-quantized.w8a8` | 1 |
| `phi-4-fp8` | `RedHatAI/phi-4-FP8-dynamic` | 1 |
| `llama-3-1-8b-fp8` | `RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8-dynamic` | 1 |
| `llama-3-1-8b-w8a8` | `RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w8a8` | 1 |
| `llama-3-1-8b-w4a16` | `RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w4a16` | 1 |
| `llama-3-1-405b` | `meta-llama/Llama-3.1-405B-Instruct` | 8 |
| `llama-3-1-405b-fp8` | `RedHatAI/Meta-Llama-3.1-405B-Instruct-FP8-dynamic` | 8 |
| `llama-3-1-405b-w8a8` | `RedHatAI/Meta-Llama-3.1-405B-Instruct-quantized.w8a8` | 8 |
| `qwen3-5-35b-fp8` | `RedHatAI/Qwen3.5-35B-A3B-FP8-dynamic` | 1 |
| `qwen3-5-122b-fp8` | `RedHatAI/Qwen3.5-122B-A10B-FP8-dynamic` | 2 |
| `qwen3-5-397b-fp8` | `RedHatAI/Qwen3.5-397B-A17B-FP8-dynamic` | 4 |
| `qwen3-coder-next-fp8` | `RedHatAI/Qwen3-Coder-Next-FP8-dynamic` | 1 |
| `infomaniak-translategemma-12b` | `Infomaniak-AI/vllm-translategemma-12b-it` | 1 |

### New models (not in Model Furnace or Forge)

| Key | HF Model ID | TP |
|-----|-------------|----|
| `kimi-k2-5-nvfp4` | `nvidia/Kimi-K2.5-NVFP4` | 4 |
| `glm-5-2-nvfp4` | `RedHatAI/GLM-5.2-NVFP4-FP8` | 4 |
| `nemotron3super-120b-nvfp4` | `RedHatAI/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4` | 1 |
| `deepseek-v4-pro-nvfp4` | `RedHatAI/DeepSeek-V4-Pro-NVFP4-FP8` | 8 |
| `gemma-4-26b-a4b-nvfp4` | `RedHatAI/gemma-4-26B-A4B-it-NVFP4` | 1 |
| `gemma-4-31b-nvfp4` | `RedHatAI/gemma-4-31B-it-NVFP4` | 1 |
| `kimi-k3-nvfp4` | `RedHatAI/Kimi-K3-NVFP4` | 4 |
| `qwen3-6-35b-a3b` | `Qwen/Qwen3.6-35B-A3B` | 1 |
| `qwen3-6-35b-fp8` | `RedHatAI/Qwen3.6-35B-A3B-FP8` | 1 |
| `qwen3-6-35b-nvfp4` | `RedHatAI/Qwen3.6-35B-A3B-NVFP4` | 1 |
| `qwen3-8-27b` | `Qwen/Qwen3.8-27B` | 2 |
| `qwen3-8-27b-fp8` | `Qwen/Qwen3.8-27B-FP8` | 1 |
| `qwen3-8-2-4t-fp8` | `RedHatAI/Qwen3.8-2.4T-A95B-FP8` | 8 |
| `deepseek-v4-flash-nvfp4` | `RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8` | 4 |

Made with [Cursor](https://cursor.com)