### PR TITLE
[rhaiis] add custom dspark spec-decoding preset

### DIFF
--- a/projects/rhaiis/README.md
+++ b/projects/rhaiis/README.md
@@ -526,6 +526,11 @@ python3 -m projects.rhaiis.orchestration.cli test \
 #   deepseek-r1, deepseek-v3, gpt-oss
 # Workload presets: profile1, profile2, profile3, profile4
 # Accelerator presets: nvidia, amd
+#
+# Spec decoding comparison (H200 Zeus): presets.d/spec-decoding.yaml
+#   deepseek-v4-baseline | deepseek-v4-mtp | deepseek-v4-dspark | deepseek-v4-dspark-dynamic
+python3 -m projects.rhaiis.orchestration.cli test \
+  --preset deepseek-v4-dspark --preset profile1
 ```
 
 Per-cluster presets (e.g. `presets.d/mehulvalidation.yaml`) set cluster-specific

--- a/projects/rhaiis/README.md
+++ b/projects/rhaiis/README.md
@@ -530,7 +530,7 @@ python3 -m projects.rhaiis.orchestration.cli test \
 # Spec decoding comparison (H200 Zeus): presets.d/spec-decoding.yaml
 #   deepseek-v4-baseline | deepseek-v4-mtp | deepseek-v4-dspark | deepseek-v4-dspark-dynamic
 python3 -m projects.rhaiis.orchestration.cli test \
-  --preset deepseek-v4-dspark --preset profile1
+  --preset deepseek-v4-dspark
 ```
 
 Per-cluster presets (e.g. `presets.d/mehulvalidation.yaml`) set cluster-specific

--- a/projects/rhaiis/orchestration/config.d/models.yaml
+++ b/projects/rhaiis/orchestration/config.d/models.yaml
@@ -227,6 +227,40 @@ deepseek-v4-pro:
   engine_args:
     tensor-parallel-size: 8
 
+deepseek-v4-pro-0813: &deepseek-v4-pro-0813
+  name: DeepSeek-V4-Pro-0813
+  hf_model_id: deepseek-ai/DeepSeek-V4-Pro-0813
+  engine_args: &deepseek-v4-pro-0813-args
+    tensor-parallel-size: 8
+    enable-expert-parallel: true
+    kv-cache-dtype: fp8
+    max-model-len: 16384
+    max-num-seqs: 256
+    max-num-batched-tokens: 16384
+    gpu-memory-utilization: 0.9
+    compilation-config: '{"max_cudagraph_capture_size":4096}'
+
+deepseek-v4-pro-0813-mtp:
+  <<: *deepseek-v4-pro-0813
+  name: DeepSeek-V4-Pro-0813-MTP
+  engine_args:
+    <<: *deepseek-v4-pro-0813-args
+    speculative-config: '{"method":"mtp"}'
+
+deepseek-v4-pro-0813-dspark:
+  <<: *deepseek-v4-pro-0813
+  name: DeepSeek-V4-Pro-0813-DSpark
+  engine_args:
+    <<: *deepseek-v4-pro-0813-args
+    speculative-config: '{"method":"dspark","num_speculative_tokens":7,"draft_sample_method":"probabilistic"}'
+
+deepseek-v4-pro-0813-dspark-dynamic:
+  <<: *deepseek-v4-pro-0813
+  name: DeepSeek-V4-Pro-0813-DSpark-Dynamic
+  engine_args:
+    <<: *deepseek-v4-pro-0813-args
+    speculative-config: '{"method":"dspark","num_speculative_tokens":7,"draft_sample_method":"probabilistic","num_speculative_tokens_per_batch_size":[[1,64,7],[65,128,5],[129,512,0]]}'
+
 deepseek-r1-0528:
   name: DeepSeek-R1-0528
   hf_model_id: deepseek-ai/DeepSeek-R1-0528

--- a/projects/rhaiis/orchestration/presets.d/spec-decoding.yaml
+++ b/projects/rhaiis/orchestration/presets.d/spec-decoding.yaml
@@ -1,7 +1,7 @@
 __multiple: true
 
 # DeepSeek-V4-Pro-0813 speculative decoding comparison on H200 Zeus (TP=8).
-# Combine with a workload preset (profile1/profile2/profile3/profile4).
+# Runs all four workload profiles so they land on the staging dashboard.
 #
 # Adaptive verification (enable_adaptive_verification) is omitted: DeepSeek-V4
 # indexer/MLA backends only support the device-side trim + varlen full CUDA
@@ -11,6 +11,12 @@ deepseek-v4-spec-base:
   rhaiis.accelerator: nvidia
   rhaiis.cluster_tag: zeus
   rhaiis.engines.vllm.args.gpu-memory-utilization: 0.9
+  tests.rhaiis.workload_keys:
+    - profile1
+    - profile2
+    - profile3
+    - profile4
+  rhaiis.profiler.enabled: true
 
 # 1. No speculative decoding
 deepseek-v4-baseline:

--- a/projects/rhaiis/orchestration/presets.d/spec-decoding.yaml
+++ b/projects/rhaiis/orchestration/presets.d/spec-decoding.yaml
@@ -1,0 +1,37 @@
+__multiple: true
+
+# DeepSeek-V4-Pro-0813 speculative decoding comparison on H200 Zeus (TP=8).
+# Combine with a workload preset (profile1/profile2/profile3/profile4).
+#
+# Adaptive verification (enable_adaptive_verification) is omitted: DeepSeek-V4
+# indexer/MLA backends only support the device-side trim + varlen full CUDA
+# graphs on SM100 (B300). H200 (SM90) rejects it at startup.
+
+deepseek-v4-spec-base:
+  rhaiis.accelerator: nvidia
+  rhaiis.cluster_tag: zeus
+  rhaiis.engines.vllm.args.gpu-memory-utilization: 0.9
+
+# 1. No speculative decoding
+deepseek-v4-baseline:
+  extends:
+    - deepseek-v4-spec-base
+  tests.rhaiis.model_key: deepseek-v4-pro-0813
+
+# 2. Native DeepSeek MTP
+deepseek-v4-mtp:
+  extends:
+    - deepseek-v4-spec-base
+  tests.rhaiis.model_key: deepseek-v4-pro-0813-mtp
+
+# 3. DSpark fixed-k (K=7)
+deepseek-v4-dspark:
+  extends:
+    - deepseek-v4-spec-base
+  tests.rhaiis.model_key: deepseek-v4-pro-0813-dspark
+
+# 4. DSpark + dynamic SD (K by concurrency bucket)
+deepseek-v4-dspark-dynamic:
+  extends:
+    - deepseek-v4-spec-base
+  tests.rhaiis.model_key: deepseek-v4-pro-0813-dspark-dynamic


### PR DESCRIPTION
Add four H200 Zeus comparison presets: baseline, native MTP, DSpark fixed-k, and DSpark with dynamic SD. Adaptive verification is omitted because DeepSeek-V4 varlen full graphs are SM100-only.