### PR TITLE
[mcp-gw] Node scheduling for platform install/cleanup

### DIFF
--- a/projects/mcp_gateway/orchestration/cleanup_phase.py
+++ b/projects/mcp_gateway/orchestration/cleanup_phase.py
@@ -82,7 +82,11 @@ def run_platform_cleanup() -> int:
                     "Kustomize-based cleanup steps will be skipped."
                 )
 
-        cleanup_platform_mod.run(platform_config=platform_cfg)
+        scheduling = cfg.get_scheduling_config()
+        cleanup_platform_mod.run(
+            platform_config=platform_cfg,
+            scheduling_node_selector=scheduling.get("node_selector"),
+        )
         cleanup_platform_clone()
     else:
         logger.info("Platform cleanup not enabled (cleanup_platform=false)")

--- a/projects/mcp_gateway/orchestration/prepare_phase.py
+++ b/projects/mcp_gateway/orchestration/prepare_phase.py
@@ -80,7 +80,11 @@ def run() -> int:
                 f"Cannot install nightly build for commit {version}."
             )
 
-    install_platform_mod.run(platform_config=platform_cfg)
+    scheduling = cfg.get_scheduling_config()
+    install_platform_mod.run(
+        platform_config=platform_cfg,
+        scheduling_node_selector=scheduling.get("node_selector"),
+    )
 
     ensure_namespace(
         namespace,

--- a/projects/mcp_gateway/toolbox/cleanup_platform/main.py
+++ b/projects/mcp_gateway/toolbox/cleanup_platform/main.py
@@ -26,12 +26,14 @@ logger = logging.getLogger(__name__)
 def run(
     *,
     platform_config: dict[str, Any],
+    scheduling_node_selector: dict[str, str] | None = None,
 ) -> int:
     """
     Remove the full MCP Gateway platform stack in reverse order.
 
     Args:
         platform_config: Platform configuration dict from infrastructure.yaml
+        scheduling_node_selector: Labels to remove from worker nodes after cleanup
     """
     execute_tasks(locals())
     return 0
@@ -49,6 +51,7 @@ def resolve_config(args, ctx):
     ctx.gateway_namespace = config.get("gateway_namespace", "gateway-system")
     ctx.ctrl = config.get("mcp_gateway_controller", {})
     ctx.steps = config.get("steps", [])
+    ctx.node_selector = args.scheduling_node_selector or {}
 
     return f"Cleanup config resolved: {len(ctx.steps)} steps"
 
@@ -191,6 +194,23 @@ def delete_namespaces(args, ctx):
     )
 
     return f"Deleted namespaces: {', '.join(to_delete)}"
+
+
+@always
+@task
+def unlabel_worker_nodes(args, ctx):
+    """Remove scheduling node_selector labels from worker nodes."""
+    selector = ctx.node_selector
+    if not selector:
+        return "No node_selector configured, skipping"
+
+    label_sel = ",".join(f"{k}={v}" for k, v in selector.items())
+    result = oc("get", "nodes", "-l", label_sel, "-o", "name", check=False, log_stdout=False)
+    nodes = [line.rsplit("/", 1)[-1] for line in result.stdout.splitlines() if line.strip()]
+    for node in nodes:
+        oc("label", "node", node, *[f"{k}-" for k in selector], check=False)
+        logger.info("Removed scheduling labels from node %s", node)
+    return f"Removed scheduling labels from {len(nodes)} node(s)"
 
 
 @always

--- a/projects/mcp_gateway/toolbox/install_platform/main.py
+++ b/projects/mcp_gateway/toolbox/install_platform/main.py
@@ -38,12 +38,14 @@ logger = logging.getLogger(__name__)
 def run(
     *,
     platform_config: dict[str, Any],
+    scheduling_node_selector: dict[str, str] | None = None,
 ) -> int:
     """
     Install the full MCP Gateway platform stack.
 
     Args:
         platform_config: Platform configuration dict from infrastructure.yaml
+        scheduling_node_selector: Labels to apply to worker nodes before install
     """
     execute_tasks(locals())
     return 0
@@ -75,7 +77,66 @@ def validate_config(args, ctx):
     logger.info("MCP Gateway namespace: %s", ctx.mcp_gateway_namespace)
     logger.info("Gateway namespace: %s", ctx.gateway_namespace)
 
+    ctx.node_selector = args.scheduling_node_selector or {}
+
     return f"Config validated: {len(ctx.steps)} steps, kustomize_base={ctx.kustomize_base}"
+
+
+@task
+def label_worker_nodes(args, ctx):
+    """Select the worker node with the most allocatable resources and label it."""
+    selector = ctx.node_selector
+    if not selector:
+        return "No node_selector configured, skipping"
+
+    import json
+
+    result = oc(
+        "get",
+        "nodes",
+        "-l",
+        "node-role.kubernetes.io/worker",
+        "-o",
+        "json",
+        check=False,
+        log_stdout=False,
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        return "No worker nodes found"
+
+    nodes_data = json.loads(result.stdout)
+    best_node = None
+    best_score = -1
+
+    for node in nodes_data.get("items", []):
+        conditions = node.get("status", {}).get("conditions", [])
+        ready = any(c.get("type") == "Ready" and c.get("status") == "True" for c in conditions)
+        if not ready:
+            continue
+
+        alloc = node.get("status", {}).get("allocatable", {})
+        cpu_str = alloc.get("cpu", "0")
+        cpu_milli = _parse_cpu_to_milli(cpu_str)
+        mem_str = alloc.get("memory", "0")
+        mem_bytes = _parse_mem_to_bytes(mem_str)
+
+        score = cpu_milli * 1_000_000 + mem_bytes
+        if score > best_score:
+            best_score = score
+            best_node = node["metadata"]["name"]
+
+    if not best_node:
+        return "No Ready worker nodes found"
+
+    oc(
+        "label",
+        "node",
+        best_node,
+        "--overwrite",
+        *[f"{k}={v}" for k, v in selector.items()],
+        log_stdout=False,
+    )
+    return f"Labeled strongest worker node with {selector}"
 
 
 @task
@@ -545,6 +606,31 @@ def _version_gte(version: str, minimum: str) -> bool:
             minimum,
         )
         return False
+
+
+def _parse_cpu_to_milli(cpu: str) -> int:
+    """Convert a Kubernetes CPU string to millicores."""
+    if cpu.endswith("m"):
+        return int(cpu[:-1])
+    return int(float(cpu) * 1000)
+
+
+def _parse_mem_to_bytes(mem: str) -> int:
+    """Convert a Kubernetes memory string to bytes."""
+    suffixes = {
+        "Ki": 1024,
+        "Mi": 1024**2,
+        "Gi": 1024**3,
+        "Ti": 1024**4,
+        "K": 1000,
+        "M": 1000**2,
+        "G": 1000**3,
+        "T": 1000**4,
+    }
+    for suffix, multiplier in suffixes.items():
+        if mem.endswith(suffix):
+            return int(mem[: -len(suffix)]) * multiplier
+    return int(mem)
 
 
 def _version_spec(version: str) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
Split out of #170 (3/3).

- Add `scheduling_node_selector` support to `install_platform`/`cleanup_platform` toolbox commands to label/unlabel worker nodes around platform install and teardown.
- Wire `prepare_phase.py`/`cleanup_phase.py` to pass `infrastructure.scheduling.node_selector` (via the existing `cfg.get_scheduling_config()`) into those toolbox calls.

## Files
- projects/mcp_gateway/toolbox/install_platform/main.py
- projects/mcp_gateway/toolbox/cleanup_platform/main.py
- projects/mcp_gateway/orchestration/prepare_phase.py
- projects/mcp_gateway/orchestration/cleanup_phase.py

## Test plan
- [ ] Smoke: platform install labels the selected worker node(s) per `infrastructure.scheduling.node_selector`
- [ ] Smoke: platform cleanup removes those labels afterward

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional worker-node scheduling labels for platform installation.
  * The system selects the Ready worker node with the greatest available CPU and memory, then applies the configured labels.
* **Bug Fixes**
  * Cleanup now removes previously applied scheduling labels from matching worker nodes.
  * Cleanup safely skips label removal when no scheduling selector is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->