### PR TITLE
Enable sglang to expose /metrics endpoint

### DIFF
--- a/projects/rhaiis/orchestration/config.d/rhaiis.yaml
+++ b/projects/rhaiis/orchestration/config.d/rhaiis.yaml
@@ -26,7 +26,7 @@ engines:
       nvidia: lmsysorg/sglang:v0.5.11
       amd: lmsysorg/sglang:v0.5.4.post2-rocm700-mi30x
     port: 8080
-    args: {}
+    args: 
       enable-metrics: true
   trtllm:
     images:

--- a/projects/rhaiis/orchestration/config.d/rhaiis.yaml
+++ b/projects/rhaiis/orchestration/config.d/rhaiis.yaml
@@ -27,6 +27,7 @@ engines:
       amd: lmsysorg/sglang:v0.5.4.post2-rocm700-mi30x
     port: 8080
     args: {}
+      enable-metrics: true
   trtllm:
     images:
       nvidia: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc13


### PR DESCRIPTION
sglang needs --enable-metrics to expose its /metrics endpoint 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled metrics collection for the sglang engine, providing improved visibility into its operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->