### PR TITLE
[rhaiis] Add missing workload profiles 5-7 and composite benchmark presets

### DIFF
--- a/projects/rhaiis/orchestration/presets.d/benchmarks.yaml
+++ b/projects/rhaiis/orchestration/presets.d/benchmarks.yaml
@@ -6,3 +6,39 @@ benchmark:
   rhaiis.profiler.enabled: true
   caliper.postprocess.csv_dashboard.enabled: true
   rhaiis.agent_analysis.enabled: false
+
+benchmark-standard:
+  extends:
+  - benchmark
+  tests.rhaiis.workload_key:
+  - profile1
+  - profile2
+
+benchmark-long-context:
+  extends:
+  - benchmark
+  tests.rhaiis.workload_key:
+  - profile4
+  - profile5
+
+benchmark-full-sweep:
+  extends:
+  - benchmark
+  tests.rhaiis.workload_key:
+  - profile1
+  - profile2
+  - profile3
+  - profile4
+  - profile5
+  - profile6
+  - profile7
+
+benchmark-multi-turn:
+  extends:
+  - benchmark
+  tests.rhaiis.workload_key: profile6
+
+benchmark-heterogeneous:
+  extends:
+  - benchmark
+  tests.rhaiis.workload_key: profile7


### PR DESCRIPTION
## Summary
- Sync workload profiles from model-furnace that were missing in forge:
  - **profile5**: 100k/1k ultra-long context (rates [1,2,5], 10 samples)
  - **profile6**: multi-turn with prefix caching (5 turns, prefix_tokens=512)
  - **profile7**: heavy heterogeneous (prompt 50-30k, output 20-8k)
- Add workload key preset mappings for profiles 5, 6, 7
- Add composite benchmark presets for common test matrices:
  - **benchmark-standard**: profile1 + profile2
  - **benchmark-long-context**: profile4 + profile5
  - **benchmark-full-sweep**: all profiles 1-7
  - **benchmark-multi-turn**: profile6
  - **benchmark-heterogeneous**: profile7

## Test plan
- [ ] Verify profile5/6/7 workload definitions match model-furnace
- [ ] Verify composite presets resolve correctly via runtime_config
- [ ] Run ci-test preset to confirm no regressions