### PR TITLE
pyproject: update the kaleido dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
 
 dependencies = [
     "plotly>=5.17.0",
+    "kaleido>=1.0.0",
     "dash>=2.14.0",
     "dash-bootstrap-components>=1.5.0",
     "jinja2",
@@ -71,7 +72,7 @@ matrix_benchmarking = [
     "pandas",
     "dash",
     "plotly",
-    "kaleido==0.2.1",
+    "kaleido>=1.0.0",
     "fire",
     "pyyaml",
     "BeautifulSoup4==4.11.*",


### PR DESCRIPTION
hitting this otherwise:
```
Saving multi-turn_token_throughput_percentiles as PNG image...
Failed to save figure multi-turn_token_throughput_percentiles:
Image export requires the Kaleido package, v1.0.0 or greater,
which can be installed using pip:

    $ pip install --upgrade "kaleido>=1"
```