### PR TITLE
[mcp-gw] Support for new MCP protocol (2026-07-28, stateless)

### DIFF
--- a/projects/agentic_tools/locust/locust_runtime/locustfile_main.py
+++ b/projects/agentic_tools/locust/locust_runtime/locustfile_main.py
@@ -20,6 +20,7 @@ user_class_name = os.environ.get("USER_CLASS", "ResponsesSimpleUser")
 _user_class_modules = [
     "responses_users",
     "mcp_session_user",
+    "mcp_2026_user",
 ]
 
 

--- a/projects/agentic_tools/locust/locust_users/__init__.py
+++ b/projects/agentic_tools/locust/locust_users/__init__.py
@@ -9,6 +9,7 @@ User classes (one per file):
 - ResponsesMCPBenchmarkUser  (responses_mcp_benchmark_user.py)
 - ChatCompletionsUser        (chat_completions_user.py)
 - MCPSessionUser             (mcp_session_user.py)
+- MCP2026User                (mcp_2026_user.py)
 
 Shared utilities:
 - _common.py                 Prompt loading, round-robin counter

--- a/projects/agentic_tools/locust/locust_users/mcp_2026_user.py
+++ b/projects/agentic_tools/locust/locust_users/mcp_2026_user.py
@@ -1,0 +1,273 @@
+"""
+Locust user for MCP 2026-07-28 (stateless) through mcp-gw or direct.
+
+Does not initialize, discover, or tools/list. The first RPC is tools/call.
+
+Reusable across any FORGE project that benchmarks MCP servers or gateways.
+Copied into Locust pods as a sibling of locustfile_main.py (/scripts/).
+
+Import (host / tests)::
+
+    from projects.agentic_tools.locust.locust_users.mcp_2026_user import MCP2026User
+
+Environment variables (set by the Locust job template):
+    TOOL_PREFIX:        prefix for tool names ("mock_" via gateway, "" direct)
+    HOST_HEADER:        Host header for gateway routing (empty = none)
+    CALLS_PER_SESSION:  tool calls before rebinding host (0 = never; no handshake)
+    NUM_SERVERS:        registered servers for scale-out (0 = single server)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+import time
+from dataclasses import dataclass, field
+
+import requests
+from locust import User, between, events, task
+
+PROTOCOL_2026 = "2026-07-28"
+
+TOOL_PREFIX = os.environ.get("TOOL_PREFIX", "")
+HOST_HEADER = os.environ.get("HOST_HEADER", "")
+CALLS_PER_SESSION = int(os.environ.get("CALLS_PER_SESSION", "0"))
+NUM_SERVERS = int(os.environ.get("NUM_SERVERS", "0"))
+
+TOOL_SEQUENCE = [
+    {"name": "alpha", "args": {"input": "test"}},
+    {"name": "bravo", "args": {"input": "test"}},
+    {"name": "charlie", "args": {"input": "test"}},
+    {"name": "delta", "args": {"input": "test"}},
+    {"name": "echo", "args": {"input": "test"}},
+    {"name": "foxtrot", "args": {"input": "test"}},
+    {"name": "golf", "args": {"input": "test"}},
+    {"name": "hotel", "args": {"input": "test"}},
+    {"name": "india", "args": {"input": "test"}},
+    {"name": "juliet", "args": {"input": "test"}},
+]
+
+
+@dataclass
+class MCPResponse:
+    success: bool
+    response_time_ms: float
+    status_code: int
+    data: dict | None = None
+    error: str | None = None
+
+
+@dataclass
+class MCP2026Client:
+    """Stateless MCP client. First RPC may be tools/call."""
+
+    base_url: str
+    host_header: str | None = None
+    request_id: int = field(default=0, init=False)
+    timeout: float = 30.0
+
+    def _next_id(self) -> int:
+        self.request_id += 1
+        return self.request_id
+
+    def _headers(self, *, method: str, name: str | None = None) -> dict:
+        h = {
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream",
+            "MCP-Protocol-Version": PROTOCOL_2026,
+            "Mcp-Method": method,
+        }
+        if name:
+            h["Mcp-Name"] = name
+        if self.host_header:
+            h["Host"] = self.host_header
+        return h
+
+    def _with_meta(self, params: dict | None) -> dict:
+        out = dict(params) if params else {}
+        meta = dict(out["_meta"]) if isinstance(out.get("_meta"), dict) else {}
+        meta.setdefault("io.modelcontextprotocol/protocolVersion", PROTOCOL_2026)
+        meta.setdefault(
+            "io.modelcontextprotocol/clientInfo",
+            {"name": "forge-mcp-2026", "version": "1.0.0"},
+        )
+        meta.setdefault("io.modelcontextprotocol/clientCapabilities", {})
+        out["_meta"] = meta
+        return out
+
+    def _parse_body(self, response, elapsed_ms: float) -> MCPResponse:
+        if response.status_code != 200:
+            return MCPResponse(
+                success=False,
+                response_time_ms=elapsed_ms,
+                status_code=response.status_code,
+                error=f"HTTP {response.status_code}: {response.text[:200]}",
+            )
+
+        try:
+            ct = response.headers.get("Content-Type", "")
+            text = response.text
+
+            if "text/event-stream" in ct or text.lstrip().startswith("event:"):
+                data = None
+                for line in text.split("\n"):
+                    line = line.strip()
+                    if line.startswith("data:"):
+                        data = json.loads(line[5:].strip())
+                        break
+                if data is None:
+                    return MCPResponse(
+                        success=False,
+                        response_time_ms=elapsed_ms,
+                        status_code=response.status_code,
+                        error="Empty SSE response",
+                    )
+            else:
+                data = response.json()
+
+            if not isinstance(data, dict):
+                return MCPResponse(
+                    success=False,
+                    response_time_ms=elapsed_ms,
+                    status_code=response.status_code,
+                    error=f"Expected JSON object, got {type(data).__name__}",
+                )
+
+            if "error" in data:
+                msg = data["error"]
+                if isinstance(msg, dict):
+                    msg = msg.get("message", str(msg))
+                return MCPResponse(
+                    success=False,
+                    response_time_ms=elapsed_ms,
+                    status_code=response.status_code,
+                    error=str(msg),
+                )
+
+            return MCPResponse(
+                success=True,
+                response_time_ms=elapsed_ms,
+                status_code=response.status_code,
+                data=data.get("result"),
+            )
+        except json.JSONDecodeError as e:
+            return MCPResponse(
+                success=False,
+                response_time_ms=elapsed_ms,
+                status_code=response.status_code,
+                error=f"Invalid JSON: {e}",
+            )
+
+    def _send(
+        self, method: str, params: dict | None = None, *, name: str | None = None
+    ) -> MCPResponse:
+        payload = {
+            "jsonrpc": "2.0",
+            "method": method,
+            "id": self._next_id(),
+            "params": self._with_meta(params),
+        }
+        start = time.perf_counter()
+        try:
+            resp = requests.post(
+                f"{self.base_url}/mcp",
+                json=payload,
+                headers=self._headers(method=method, name=name),
+                timeout=self.timeout,
+            )
+            elapsed = (time.perf_counter() - start) * 1000
+            return self._parse_body(resp, elapsed)
+        except requests.exceptions.RequestException as e:
+            elapsed = (time.perf_counter() - start) * 1000
+            return MCPResponse(False, elapsed, 0, error=str(e))
+
+    def call_tool(self, name: str, arguments: dict | None = None) -> MCPResponse:
+        """POST tools/call. This is a valid first request on 2026-07-28."""
+        return self._send(
+            "tools/call",
+            {"name": name, "arguments": arguments or {}},
+            name=name,
+        )
+
+
+def _report(name: str, resp: MCPResponse):
+    if resp.success:
+        events.request.fire(
+            request_type="MCP",
+            name=name,
+            response_time=resp.response_time_ms,
+            response_length=len(str(resp.data)) if resp.data else 0,
+            exception=None,
+            context={},
+        )
+    else:
+        events.request.fire(
+            request_type="MCP",
+            name=f"FAIL:{name}",
+            response_time=resp.response_time_ms,
+            response_length=0,
+            exception=Exception(resp.error),
+            context={},
+        )
+
+
+class MCP2026User(User):
+    """
+    Stateless MCP user: round-robin tools/call with no protocol session.
+
+    Time to first tool response is the first tools/call (Locust name ``ttftr``),
+    not initialize or server/discover.
+    """
+
+    abstract = True
+    wait_time = between(0.1, 0.5)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.mcp: MCP2026Client | None = None
+        self.calls_done = 0
+        self.seq_index = 0
+        self._current_server_idx = 0
+        self._emitted_ttftr = False
+
+    def _bind_client(self) -> None:
+        """Point at a backend. No RPC."""
+        host_header = HOST_HEADER or None
+        if NUM_SERVERS > 0:
+            server_idx = random.randint(1, NUM_SERVERS)
+            host_header = f"server{server_idx}.mcp.local"
+            self._current_server_idx = server_idx
+        else:
+            self._current_server_idx = 0
+
+        self.mcp = MCP2026Client(
+            base_url=self.host,
+            host_header=host_header,
+        )
+        self.calls_done = 0
+
+    @task
+    def do_tool_call(self):
+        if self.mcp is None:
+            self._bind_client()
+
+        if CALLS_PER_SESSION > 0 and self.calls_done >= CALLS_PER_SESSION:
+            self._bind_client()
+
+        entry = TOOL_SEQUENCE[self.seq_index % len(TOOL_SEQUENCE)]
+        self.seq_index += 1
+
+        if NUM_SERVERS > 0 and self._current_server_idx > 0:
+            prefix = f"server{self._current_server_idx}_"
+        else:
+            prefix = TOOL_PREFIX
+        tool_name = f"{prefix}{entry['name']}"
+
+        r = self.mcp.call_tool(tool_name, dict(entry["args"]))
+        if not self._emitted_ttftr:
+            _report("ttftr", r)
+            self._emitted_ttftr = True
+        else:
+            _report(f"call:{entry['name']}", r)
+        self.calls_done += 1

--- a/projects/agentic_tools/mcp/toolbox/deploy_mock_servers/main.py
+++ b/projects/agentic_tools/mcp/toolbox/deploy_mock_servers/main.py
@@ -34,9 +34,11 @@ def run(
     image: str,
     name_prefix: str = "mock-server",
     tools_per_server: int = 10,
+    protocol_mode: str = "stateful",
     labels: dict[str, str] | None = None,
     node_selector: dict[str, str] | None = None,
     tolerations: list[dict[str, str]] | None = None,
+    resources: dict[str, Any] | None = None,
     rollout_timeout: str = "120s",
 ) -> int:
     """Deploy mock servers and wait for readiness."""
@@ -59,6 +61,7 @@ def generate_and_apply_manifests(args, ctx):
     """Generate YAML manifests for all servers and apply them."""
     merged_labels = dict(args.labels) if args.labels else {}
     merged_labels["forge.openshift.io/component"] = "mock-mcp"
+    merged_labels["forge.openshift.io/mcp-protocol"] = args.protocol_mode
 
     ctx.names = [f"{args.name_prefix}-{i}" for i in range(1, args.count + 1)]
 
@@ -69,9 +72,11 @@ def generate_and_apply_manifests(args, ctx):
             namespace=args.namespace,
             image=args.image,
             tools_per_server=args.tools_per_server,
+            protocol_mode=args.protocol_mode,
             labels=merged_labels,
             node_selector=args.node_selector,
             tolerations=args.tolerations,
+            resources=args.resources,
         )
         all_manifests.append(manifest)
 
@@ -225,34 +230,42 @@ def _generate_server_manifest(
     namespace: str,
     image: str,
     tools_per_server: int,
+    protocol_mode: str,
     labels: dict[str, str],
     node_selector: dict[str, str] | None = None,
     tolerations: list[dict[str, str]] | None = None,
+    resources: dict[str, Any] | None = None,
 ) -> str:
     """Generate a YAML manifest for a single mock server Deployment + Service."""
     label_set = {"app": name}
     label_set.update(labels)
 
-    pod_spec: dict[str, Any] = {
-        "containers": [
+    container: dict[str, Any] = {
+        "name": "server",
+        "image": image,
+        "imagePullPolicy": "Always",
+        "args": ["--addr", ":8080"],
+        "env": [
+            {"name": "GOGC", "value": "off"},
+            {"name": "NUM_TOOLS", "value": str(tools_per_server)},
             {
-                "name": "server",
-                "image": image,
-                "imagePullPolicy": "Always",
-                "args": ["--addr", ":8080"],
-                "env": [
-                    {"name": "GOGC", "value": "off"},
-                    {"name": "NUM_TOOLS", "value": str(tools_per_server)},
-                ],
-                "ports": [{"containerPort": 8080, "name": "http"}],
-                "readinessProbe": {
-                    "tcpSocket": {"port": 8080},
-                    "initialDelaySeconds": 2,
-                    "periodSeconds": 5,
-                    "timeoutSeconds": 2,
-                },
-            }
+                "name": "STATELESS",
+                "value": "true" if protocol_mode == "stateless" else "false",
+            },
         ],
+        "ports": [{"containerPort": 8080, "name": "http"}],
+        "readinessProbe": {
+            "tcpSocket": {"port": 8080},
+            "initialDelaySeconds": 2,
+            "periodSeconds": 5,
+            "timeoutSeconds": 2,
+        },
+    }
+    if resources:
+        container["resources"] = resources
+
+    pod_spec: dict[str, Any] = {
+        "containers": [container],
     }
     if node_selector:
         pod_spec["nodeSelector"] = node_selector

--- a/projects/mcp_gateway/README.md
+++ b/projects/mcp_gateway/README.md
@@ -50,7 +50,8 @@ projects/
 | Summary helpers | `agentic_tools/locust/helpers/summary` | Saving metrics.json + parameters.json for caliper multi-run export |
 | Locust K8s template | `agentic_tools/locust/templates/locust_job.yaml` | Base Job/Service YAML for distributed Locust deployments |
 | Locust runtime | `agentic_tools/locust/locust_runtime/` | Shared entry point, warmup hook, load shapes |
-| MCP session user | `agentic_tools/locust/locust_users/mcp_session_user.py` | Locust user class for MCP protocol load |
+| MCP session user | `agentic_tools/locust/locust_users/mcp_session_user.py` | Locust user class for MCP protocol load (stateful) |
+| MCP 2026 user | `agentic_tools/locust/locust_users/mcp_2026_user.py` | Locust user class for MCP 2026-07-28 (stateless) |
 | Mock MCP server deployer | `agentic_tools/mcp/toolbox/deploy_mock_servers` | Deploying/restarting/cleaning up 1..N mock MCP server pods |
 | MCP HTTP client | `agentic_tools/mcp/clients/mcp_client.py` | Streamable HTTP client implementing MCP protocol |
 

--- a/projects/mcp_gateway/orchestration/config.d/mock_servers.yaml
+++ b/projects/mcp_gateway/orchestration/config.d/mock_servers.yaml
@@ -1,3 +1,3 @@
 perf-mock-server:
-  image: quay.io/rh-ee-aharush/perf-mock-server:latest
+  image: quay.io/rh-ee-aharush/perf-mock-server:new-protocol
   tools_per_server: 10

--- a/projects/mcp_gateway/orchestration/config.d/runtime.yaml
+++ b/projects/mcp_gateway/orchestration/config.d/runtime.yaml
@@ -3,6 +3,7 @@ namespace_override: null
 
 namespace: mcp-gw-bench
 mock_server: perf-mock-server
+protocol_mode: stateful
 calls_per_session: 0
 spawn_rate: null
 users_per_worker: 32

--- a/projects/mcp_gateway/orchestration/preflight_phase.py
+++ b/projects/mcp_gateway/orchestration/preflight_phase.py
@@ -338,6 +338,6 @@ def _get_mock_server_image() -> str:
     """Resolve the mock server container image from config."""
     try:
         mock_cfg = cfg.get_mock_server_config()
-        return mock_cfg.get("image", "quay.io/rh-ee-aharush/perf-mock-server:latest")
+        return mock_cfg.get("image", "quay.io/rh-ee-aharush/perf-mock-server:new-protocol")
     except Exception:
-        return "quay.io/rh-ee-aharush/perf-mock-server:latest"
+        return "quay.io/rh-ee-aharush/perf-mock-server:new-protocol"

--- a/projects/mcp_gateway/orchestration/runtime_config.py
+++ b/projects/mcp_gateway/orchestration/runtime_config.py
@@ -25,6 +25,10 @@ class MCPGatewayConfig(BaseRuntimeConfig):
     def get_mock_server_key(self) -> str:
         return config.project.get_config("runtime.mock_server")
 
+    def get_protocol_mode(self) -> str:
+        """Return MCP protocol mode: stateful (2025) or stateless (2026)."""
+        return config.project.get_config("runtime.protocol_mode", "stateful")
+
     def get_mock_server_config(self) -> dict[str, Any]:
         key = self.get_mock_server_key()
         return copy.deepcopy(config.project.get_config(f"mock_servers.{key}"))
@@ -197,19 +201,33 @@ class MCPGatewayConfig(BaseRuntimeConfig):
             tool_prefix = ""
             host_header = ""
 
+        protocol_mode = self.get_protocol_mode()
+        runtime_dir = Path(locust_runtime.__file__).parent
+        users_dir = Path(locust_users.__file__).parent
+
+        if protocol_mode == "stateless":
+            user_class = "MCP2026User"
+            extra_files = [
+                str(users_dir / "mcp_2026_user.py"),
+            ]
+        else:
+            user_class = "MCPSessionUser"
+            extra_files = [
+                str(users_dir / "mcp_session_user.py"),
+                str(self.get_mcp_client_path()),
+            ]
+
         env_vars = {
-            "USER_CLASS": "MCPSessionUser",
+            "USER_CLASS": user_class,
             "TARGET": target,
             "TOOL_PREFIX": tool_prefix,
             "HOST_HEADER": host_header,
             "CALLS_PER_SESSION": str(self.get_calls_per_session()),
             "WARMUP_SECONDS": str(warmup_seconds),
+            "PROTOCOL_MODE": protocol_mode,
         }
         if num_servers > 1:
             env_vars["NUM_SERVERS"] = str(num_servers)
-
-        runtime_dir = Path(locust_runtime.__file__).parent
-        users_dir = Path(locust_users.__file__).parent
 
         return dict(
             job_name=job_name,
@@ -222,7 +240,7 @@ class MCPGatewayConfig(BaseRuntimeConfig):
             configmap_name=f"locust-scripts-mcp-{preset}"[:63],
             locustfiles_dir=str(runtime_dir),
             locustfile_names=["locustfile_main.py", "metrics_hook.py"],
-            extra_files=[str(users_dir / "mcp_session_user.py"), str(self.get_mcp_client_path())],
+            extra_files=extra_files,
             env_vars=env_vars,
             labels={"forge.openshift.io/project": "mcp_gateway"},
             node_selector=scheduling.get("node_selector"),

--- a/projects/mcp_gateway/orchestration/test_phase.py
+++ b/projects/mcp_gateway/orchestration/test_phase.py
@@ -42,6 +42,7 @@ def do_test() -> int:
     preset = cfg.get_preset_name()
     mock_server = cfg.get_mock_server_key()
     mock_server_cfg = cfg.get_mock_server_config()
+    protocol_mode = cfg.get_protocol_mode()
     version = cfg.get_deployed_version()
 
     servers = cfg.get_experiment_servers()
@@ -82,6 +83,7 @@ def do_test() -> int:
                         preset=preset,
                         mock_server=mock_server,
                         mock_server_cfg=mock_server_cfg,
+                        protocol_mode=protocol_mode,
                         version=version,
                         num_servers=num_servers,
                         users=users,
@@ -99,6 +101,7 @@ def do_test() -> int:
     summary: dict[str, Any] = {
         "preset": preset,
         "version": version,
+        "protocol_mode": protocol_mode,
         "servers": servers,
         "concurrency": concurrency,
         "targets": targets,
@@ -126,6 +129,7 @@ def run_one_test(
     preset: str,
     mock_server: str,
     mock_server_cfg: dict[str, Any],
+    protocol_mode: str,
     version: str,
     num_servers: int,
     users: int,
@@ -138,6 +142,8 @@ def run_one_test(
     job_name: str,
 ) -> None:
     """Run a single test iteration inside a NextArtifactDir context."""
+    version_kind = "sha" if re.fullmatch(r"[0-9a-f]{40}", version) else "release"
+    version_source = "ghcr" if version_kind == "sha" else "tag"
     write_test_labels(
         env.ARTIFACT_DIR,
         {
@@ -146,7 +152,10 @@ def run_one_test(
             "users": str(users),
             "num_servers": str(num_servers),
             "mock_server": mock_server,
+            "protocol_mode": protocol_mode,
             "mcp_gateway_version": version,
+            "version_kind": version_kind,
+            "version_source": version_source,
             "tools_per_server": str(tools_per_server),
         },
     )
@@ -203,7 +212,7 @@ def _deploy_servers(
     scheduling: dict[str, Any] | None = None,
 ) -> None:
     """Deploy mock server(s) and gateway infrastructure."""
-    image = mock_server_cfg.get("image", "quay.io/rh-ee-aharush/perf-mock-server:latest")
+    image = mock_server_cfg.get("image", "quay.io/rh-ee-aharush/perf-mock-server:new-protocol")
     sched = scheduling or {}
 
     deploy_mock_servers.run(
@@ -211,9 +220,11 @@ def _deploy_servers(
         count=num_servers,
         image=image,
         tools_per_server=tools_per_server,
+        protocol_mode=cfg.get_protocol_mode(),
         labels={"forge.openshift.io/project": "mcp_gateway"},
         node_selector=sched.get("node_selector"),
         tolerations=sched.get("tolerations"),
+        resources=mock_server_cfg.get("resources"),
     )
 
     if "gateway" in targets:


### PR DESCRIPTION
## Summary
Split out of #170 (1/3).

- Add a stateless MCP 2026-07-28 Locust user (`mcp_2026_user.py`) alongside the existing stateful `mcp_session_user.py`.
- Wire `runtime.protocol_mode` (`stateful`/`stateless`) through `runtime_config.py` to select the Locust user class/env vars.
- Point the mock server deployer/image at the new-protocol build and update `deploy_mock_servers`.
- Update `test_phase.py` and mcp_gateway `README.md` accordingly.

## Files
- projects/agentic_tools/locust/locust_runtime/locustfile_main.py
- projects/agentic_tools/locust/locust_users/__init__.py
- projects/agentic_tools/locust/locust_users/mcp_2026_user.py
- projects/agentic_tools/mcp/toolbox/deploy_mock_servers/main.py
- projects/mcp_gateway/README.md
- projects/mcp_gateway/orchestration/config.d/mock_servers.yaml
- projects/mcp_gateway/orchestration/config.d/runtime.yaml
- projects/mcp_gateway/orchestration/preflight_phase.py
- projects/mcp_gateway/orchestration/runtime_config.py
- projects/mcp_gateway/orchestration/test_phase.py

## Test plan
- [ ] Smoke: `protocol_mode: stateful` Locust job still mounts `mcp_session_user` + `mcp_client`
- [ ] Smoke: `protocol_mode: stateless` Locust job mounts `mcp_2026_user` and mock servers get the new-protocol image

Made with [Cursor](https://cursor.com)