### PR TITLE
[rhaiis] fix: run all selected workload profiles from the UI

### DIFF
--- a/projects/rhaiis/orchestration/test_rhaiis.py
+++ b/projects/rhaiis/orchestration/test_rhaiis.py
@@ -16,6 +16,10 @@ init = runtime_config.init
 def test(_cfg):
     workload_keys = config.project.get_config("tests.rhaiis.workload_keys", [])
     if not workload_keys:
+        all_workloads = config.project.get_config("workloads", {})
+        project_args = config.project.get_config("project.args", [])
+        workload_keys = [a for a in project_args if a in all_workloads]
+    if not workload_keys:
         workload_keys = [_cfg.workload_key]
 
     test_phase.run(


### PR DESCRIPTION
## Summary
- When selecting multiple profiles in a single run, each preset writes `tests.rhaiis.workload_key`, so only the last profile runs.
- The test runner now builds `workload_keys` from `project.args` by matching known `workloads.*` keys, then falls back to the single `workload_key`.
- Explicit `tests.rhaiis.workload_keys` (CPT / config overrides) is still used first.

## Motivation
Selecting profile1 + profile4 (or more) in the dashboard was supposed to run every checked profile. It only ran the last one.

## Testing
- Reproduced on `rhaiis-hera-58lqd`: args had profile2, profile1, profile3, profile5; only profile5 ran.Also tested on a few other runs and confirmed that selecting multiple profiles runs only the last one.
- After this change, the same `project.args` list would become `workload_keys: [profile2, profile1, profile3, profile5]`.
- Single-profile jobs and jobs that already set `tests.rhaiis.workload_keys` are unchanged.