### PR TITLE
[rhaiis] Fix empty dashboard CSV: wire kpi_catalog in RhaiisPlugin

### DIFF
--- a/projects/caliper/engine/kpi/format.py
+++ b/projects/caliper/engine/kpi/format.py
@@ -86,6 +86,8 @@ def transform_kpis_to_hierarchical_format(kpis: list[dict], model) -> dict:
             final_value = raw_value
 
         kpi_record: dict[str, Any] = kpi_model.copy()
+        if "kpi_id" in kpi_record:
+            kpi_record["id"] = kpi_record.pop("kpi_id")
         kpi_record["value"] = final_value
 
         kpi_specific_labels = {k: kpi_labels[k] for k in varying_keys if k in kpi_labels}

--- a/projects/caliper/engine/kpi/format.py
+++ b/projects/caliper/engine/kpi/format.py
@@ -46,6 +46,10 @@ def transform_kpis_to_hierarchical_format(kpis: list[dict], model) -> dict:
         for k, v in kpi.get("labels", {}).items():
             run_label_values[run_id][k].add(str(v))
 
+    per_kpi_label_keys: dict[str, set[str]] = {}
+    for run_id, label_vals in run_label_values.items():
+        per_kpi_label_keys[run_id] = {k for k, vals in label_vals.items() if len(vals) > 1}
+
     for kpi in kpis:
         kpi_id = kpi.get("kpi_id")
         if kpi_id not in kpi_models:
@@ -55,11 +59,11 @@ def transform_kpis_to_hierarchical_format(kpis: list[dict], model) -> dict:
 
         run_id = kpi.get("run_id", "unknown")
         test_data = tests_data[run_id]
+        varying_keys = per_kpi_label_keys.get(run_id, set())
 
-        if "labels" not in test_data:
-            test_data["labels"] = {}
-
-        test_data["labels"].update(kpi["labels"])
+        kpi_labels = kpi.get("labels", {})
+        test_labels = {k: v for k, v in kpi_labels.items() if k not in varying_keys}
+        test_data["labels"].update(test_labels)
 
         # Store test metadata from first KPI
         if not test_data["metadata"]:
@@ -83,6 +87,10 @@ def transform_kpis_to_hierarchical_format(kpis: list[dict], model) -> dict:
 
         kpi_record: dict[str, Any] = kpi_model.copy()
         kpi_record["value"] = final_value
+
+        kpi_specific_labels = {k: kpi_labels[k] for k in varying_keys if k in kpi_labels}
+        if kpi_specific_labels:
+            kpi_record["labels"] = kpi_specific_labels
 
         for fmt_key in "x_format", "y_format", "format":
             kpi_record.pop(fmt_key, None)

--- a/projects/guidellm/postprocess/guidellm/dashboard.py
+++ b/projects/guidellm/postprocess/guidellm/dashboard.py
@@ -423,7 +423,7 @@ def export_dashboard_kpis_to_csv(
     labels_by_group: dict[tuple[str, str], dict[str, Any]] = {}
     for kpi in kpi_records:
         labels = kpi.get("labels", {})
-        key = (str(kpi.get("run_path", "")), str(labels.get("rate_index", "0")))
+        key = (str(kpi.get("run_path") or kpi.get("run_id", "")), str(labels.get("rate_index", "0")))
         column = kpi_to_column.get(kpi.get("kpi_id", ""))
         if column:
             groups.setdefault(key, {})[column] = kpi.get("value")

--- a/projects/guidellm/postprocess/guidellm/dashboard.py
+++ b/projects/guidellm/postprocess/guidellm/dashboard.py
@@ -402,6 +402,7 @@ def dashboard_kpi_catalog(*, prefix: str) -> list[dict[str, Any]]:
             "name": f"{prefix}_{suffix}",
             "unit": unit,
             "higher_is_better": higher_is_better,
+            "is_2d": False,
         }
         for suffix, _, _, unit, higher_is_better in DASHBOARD_METRICS
     ]

--- a/projects/guidellm/postprocess/guidellm/dashboard.py
+++ b/projects/guidellm/postprocess/guidellm/dashboard.py
@@ -423,7 +423,10 @@ def export_dashboard_kpis_to_csv(
     labels_by_group: dict[tuple[str, str], dict[str, Any]] = {}
     for kpi in kpi_records:
         labels = kpi.get("labels", {})
-        key = (str(kpi.get("run_path") or kpi.get("run_id", "")), str(labels.get("rate_index", "0")))
+        key = (
+            str(kpi.get("run_path") or kpi.get("run_id", "")),
+            str(labels.get("rate_index", "0")),
+        )
         column = kpi_to_column.get(kpi.get("kpi_id", ""))
         if column:
             groups.setdefault(key, {})[column] = kpi.get("value")

--- a/projects/rhaiis/postprocess/plugin.py
+++ b/projects/rhaiis/postprocess/plugin.py
@@ -55,6 +55,9 @@ class RhaiisPlugin(PostProcessingPlugin):
     ) -> list[str]:
         return []
 
+    def kpi_catalog(self) -> list[dict[str, object]]:
+        return self.kpi_handler.get_catalog()
+
     def compute_kpis(self, model: UnifiedRunModel) -> list[dict[str, Any]]:
         return self.kpi_handler.compute_kpis(model)
 


### PR DESCRIPTION
## Summary

Fixes 5 bugs introduced by PR #191 (`kpouget/kpis`) that broke the rhaiis KPI pipeline end-to-end: empty `kpis.json`, 0-row `dashboard.csv`, no MLflow metrics, and no Slack notifications.

## Bugs Fixed

### 1. `RhaiisPlugin` missing `kpi_catalog()` override
`transform_kpis_to_hierarchical_format` validates every KPI against the plugin's `kpi_catalog()`. `RhaiisPlugin` inherited the default empty list, so all `rhaiis_*` KPIs were rejected as "not found in the KPI metadata" → empty `kpis.json`.

**Fix:** Wire `RhaiisKpiHandler.get_catalog()` to `kpi_catalog()`.

### 2. `dashboard_kpi_catalog` missing `is_2d` field
The formatter accesses `kpi_model["is_2d"]` on every catalog entry. `dashboard_kpi_catalog()` didn't include this field → `KeyError: 'is_2d'` crash, `kpis.json` never written.

**Fix:** Add `"is_2d": False` to catalog entries (all dashboard metrics are scalar).

### 3. Varying labels (e.g. `rate_index`) merged into test-level labels
The first-pass varying-label detection was computed but never used — all labels were blindly merged into test-level labels via `test_data["labels"].update(kpi["labels"])`. Last-writer-wins dropped all but the last `rate_index`, collapsing all rate points into 1 CSV row.

**Fix:** Split labels: constant labels go to test level, varying labels (`rate_index`, `run_uuid`, etc.) attached per-KPI.

### 4. `kpi_id` vs `id` field name mismatch in hierarchical format
`kpi_model.copy()` produces records with `kpi_id`, but `kpis_to_mlflow` and `flatten_hierarchical_kpis` read `kpi.get("id")`. This caused `kpis_to_mlflow` to skip ALL metrics → empty `metrics.json` in MLflow.

**Fix:** Rename `kpi_id` → `id` when building the hierarchical KPI record.

### 5. `run_path` lost after hierarchical round-trip
`export_dashboard_kpis_to_csv` groups by `(run_path, rate_index)`, but `run_path` doesn't survive the hierarchical transform. For multi-profile runs (e.g. profile1 + profile2 + profile4), all records collapse to `run_path=""`, merging different profiles into the same CSV rows — data loss.

**Fix:** Fall back to `run_id` when `run_path` is absent.

## Downstream effects resolved

- **Slack notifications**: gated on `ret == 0` in `test_phase.py`; postprocess failure set `ret = 1`. With fixes, postprocess succeeds → notifications fire.
- **Regression analysis**: reads `dashboard.csv` from S3; was getting empty/wrong data.
- **MLflow metrics**: `kpis_to_mlflow` writes `metrics.json` per test directory; was writing nothing.

## Latent bugs in other plugins (same pattern)

`GuideLLMPlugin` and `MCPGatewayPlugin` also don't override `kpi_catalog()` — they would hit bug #1 if their KPI pipeline runs with the hierarchical formatter.

## Test plan

- [ ] Verify a ci-quick rhaiis run produces non-empty `kpis.json` with correct KPI IDs (`id` field)
- [ ] Verify `dashboard.csv` has the correct number of rows (1 per rate point per profile)
- [ ] Verify MLflow `metrics.json` is written with metric values
- [ ] Verify Slack notification fires on success
- [ ] Verify multi-profile run (3+ profiles) produces correct CSV row count