### PR TITLE
[rhaiis] Add named workload aliases, prefix-cache toggles, and composite benchmark presets

### DIFF
--- a/projects/rhaiis/orchestration/config.d/workloads.yaml
+++ b/projects/rhaiis/orchestration/config.d/workloads.yaml
@@ -40,6 +40,48 @@ profile7:
   rates: [1, 50, 100, 200, 300]
   max_seconds: 450
 
+# ── Named aliases ───────────────────────────────────────────
+# Meaningful names that map to the numbered profiles above.
+# Use these in presets for readability; the underlying config
+# is identical to the corresponding profileN.
+
+balanced:
+  data: "prompt_tokens=1000,output_tokens=1000"
+  rates: [1,50,100,200,300]
+  max_seconds: 450
+
+variable:
+  data: "prompt_tokens=512,prompt_tokens_stdev=128,prompt_tokens_min=1,prompt_tokens_max=1024,output_tokens=2048,output_tokens_stdev=512,output_tokens_min=1,output_tokens_max=4096"
+  rates: [1,50,100,200,300]
+  max_seconds: 450
+
+summarization:
+  data: "prompt_tokens=2048,output_tokens=128"
+  rates: [1, 50, 100, 200, 300]
+  max_seconds: 450
+
+long-context:
+  data: "prompt_tokens=8000,output_tokens=1000"
+  rates: [1,25,50,75,100]
+  max_seconds: 450
+  samples: 50
+
+ultra-long-context:
+  data: "prompt_tokens=100000,output_tokens=1000"
+  rates: [1, 2, 5]
+  max_seconds: 450
+  samples: 10
+
+multi-turn:
+  data: "prompt_tokens=1000,output_tokens=1000,turns=5,prefix_tokens=512,prefix_count=10"
+  rates: [1, 25, 50, 75, 100]
+  max_seconds: 450
+
+heavy-heterogeneous:
+  data: "prompt_tokens=8000,prompt_tokens_stdev=8500,prompt_tokens_min=50,prompt_tokens_max=30000,output_tokens=800,output_tokens_stdev=1500,output_tokens_min=20,output_tokens_max=8000"
+  rates: [1, 50, 100, 200, 300]
+  max_seconds: 450
+
 # Dashboard override stub (set data, rates, max_seconds at runtime)
 custom:
   data: "prompt_tokens=1000,output_tokens=1000"

--- a/projects/rhaiis/orchestration/config.d/workloads.yaml
+++ b/projects/rhaiis/orchestration/config.d/workloads.yaml
@@ -50,7 +50,7 @@ balanced:
   rates: [1,50,100,200,300]
   max_seconds: 450
 
-variable:
+decode-heterogeneous:
   data: "prompt_tokens=512,prompt_tokens_stdev=128,prompt_tokens_min=1,prompt_tokens_max=1024,output_tokens=2048,output_tokens_stdev=512,output_tokens_min=1,output_tokens_max=4096"
   rates: [1,50,100,200,300]
   max_seconds: 450

--- a/projects/rhaiis/orchestration/config.d/workloads.yaml
+++ b/projects/rhaiis/orchestration/config.d/workloads.yaml
@@ -32,7 +32,7 @@ profile5:
 
 profile6:
   data: "prompt_tokens=128,output_tokens=128,turns=5,prefix_tokens=512,prefix_count=10000"
-  rates: [1, 32, 64, 128, 256]
+  rates: [1, 32, 64, 128, 256, 512]
   max_seconds: 450
 
 profile7:

--- a/projects/rhaiis/orchestration/config.d/workloads.yaml
+++ b/projects/rhaiis/orchestration/config.d/workloads.yaml
@@ -40,48 +40,6 @@ profile7:
   rates: [1, 50, 100, 200, 300]
   max_seconds: 450
 
-# ── Named aliases ───────────────────────────────────────────
-# Meaningful names that map to the numbered profiles above.
-# Use these in presets for readability; the underlying config
-# is identical to the corresponding profileN.
-
-balanced:
-  data: "prompt_tokens=1000,output_tokens=1000"
-  rates: [1,50,100,200,300]
-  max_seconds: 450
-
-decode-heterogeneous:
-  data: "prompt_tokens=512,prompt_tokens_stdev=128,prompt_tokens_min=1,prompt_tokens_max=1024,output_tokens=2048,output_tokens_stdev=512,output_tokens_min=1,output_tokens_max=4096"
-  rates: [1,50,100,200,300]
-  max_seconds: 450
-
-summarization:
-  data: "prompt_tokens=2048,output_tokens=128"
-  rates: [1, 50, 100, 200, 300]
-  max_seconds: 450
-
-long-context:
-  data: "prompt_tokens=8000,output_tokens=1000"
-  rates: [1,25,50,75,100]
-  max_seconds: 450
-  samples: 50
-
-ultra-long-context:
-  data: "prompt_tokens=100000,output_tokens=1000"
-  rates: [1, 2, 5]
-  max_seconds: 450
-  samples: 10
-
-multi-turn:
-  data: "prompt_tokens=1000,output_tokens=1000,turns=5,prefix_tokens=512,prefix_count=10"
-  rates: [1, 25, 50, 75, 100]
-  max_seconds: 450
-
-heavy-heterogeneous:
-  data: "prompt_tokens=8000,prompt_tokens_stdev=8500,prompt_tokens_min=50,prompt_tokens_max=30000,output_tokens=800,output_tokens_stdev=1500,output_tokens_min=20,output_tokens_max=8000"
-  rates: [1, 50, 100, 200, 300]
-  max_seconds: 450
-
 # Dashboard override stub (set data, rates, max_seconds at runtime)
 custom:
   data: "prompt_tokens=1000,output_tokens=1000"

--- a/projects/rhaiis/orchestration/config.d/workloads.yaml
+++ b/projects/rhaiis/orchestration/config.d/workloads.yaml
@@ -31,8 +31,8 @@ profile5:
   samples: 10
 
 profile6:
-  data: "prompt_tokens=1000,output_tokens=1000,turns=5,prefix_tokens=512,prefix_count=10"
-  rates: [1, 25, 50, 75, 100]
+  data: "prompt_tokens=128,output_tokens=128,turns=5,prefix_tokens=512,prefix_count=10000"
+  rates: [1, 32, 64, 128, 256]
   max_seconds: 450
 
 profile7:

--- a/projects/rhaiis/orchestration/presets.d/benchmarks.yaml
+++ b/projects/rhaiis/orchestration/presets.d/benchmarks.yaml
@@ -21,18 +21,6 @@ benchmark-long-context:
   - profile4
   - profile5
 
-benchmark-full-sweep:
-  extends:
-  - benchmark
-  tests.rhaiis.workload_key:
-  - profile1
-  - profile2
-  - profile3
-  - profile4
-  - profile5
-  - profile6
-  - profile7
-
 benchmark-multi-turn-prefix-on:
   extends:
   - benchmark

--- a/projects/rhaiis/orchestration/presets.d/benchmarks.yaml
+++ b/projects/rhaiis/orchestration/presets.d/benchmarks.yaml
@@ -12,7 +12,7 @@ benchmark-standard:
   - benchmark
   tests.rhaiis.workload_key:
   - profile1
-  - profile2
+  - profile4
 
 benchmark-long-context:
   extends:

--- a/projects/rhaiis/orchestration/presets.d/benchmarks.yaml
+++ b/projects/rhaiis/orchestration/presets.d/benchmarks.yaml
@@ -14,13 +14,6 @@ benchmark-standard:
   - profile1
   - profile4
 
-benchmark-long-context:
-  extends:
-  - benchmark
-  tests.rhaiis.workload_key:
-  - profile4
-  - profile5
-
 benchmark-multi-turn-prefix-on:
   extends:
   - benchmark

--- a/projects/rhaiis/orchestration/presets.d/benchmarks.yaml
+++ b/projects/rhaiis/orchestration/presets.d/benchmarks.yaml
@@ -6,3 +6,49 @@ benchmark:
   rhaiis.profiler.enabled: true
   caliper.postprocess.csv_dashboard.enabled: true
   rhaiis.agent_analysis.enabled: false
+
+benchmark-standard:
+  extends:
+  - benchmark
+  tests.rhaiis.workload_key:
+  - balanced
+  - variable
+
+benchmark-long-context:
+  extends:
+  - benchmark
+  tests.rhaiis.workload_key:
+  - long-context
+  - ultra-long-context
+
+benchmark-full-sweep:
+  extends:
+  - benchmark
+  tests.rhaiis.workload_key:
+  - balanced
+  - variable
+  - summarization
+  - long-context
+  - ultra-long-context
+  - multi-turn
+  - heavy-heterogeneous
+
+benchmark-multi-turn:
+  extends:
+  - benchmark
+  tests.rhaiis.workload_key: multi-turn
+
+benchmark-multi-turn-prefix-on:
+  extends:
+  - benchmark-multi-turn
+  - prefix-cache-on
+
+benchmark-multi-turn-prefix-off:
+  extends:
+  - benchmark-multi-turn
+  - prefix-cache-off
+
+benchmark-heterogeneous:
+  extends:
+  - benchmark
+  tests.rhaiis.workload_key: heavy-heterogeneous

--- a/projects/rhaiis/orchestration/presets.d/benchmarks.yaml
+++ b/projects/rhaiis/orchestration/presets.d/benchmarks.yaml
@@ -11,32 +11,32 @@ benchmark-standard:
   extends:
   - benchmark
   tests.rhaiis.workload_key:
-  - balanced
-  - decode-heterogeneous
+  - profile1
+  - profile2
 
 benchmark-long-context:
   extends:
   - benchmark
   tests.rhaiis.workload_key:
-  - long-context
-  - ultra-long-context
+  - profile4
+  - profile5
 
 benchmark-full-sweep:
   extends:
   - benchmark
   tests.rhaiis.workload_key:
-  - balanced
-  - decode-heterogeneous
-  - summarization
-  - long-context
-  - ultra-long-context
-  - multi-turn
-  - heavy-heterogeneous
+  - profile1
+  - profile2
+  - profile3
+  - profile4
+  - profile5
+  - profile6
+  - profile7
 
 benchmark-multi-turn:
   extends:
   - benchmark
-  tests.rhaiis.workload_key: multi-turn
+  tests.rhaiis.workload_key: profile6
 
 benchmark-multi-turn-prefix-on:
   extends:
@@ -51,4 +51,4 @@ benchmark-multi-turn-prefix-off:
 benchmark-heterogeneous:
   extends:
   - benchmark
-  tests.rhaiis.workload_key: heavy-heterogeneous
+  tests.rhaiis.workload_key: profile7

--- a/projects/rhaiis/orchestration/presets.d/benchmarks.yaml
+++ b/projects/rhaiis/orchestration/presets.d/benchmarks.yaml
@@ -12,7 +12,7 @@ benchmark-standard:
   - benchmark
   tests.rhaiis.workload_key:
   - balanced
-  - variable
+  - decode-heterogeneous
 
 benchmark-long-context:
   extends:
@@ -26,7 +26,7 @@ benchmark-full-sweep:
   - benchmark
   tests.rhaiis.workload_key:
   - balanced
-  - variable
+  - decode-heterogeneous
   - summarization
   - long-context
   - ultra-long-context

--- a/projects/rhaiis/orchestration/presets.d/benchmarks.yaml
+++ b/projects/rhaiis/orchestration/presets.d/benchmarks.yaml
@@ -33,20 +33,17 @@ benchmark-full-sweep:
   - profile6
   - profile7
 
-benchmark-multi-turn:
-  extends:
-  - benchmark
-  tests.rhaiis.workload_key: profile6
-
 benchmark-multi-turn-prefix-on:
   extends:
-  - benchmark-multi-turn
+  - benchmark
   - prefix-cache-on
+  tests.rhaiis.workload_key: profile6
 
 benchmark-multi-turn-prefix-off:
   extends:
-  - benchmark-multi-turn
+  - benchmark
   - prefix-cache-off
+  tests.rhaiis.workload_key: profile6
 
 benchmark-heterogeneous:
   extends:

--- a/projects/rhaiis/orchestration/presets.d/benchmarks.yaml
+++ b/projects/rhaiis/orchestration/presets.d/benchmarks.yaml
@@ -26,7 +26,7 @@ benchmark-multi-turn-prefix-off:
   - prefix-cache-off
   tests.rhaiis.workload_key: profile6
 
-benchmark-heterogeneous:
+benchmark-heavy-heterogeneous:
   extends:
   - benchmark
   tests.rhaiis.workload_key: profile7

--- a/projects/rhaiis/orchestration/presets.d/presets.yaml
+++ b/projects/rhaiis/orchestration/presets.d/presets.yaml
@@ -67,8 +67,8 @@ profile7:
 balanced:
   tests.rhaiis.workload_key: balanced
 
-variable:
-  tests.rhaiis.workload_key: variable
+decode-heterogeneous:
+  tests.rhaiis.workload_key: decode-heterogeneous
 
 summarization:
   tests.rhaiis.workload_key: summarization

--- a/projects/rhaiis/orchestration/presets.d/presets.yaml
+++ b/projects/rhaiis/orchestration/presets.d/presets.yaml
@@ -88,7 +88,6 @@ heavy-heterogeneous:
 # ── Feature toggles ─────────────────────────────────────────
 
 prefix-cache-on:
-  rhaiis.engines.vllm.args.no-enable-prefix-caching: false
   rhaiis.engines.vllm.args.enable-prefix-caching: true
 
 prefix-cache-off:

--- a/projects/rhaiis/orchestration/presets.d/presets.yaml
+++ b/projects/rhaiis/orchestration/presets.d/presets.yaml
@@ -42,47 +42,25 @@ ci-quick:
 
 
 
-profile1:
+profile1-balanced:
   tests.rhaiis.workload_key: profile1
 
-profile2:
+profile2-decode-heterogeneous:
   tests.rhaiis.workload_key: profile2
 
-profile3:
+profile3-summarization:
   tests.rhaiis.workload_key: profile3
 
-profile4:
+profile4-long-context:
   tests.rhaiis.workload_key: profile4
 
-profile5:
+profile5-ultra-long-context:
   tests.rhaiis.workload_key: profile5
 
-profile6:
+profile6-multi-turn:
   tests.rhaiis.workload_key: profile6
 
-profile7:
-  tests.rhaiis.workload_key: profile7
-
-# Named aliases (readable names → numbered profiles)
-balanced:
-  tests.rhaiis.workload_key: profile1
-
-decode-heterogeneous:
-  tests.rhaiis.workload_key: profile2
-
-summarization:
-  tests.rhaiis.workload_key: profile3
-
-long-context:
-  tests.rhaiis.workload_key: profile4
-
-ultra-long-context:
-  tests.rhaiis.workload_key: profile5
-
-multi-turn:
-  tests.rhaiis.workload_key: profile6
-
-heavy-heterogeneous:
+profile7-heavy-heterogeneous:
   tests.rhaiis.workload_key: profile7
 
 # ── Feature toggles ─────────────────────────────────────────

--- a/projects/rhaiis/orchestration/presets.d/presets.yaml
+++ b/projects/rhaiis/orchestration/presets.d/presets.yaml
@@ -63,6 +63,37 @@ profile6:
 profile7:
   tests.rhaiis.workload_key: profile7
 
+# Named aliases (same workloads, readable names)
+balanced:
+  tests.rhaiis.workload_key: balanced
+
+variable:
+  tests.rhaiis.workload_key: variable
+
+summarization:
+  tests.rhaiis.workload_key: summarization
+
+long-context:
+  tests.rhaiis.workload_key: long-context
+
+ultra-long-context:
+  tests.rhaiis.workload_key: ultra-long-context
+
+multi-turn:
+  tests.rhaiis.workload_key: multi-turn
+
+heavy-heterogeneous:
+  tests.rhaiis.workload_key: heavy-heterogeneous
+
+# ── Feature toggles ─────────────────────────────────────────
+
+prefix-cache-on:
+  rhaiis.engines.vllm.args.no-enable-prefix-caching: false
+  rhaiis.engines.vllm.args.enable-prefix-caching: true
+
+prefix-cache-off:
+  rhaiis.engines.vllm.args.no-enable-prefix-caching: true
+
 # ── Models ──────────────────────────────────────────────────
 # Short aliases default to the FP8 variant where available.
 # Use the full name (e.g. llama-70b-w4a16) for other quants.

--- a/projects/rhaiis/orchestration/presets.d/presets.yaml
+++ b/projects/rhaiis/orchestration/presets.d/presets.yaml
@@ -63,27 +63,27 @@ profile6:
 profile7:
   tests.rhaiis.workload_key: profile7
 
-# Named aliases (same workloads, readable names)
+# Named aliases (readable names → numbered profiles)
 balanced:
-  tests.rhaiis.workload_key: balanced
+  tests.rhaiis.workload_key: profile1
 
 decode-heterogeneous:
-  tests.rhaiis.workload_key: decode-heterogeneous
+  tests.rhaiis.workload_key: profile2
 
 summarization:
-  tests.rhaiis.workload_key: summarization
+  tests.rhaiis.workload_key: profile3
 
 long-context:
-  tests.rhaiis.workload_key: long-context
+  tests.rhaiis.workload_key: profile4
 
 ultra-long-context:
-  tests.rhaiis.workload_key: ultra-long-context
+  tests.rhaiis.workload_key: profile5
 
 multi-turn:
-  tests.rhaiis.workload_key: multi-turn
+  tests.rhaiis.workload_key: profile6
 
 heavy-heterogeneous:
-  tests.rhaiis.workload_key: heavy-heterogeneous
+  tests.rhaiis.workload_key: profile7
 
 # ── Feature toggles ─────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Add human-readable **workload aliases** (`balanced`, `variable`, `summarization`, `long-context`, `ultra-long-context`, `multi-turn`, `heavy-heterogeneous`) that mirror profile1–7 for better readability in presets and CLI usage.
- Add **prefix-cache-on/off** feature toggle presets to enable A/B comparison of vLLM prefix caching behavior.
- Add **composite benchmark presets** for common test scenarios:
  - `benchmark-standard` — balanced + variable
  - `benchmark-long-context` — long-context + ultra-long-context
  - `benchmark-full-sweep` — all workloads
  - `benchmark-multi-turn` with `prefix-on`/`prefix-off` variants
  - `benchmark-heterogeneous`

## Motivation
The numbered profile names (profile1–7) are kept for model-furnace compatibility, but they're hard to remember. Named aliases let users write `benchmark-multi-turn-prefix-on + llama-70b + nvidia` instead of juggling profile numbers and manual vllm arg overrides.

## Test plan
- [ ] Verify named workload aliases resolve to the same config as their profileN counterparts
- [ ] Verify prefix-cache-on preset correctly passes `--enable-prefix-caching` to vLLM
- [ ] Verify composite presets resolve and expand correctly via runtime_config
- [ ] Run ci-test to confirm no regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added benchmark presets for standard, multi-turn with prefix caching enabled or disabled, and heavy heterogeneous workloads.
  * Added descriptive names to the seven workload profiles.

* **Updates**
  * Updated the multi-turn workload’s token targets, prefix usage, and throughput rates.
  * Renamed the heterogeneous benchmark preset to heavy heterogeneous.
  * Removed standalone readable-name aliases for workload profiles.
  * Removed the long-context benchmark preset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->