### PR TITLE
[caliper] Finish the refactoring to use dataclasses

### DIFF
--- a/projects/caliper/engine/file_export/mlflow_backend.py
+++ b/projects/caliper/engine/file_export/mlflow_backend.py
@@ -350,7 +350,7 @@ def log_artifacts(
     upload_workers: int = 10,
     run_metadata: dict[str, Any] | None = None,
     workspace: str | None = None,
-) -> tuple[str, dict[str, Any] | None]:
+) -> tuple[str, dict[str, Any] | None, bool]:
     try:
         import mlflow
     except ImportError as e:
@@ -420,6 +420,8 @@ def log_artifacts(
         if run_name:
             start_kw["run_name"] = run_name
 
+        partial_failure = []
+
         meta: dict[str, Any] | None = None
         client = mlflow.tracking.MlflowClient()
         with mlflow.start_run(**start_kw):
@@ -429,7 +431,7 @@ def log_artifacts(
             _apply_run_metadata(effective_meta)
             _apply_log_model(artifact_root, effective_meta, verbose=verbose)
 
-            _log_metrics_and_params_from_tree(artifact_root)
+            partial_failure += _log_metrics_and_params_from_tree(artifact_root)
 
             _upload_mlflow_files_parallel(
                 client=client,
@@ -441,13 +443,19 @@ def log_artifacts(
             )
             tu = mlflow.get_tracking_uri() or ""
             meta = _capture_mlflow_run_metadata(tu, workspace=workspace)
-        if verbose:
+
+        if partial_failure:
+            logger.info(f"MLflow upload partially failed ({mlflow.get_tracking_uri()})")
+
+        elif verbose:
             logger.info(f"MLflow upload finished ({mlflow.get_tracking_uri()})")
-        return f"mlflow:{mlflow.get_tracking_uri()}", meta
+
+        return f"mlflow:{mlflow.get_tracking_uri()}", meta, any(partial_failure)
 
     if connection is not None:
         with mlflow_connection_env(connection):
             return _run(tracking_uri or connection.get("tracking_uri"))
+
     return _run(tracking_uri)
 
 
@@ -464,28 +472,32 @@ def _load_json_file(path: Path) -> dict[str, Any]:
         return {}
 
 
-def _log_curve_metrics(metrics_curve: dict[str, Any]) -> None:
+def _log_curve_metrics(metrics_curve: dict[str, Any]) -> list[str]:
     """Log curve metrics as stepped MLflow metrics.
 
     Each key maps to a list of ``{"x": ..., "y": ...}`` dicts (already
     sorted by x in ``metrics_from_kpis``).  Each data point is logged
     with ``step=int(x)`` so MLflow renders the curve.
 
-    Raises:
-        ValueError: If a data point has a non-integer x value (MLflow
-            steps must be integers) or if x/y are not numeric.
+    Returns:
+        List of error messages for curves that could not be logged.
     """
     import mlflow
+
+    errors = []
 
     for metric_name, data_points in metrics_curve.items():
         if not isinstance(data_points, list):
             continue
+
+        curve_errors = []
         for i, pt in enumerate(data_points):
             if not isinstance(pt, dict):
-                raise ValueError(
-                    f"2D metric {metric_name!r}: data_points[{i}] is {type(pt).__name__}, "
+                curve_errors.append(
+                    f"curve {metric_name!r}: data_points[{i}] is {type(pt).__name__}, "
                     f"expected dict with 'x' and 'y' keys"
                 )
+                continue
             x = pt.get("x")
             y = pt.get("y")
             if (
@@ -494,19 +506,29 @@ def _log_curve_metrics(metrics_curve: dict[str, Any]) -> None:
                 or not isinstance(y, int | float)
                 or isinstance(y, bool)
             ):
-                raise ValueError(
-                    f"2D metric {metric_name!r}: data_points[{i}] has non-numeric "
-                    f"x={x!r} or y={y!r}"
+                curve_errors.append(
+                    f"curve {metric_name!r}: data_points[{i}] has non-numeric x={x!r} or y={y!r}"
                 )
+                continue
             if x != int(x):
-                raise ValueError(
-                    f"2D metric {metric_name!r}: data_points[{i}] has non-integer "
+                curve_errors.append(
+                    f"curve {metric_name!r}: data_points[{i}] has non-integer "
                     f"step x={x!r} (MLflow steps must be integers)"
                 )
-            mlflow.log_metric(str(metric_name), float(y), step=int(x))
+                continue
+
+            try:
+                mlflow.log_metric(str(metric_name), float(y), step=int(x))
+            except Exception as e:
+                curve_errors.append(f"curve {metric_name!r}: failed to log point {i}: {e}")
+
+        if curve_errors:
+            errors.extend(curve_errors)
+
+    return errors
 
 
-def _log_metrics_and_params_from_tree(artifact_root: Path) -> None:
+def _log_metrics_and_params_from_tree(artifact_root: Path) -> list[str]:
     """Find metrics.json/parameters.json under metadata-marked dirs and log them (with backwards compatibility)."""
     import mlflow
 
@@ -522,12 +544,15 @@ def _log_metrics_and_params_from_tree(artifact_root: Path) -> None:
         if marker.is_file() and marker.parent not in metadata_dirs:
             metadata_dirs.add(marker.parent)
 
+    all_errors = []
+
     for run_dir in sorted(metadata_dirs):
         mf = run_dir / "metrics.json"
         if mf.is_file():
             for k, v in _load_json_file(mf).items():
                 if isinstance(v, list):
-                    _log_curve_metrics({k: v})
+                    curve_errors = _log_curve_metrics({k: v})
+                    all_errors.extend(curve_errors)
                 elif isinstance(v, int | float) and not isinstance(v, bool):
                     mlflow.log_metric(str(k), float(v))
 
@@ -535,6 +560,11 @@ def _log_metrics_and_params_from_tree(artifact_root: Path) -> None:
         if pf.is_file():
             for k, v in _load_json_file(pf).items():
                 mlflow.log_param(str(k), "" if v is None else str(v))
+
+    for error in all_errors:
+        logger.warning("MLflow metric error: %s", error)
+
+    return all_errors
 
 
 def log_multi_run_artifacts(
@@ -605,6 +635,7 @@ def log_multi_run_artifacts(
 
         parent_meta: dict[str, Any] | None = None
         child_runs_meta: list[dict[str, Any]] = []
+        all_curve_errors: list[str] = []
         client = mlflow.tracking.MlflowClient()
 
         start_kw: dict[str, Any] = {}
@@ -654,7 +685,11 @@ def log_multi_run_artifacts(
                     if mf.is_file():
                         for k, v in _load_json_file(mf).items():
                             if isinstance(v, list):
-                                _log_curve_metrics({k: v})
+                                curve_errors = _log_curve_metrics({k: v})
+                                if curve_errors:
+                                    # Add child run context to errors
+                                    for error in curve_errors:
+                                        all_curve_errors.append(f"Run '{child_name}': {error}")
                             elif isinstance(v, int | float) and not isinstance(v, bool):
                                 mlflow.log_metric(str(k), float(v))
 
@@ -694,6 +729,12 @@ def log_multi_run_artifacts(
             parent_meta = _capture_mlflow_run_metadata(tu, workspace=workspace)
             if child_runs_meta:
                 parent_meta["child_runs"] = child_runs_meta
+            if all_curve_errors:
+                parent_meta["curve_errors"] = all_curve_errors
+
+        # Log any curve errors as warnings instead of failing
+        for error in all_curve_errors:
+            logger.warning("MLflow curve metric error: %s", error)
 
         if verbose:
             logger.info("MLflow multi-run upload finished (%s)", mlflow.get_tracking_uri())

--- a/projects/caliper/engine/file_export/runner.py
+++ b/projects/caliper/engine/file_export/runner.py
@@ -86,7 +86,7 @@ def run_file_export(
         try:
             if verbose:
                 print(f"caliper: starting backend {b!r} …", file=sys.stderr)
-            detail, ml_meta = mlflow_backend.log_artifacts(
+            detail, ml_meta, failures = mlflow_backend.log_artifacts(
                 artifact_root=source,
                 paths=paths,
                 tracking_uri=mlflow_tracking_uri,
@@ -103,7 +103,7 @@ def run_file_export(
             results.append(
                 FileExportBackendResult(
                     backend="mlflow",
-                    status="success",
+                    status="success" if not failures else "failure",
                     detail=detail,
                     metadata=ml_meta,
                 )

--- a/projects/caliper/engine/kpi/__init__.py
+++ b/projects/caliper/engine/kpi/__init__.py
@@ -21,6 +21,7 @@ from .report_dataclasses import (
     AnalysisSummary,
     BaselineSummary,
     ConfigSummary,
+    KpiComputationStatus,
     OverallStatus,
     RegressionReport,
     TestSummary,
@@ -32,7 +33,8 @@ __all__ = [
     "KpiCatalogEntry",
     "RegressionFinding",
     "RegressionReport",
-    # Status enum
+    # Status dataclasses
+    "KpiComputationStatus",
     "OverallStatus",
     # Summary dataclasses
     "AnalysisSummary",

--- a/projects/caliper/engine/kpi/generate.py
+++ b/projects/caliper/engine/kpi/generate.py
@@ -60,13 +60,22 @@ def run_kpi_generate(
 
     # Check if plugin returned status details
     if isinstance(result, tuple) and len(result) == 2:
-        rows, status_details = result
-        status = status_details.get("status", "success")
-        message = status_details.get("message")
-        warnings = status_details.get("warnings", [])
+        rows, status_obj = result
 
-        # Add success field based on status
-        status_details["success"] = status != "failed"
+        # Handle both new dataclass and legacy dict formats
+        from projects.caliper.engine.kpi import KpiComputationStatus
+
+        if isinstance(status_obj, KpiComputationStatus):
+            status = status_obj.status
+            message = status_obj.message
+            warnings = status_obj.warnings
+            status_details = status_obj.to_dict()
+        else:
+            # Legacy dict format
+            status = status_obj.get("status", "success")
+            message = status_obj.get("message")
+            warnings = status_obj.get("warnings", [])
+            status_details = status_obj
 
         # Log warnings if present
         if warnings:
@@ -83,12 +92,23 @@ def run_kpi_generate(
         rows = result
         status_details = {"status": "success", "success": True, "message": None, "warnings": []}
 
-    kpi_schema = load_schema(schema_path("kpi_record.schema.json"))
+    # Convert KpiRecord objects to dictionaries for validation and output
+    from projects.caliper.engine.kpi import KpiRecord
+
+    rows_as_dicts = []
     for row in rows:
-        validate_instance(row, kpi_schema, "KPI record")
+        if isinstance(row, KpiRecord):
+            rows_as_dicts.append(row.to_dict())
+        else:
+            rows_as_dicts.append(row)
+
+    # Validate using dictionary representations
+    kpi_schema = load_schema(schema_path("kpi_record.schema.json"))
+    for row_dict in rows_as_dicts:
+        validate_instance(row_dict, kpi_schema, "KPI record")
 
     if output:
-        write_kpis_in_format(rows, output, format_type, model)
+        write_kpis_in_format(rows_as_dicts, output, format_type, model)
 
     # Always return tuple with KPI records and status details
     return rows, status_details

--- a/projects/caliper/engine/kpi/kpis_to_mlflow.py
+++ b/projects/caliper/engine/kpi/kpis_to_mlflow.py
@@ -132,7 +132,17 @@ def generate_metrics_from_kpis(
             if kpi.is_curve:
                 # Convert coordinate pairs to point dictionaries for MLflow
                 if kpi.values:
-                    metrics[kpi.kpi_id] = [{"x": float(x), "y": float(y)} for x, y in kpi.values]
+                    # Validate that x values are integers (MLflow step values must be integers)
+                    curve_points = []
+                    for i, (x, y) in enumerate(kpi.values):
+                        if not isinstance(x, (int, float)) or x != int(x):
+                            raise ValueError(
+                                f"Curve KPI '{kpi.kpi_id}' in test '{test.run_id}': "
+                                f"data point {i} has non-integer step x={x!r} "
+                                f"(MLflow steps must be integers)"
+                            )
+                        curve_points.append({"x": float(x), "y": float(y)})
+                    metrics[kpi.kpi_id] = curve_points
             else:
                 # For scalar KPIs, use the value field
                 if kpi.value is not None:

--- a/projects/caliper/engine/kpi/report_dataclasses.py
+++ b/projects/caliper/engine/kpi/report_dataclasses.py
@@ -322,6 +322,52 @@ class RegressionTestResult:
 
 
 @dataclass
+class KpiComputationStatus:
+    """Status result from KPI computation operations."""
+
+    status: str  # "success", "failed", "warning"
+    success: bool
+    message: str | None = None
+    warnings: list[str] = field(default_factory=list)
+    tests_processed: int = 0
+    total_tests: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> KpiComputationStatus:
+        """Create KpiComputationStatus from dictionary data."""
+        return cls(**data)
+
+    @classmethod
+    def success_status(
+        cls, tests_processed: int, total_tests: int | None = None
+    ) -> KpiComputationStatus:
+        """Create a success status."""
+        return cls(
+            status="success",
+            success=True,
+            tests_processed=tests_processed,
+            total_tests=total_tests or tests_processed,
+        )
+
+    @classmethod
+    def failure_status(
+        cls, message: str, tests_processed: int = 0, total_tests: int = 0
+    ) -> KpiComputationStatus:
+        """Create a failure status."""
+        return cls(
+            status="failed",
+            success=False,
+            message=message,
+            tests_processed=tests_processed,
+            total_tests=total_tests,
+        )
+
+
+@dataclass
 class MlflowConversionResult:
     """Result of converting KPIs to MLflow format."""
 

--- a/projects/cluster/toolbox/capture_prometheus/main.py
+++ b/projects/cluster/toolbox/capture_prometheus/main.py
@@ -20,8 +20,8 @@ import logging
 from datetime import UTC, datetime
 from pathlib import Path
 
-from projects.core.dsl import always, entrypoint, execute_tasks, task
-from projects.core.dsl.utils.k8s import oc, oc_cp_from_pod, oc_exec
+from projects.core.dsl import always, entrypoint, execute_tasks, shell, task
+from projects.core.dsl.utils.k8s import oc, oc_exec
 
 logger = logging.getLogger("DSL")
 
@@ -40,6 +40,7 @@ def run(
     pod_name: str = PROMETHEUS_POD,
     namespace: str = PROMETHEUS_NAMESPACE,
     container: str = PROMETHEUS_CONTAINER,
+    head_only: bool = True,
 ) -> int:
     """
     Capture Prometheus metrics for a specific time window.
@@ -54,6 +55,7 @@ def run(
         pod_name: Prometheus pod to extract from
         namespace: Namespace where Prometheus runs
         container: Container name within the Prometheus pod
+        head_only: if true, restrict the TSDB scan to the recent in-memory data
     """
     execute_tasks(locals())
     return 0
@@ -147,6 +149,10 @@ def create_temp_tsdb_dir(args, ctx):
     instead of the full TSDB which can be tens of GB.
     """
 
+    if not args.head_only:
+        logger.info("head_only isn't set, skipping.")
+        return
+
     ctx.temp_dir = f"{TSDB_PATH}/.capture-tmp-{ctx.start_ms}"
 
     oc_exec(
@@ -165,35 +171,26 @@ def create_temp_tsdb_dir(args, ctx):
 def dump_metrics(args, ctx):
     """Run promtool tsdb dump-openmetrics with time filtering against the temp dir."""
 
-    ctx.remote_raw = f"{TSDB_PATH}/.capture-metrics-{ctx.start_ms}"
-    ctx.remote_output = f"{ctx.remote_raw}.gz"
-
+    output_file = ctx.output_dir / "open_metrics.gz"
     oc_exec(
         "sh",
         "-c",
-        f"promtool tsdb dump-openmetrics"
+        f"set -o pipefail && promtool tsdb dump-openmetrics"
         f" --min-time={ctx.start_ms} --max-time={ctx.end_ms}"
-        f" {ctx.temp_dir} > {ctx.remote_raw}"
-        f" && gzip -f {ctx.remote_raw}",
+        f" {ctx.temp_dir if args.head_only else TSDB_PATH}"
+        f" | gzip",
+        stdout_dest=output_file,
+        text=False,
         **_pod_kwargs(ctx),
     )
 
-    size_result = oc_exec("stat", "-c", "%s", ctx.remote_output, check=False, **_pod_kwargs(ctx))
+    size_result = shell.run(
+        ["stat", "-c", "%s", str(output_file)], shell=False, check=False, capture_output=True
+    )
 
     ctx.archive_size_bytes = int(size_result.stdout.strip()) if size_result.success else 0
 
     return f"Dumped metrics ({ctx.archive_size_bytes} bytes compressed)"
-
-
-@task
-def copy_to_output(args, ctx):
-    """Copy the compressed metrics file from the pod to the output directory."""
-
-    ctx.output_file = ctx.output_dir / "metrics.openmetrics.gz"
-
-    oc_cp_from_pod(ctx.remote_output, ctx.output_file, **_pod_kwargs(ctx))
-
-    return f"Copied metrics to {ctx.output_file}"
 
 
 @always
@@ -202,11 +199,9 @@ def cleanup_pod(args, ctx):
     """Remove temp files from the Prometheus pod."""
 
     temp_dir = getattr(ctx, "temp_dir", None)
-    remote_output = getattr(ctx, "remote_output", None)
-    remote_raw = getattr(ctx, "remote_raw", None)
     kwargs = _pod_kwargs(ctx)
 
-    for path in [temp_dir, remote_output, remote_raw]:
+    for path in (temp_dir,):
         if path:
             oc_exec("rm", "-rf", path, check=False, **kwargs)
 

--- a/projects/core/agentic/on_failure/__init__.py
+++ b/projects/core/agentic/on_failure/__init__.py
@@ -164,7 +164,7 @@ def agent_review_on_failure(func):
             raise e
 
         # Success - no agent needed
-        if exit_code == 0:
+        if exit_code in (0, None):
             logger.info(f"✅ CI command '{function_name}' succeeded - no agent review needed")
             return exit_code
 

--- a/projects/core/library/postprocess.py
+++ b/projects/core/library/postprocess.py
@@ -16,7 +16,7 @@ import click
 import yaml
 from pydantic import ValidationError
 
-from projects.caliper.engine.constants import LEGACY_METADATA_FILE, METADATA_FILE
+from projects.caliper.engine.constants import METADATA_FILE
 from projects.caliper.engine.kpi.dataclasses import CaliperTestMetadata
 from projects.caliper.orchestration.postprocess import (
     run_postprocess_from_orchestration_config,
@@ -88,17 +88,12 @@ def write_test_labels(
 
     # Define both file paths
     metadata_path = directory / METADATA_FILE
-    legacy_path = directory / LEGACY_METADATA_FILE
 
     # Create directory and write to both files for backward compatibility
     metadata_path.parent.mkdir(parents=True, exist_ok=True)
 
     # Write new format
     with metadata_path.open("w", encoding="utf-8") as handle:
-        yaml.safe_dump(payload, handle, sort_keys=False)
-
-    # Write legacy format (identical content)
-    with legacy_path.open("w", encoding="utf-8") as handle:
         yaml.safe_dump(payload, handle, sort_keys=False)
 
     # Optionally save project configuration

--- a/projects/guidellm/postprocess/guidellm/dashboard.py
+++ b/projects/guidellm/postprocess/guidellm/dashboard.py
@@ -354,15 +354,19 @@ def _extract_dashboard_metrics(node: TestBaseNode) -> tuple[dict[str, Any], dict
     return extra, curves
 
 
-def compute_dashboard_kpis(model: UnifiedRunModel, *, prefix: str) -> list[dict[str, Any]]:
-    """Emit one scalar KPI per dashboard metric and rate point."""
+def compute_dashboard_kpis(model: UnifiedRunModel, *, prefix: str) -> list[KpiRecord]:
+    """Generate curve KPIs for dashboard metrics."""
     timestamp = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
-    output: list[dict[str, Any]] = []
+    output: list[KpiRecord] = []
+
     for record in model.unified_result_records:
         curves = record.metrics.get("performance_curves", {})
         rates = record.metrics.get("request_rate", [])
         if not record.run_identity.get("guidellm") or not rates:
             continue
+
+        # Base labels for this run including operational data
+        labels = {**record.distinguishing_labels}
         metadata_labels = {
             "guidellm_version": str(record.metrics.get("guidellm_version", "")),
             "prompt_toks": str(record.metrics.get("prompt_toks", "")),
@@ -371,95 +375,190 @@ def compute_dashboard_kpis(model: UnifiedRunModel, *, prefix: str) -> list[dict[
             "prefix_tokens": str(record.metrics.get("prefix_tokens", "")),
             "prefix_count": str(record.metrics.get("prefix_count", "")),
             "request_type": str(record.metrics.get("request_type", "")),
+            # Operational properties now in labels to avoid hierarchical metadata overwrite
             "guidellm_start_time_ms": str(record.metrics.get("guidellm_start_time_ms", "")),
             "guidellm_end_time_ms": str(record.metrics.get("guidellm_end_time_ms", "")),
+            "runtime_args": str(
+                record.distinguishing_labels.get("runtime_args", "")
+            ),  # From test labels
+            "mlflow_run_id": str(record.metrics.get("mlflow_run_id", "")),
+            "mlflow_experiment_id": str(record.metrics.get("mlflow_experiment_id", "")),
         }
         metadata_labels.update(dashboard_metadata_labels(record.metrics))
-        run_uuids = record.metrics.get("run_uuids", [])
-        for index in range(len(rates)):
-            labels = {**record.distinguishing_labels, **metadata_labels, "rate_index": str(index)}
-            if index < len(run_uuids):
-                labels["run_uuid"] = run_uuids[index]
-            for suffix, curve_key, _, unit, higher_is_better in DASHBOARD_METRICS:
-                values = curves.get(curve_key, [])
-                if index >= len(values) or values[index] is None:
-                    continue
-                kpi_labels = dict(labels)
-                if higher_is_better is not None:
-                    kpi_labels["higher_is_better"] = higher_is_better
 
-                # Create structured KPI record using core dataclass
-                kpi_record = KpiRecord(
-                    schema_version="1",
-                    kpi_id=f"{prefix}_{suffix}",
-                    value=float(values[index]),
-                    unit=unit,
-                    run_id=record.test_base_path,
-                    timestamp=timestamp,
-                    labels=kpi_labels,
-                    metadata={"run_path": record.test_base_path},  # Move run_path to metadata
-                    is_curve=False,  # Scalar KPI
+        # Simple metadata for hierarchical compatibility
+        metadata_dict = {
+            "run_path": record.test_base_path,
+        }
+
+        # Create curve KPI for each metric
+        for suffix, curve_key, _, unit, higher_is_better in DASHBOARD_METRICS:
+            curve_values = curves.get(curve_key, [])
+            if not curve_values or all(v is None for v in curve_values):
+                continue
+
+            # Create [intended_concurrency, metric_value] pairs using intended concurrency from strategy
+            curve_data = []
+            intended_concurrency_values = curves.get("intended_concurrency", [])
+
+            # Track data quality for warnings
+            total_values = len([v for v in curve_values if v is not None])
+            skipped_count = 0
+
+            for i, value in enumerate(curve_values):
+                if value is None:
+                    continue
+
+                if (
+                    i < len(intended_concurrency_values)
+                    and intended_concurrency_values[i] is not None
+                ):
+                    x_value = float(intended_concurrency_values[i])
+                    curve_data.append([x_value, float(value)])
+                else:
+                    skipped_count += 1
+
+            # Log warnings for data quality issues
+            if not intended_concurrency_values:
+                logger.warning(
+                    f"Curve KPI '{suffix}' for {record.test_base_path}: no intended_concurrency values found, skipping all {total_values} data points"
                 )
-                output.append(kpi_record.to_dict())
+            elif skipped_count > 0:
+                logger.warning(
+                    f"Curve KPI '{suffix}' for {record.test_base_path}: skipped {skipped_count}/{total_values} data points due to missing intended_concurrency values"
+                )
+
+            if not curve_data:
+                continue
+
+            kpi_labels = dict(labels)
+            kpi_labels.update(metadata_labels)
+
+            # Create curve KPI record
+            kpi_record = KpiRecord(
+                schema_version="1",
+                kpi_id=f"{prefix}_{suffix}",
+                values=curve_data,  # [[x, y], [x, y], ...] format
+                x_unit="rps",
+                y_unit=unit,
+                x_help="Request rate (concurrency)",
+                y_help=f"Dashboard metric: {suffix}",
+                run_id=record.test_base_path,
+                timestamp=timestamp,
+                labels=kpi_labels,
+                metadata=metadata_dict,
+                is_curve=True,
+                higher_is_better=higher_is_better if higher_is_better is not None else True,
+            )
+            output.append(kpi_record)
+
     return output
 
 
-def dashboard_kpi_catalog(*, prefix: str) -> list[dict[str, Any]]:
+def dashboard_kpi_catalog(*, prefix: str) -> list[KpiCatalogEntry]:
     """Return catalog entries for the shared dashboard KPI set using dataclasses."""
     catalog_entries = []
     for suffix, _, _, unit, higher_is_better in DASHBOARD_METRICS:
         catalog_entry = KpiCatalogEntry(
             kpi_id=f"{prefix}_{suffix}",
             name=f"{prefix}_{suffix}",
-            unit=unit,
+            y_unit=unit,  # For curve KPIs, use y_unit
+            x_unit="rps",  # Concurrency/request rate
             higher_is_better=higher_is_better if higher_is_better is not None else True,
-            is_curve=False,
-            help=f"Dashboard metric: {suffix}",
+            is_curve=True,  # Now curve KPIs
+            help=f"Dashboard curve metric: {suffix}",
+            x_help="Request rate (concurrency)",
+            y_help=f"Performance metric: {suffix}",
         )
-        catalog_entries.append(catalog_entry.to_dict())
+        catalog_entries.append(catalog_entry)
     return catalog_entries
 
 
 def export_dashboard_kpis_to_csv(
-    kpi_records: list[dict[str, Any]],
+    kpi_records: list[KpiRecord],
     output_path: Path,
     *,
     prefix: str,
     fieldnames: list[str],
     metadata_row: Callable[[dict[str, Any]], dict[str, Any]],
 ) -> str:
-    """Pivot scalar per-rate KPIs into a dashboard-compatible CSV."""
+    """Extract dashboard metrics from curve KPIs and export to CSV."""
     validate_dashboard_fieldnames(fieldnames)
-    kpi_to_column = {f"{prefix}_{suffix}": column for suffix, _, column, _, _ in DASHBOARD_METRICS}
-    groups: dict[tuple[str, str], dict[str, Any]] = {}
-    labels_by_group: dict[tuple[str, str], dict[str, Any]] = {}
+
+    # Group KPIs by run_id to process runs together
+    runs_by_id: dict[str, list[dict[str, Any]]] = {}
+
     for kpi in kpi_records:
-        labels = kpi.get("labels", {})
-        metadata = kpi.get("metadata", {})
-        key = (
-            str(metadata.get("run_path") or kpi.get("run_id", "")),
-            str(labels.get("rate_index", "0")),
-        )
-        column = kpi_to_column.get(kpi.get("kpi_id", ""))
-        if column:
-            groups.setdefault(key, {})[column] = kpi.get("value")
-        if key not in labels_by_group or len(labels) > len(labels_by_group[key]):
-            labels_by_group[key] = labels
+        # Handle both KpiRecord objects and dictionaries
+        if hasattr(kpi, "to_dict"):
+            kpi_dict = kpi.to_dict()
+        elif isinstance(kpi, dict):
+            kpi_dict = kpi
+        else:
+            # Skip invalid entries (might be tuple or other unexpected types)
+            continue
+
+        run_id = kpi_dict.get("run_id", "")
+        runs_by_id.setdefault(run_id, []).append(kpi_dict)
 
     rows: list[dict[str, Any]] = []
-    for key in sorted(groups, key=lambda k: (k[0], int(k[1]) if k[1].isdigit() else k[1])):
-        metrics = groups[key]
-        labels = labels_by_group.get(key, {})
-        row: dict[str, Any] = dict.fromkeys(fieldnames, "")
-        row.update(metadata_row(labels))
-        row.update(metrics)
-        if "intended concurrency" in row and row["intended concurrency"] in ("", None):
-            row["intended concurrency"] = labels.get("intended_concurrency", "")
-        for column in SECONDS_TO_MS_COLUMNS:
-            value = row.get(column)
-            if value not in ("", None):
-                row[column] = float(value) * 1000.0
-        rows.append(row)
+
+    for _run_id, run_kpis in runs_by_id.items():
+        # Find curve KPIs for this run
+        curve_kpis = {
+            kpi["kpi_id"]: kpi
+            for kpi in run_kpis
+            if kpi.get("is_curve", False) and kpi.get("values")
+        }
+
+        if not curve_kpis:
+            continue  # Skip runs without curve data
+
+        # Get representative labels from any KPI in this run
+        representative_kpi = run_kpis[0]
+        labels = representative_kpi.get("labels", {})
+        metadata = representative_kpi.get("metadata", {})
+
+        # Merge metadata into labels for backward compatibility with metadata_row functions
+        combined_labels = {**labels, **metadata}
+
+        # Map KPI IDs to dashboard columns
+        kpi_to_column = {
+            f"{prefix}_{suffix}": column for suffix, _, column, _, _ in DASHBOARD_METRICS
+        }
+
+        # Extract rate points from primary curve KPI to determine concurrency levels
+        primary_kpi = next(iter(curve_kpis.values()))
+        values = primary_kpi.get("values", [])  # [[x, y], [x, y], ...]
+
+        # Create one row per concurrency level
+        for concurrency, _ in values:
+            row: dict[str, Any] = dict.fromkeys(fieldnames, "")
+            row.update(metadata_row(combined_labels))
+
+            # Set intended concurrency from the x-value (concurrency level)
+            if "intended concurrency" in fieldnames:
+                row["intended concurrency"] = int(concurrency)
+
+            # Fill in data from each curve KPI
+            for kpi_id, kpi in curve_kpis.items():
+                column = kpi_to_column.get(kpi_id)
+                if column and column in fieldnames:
+                    # Find the value for this concurrency level
+                    for conc, value in kpi["values"]:
+                        if conc == concurrency:
+                            row[column] = float(value)
+                            break
+
+            # Convert seconds to milliseconds for timing metrics
+            for column in SECONDS_TO_MS_COLUMNS:
+                if column in row and row[column] not in ("", None):
+                    try:
+                        row[column] = float(row[column]) * 1000
+                    except (ValueError, TypeError):
+                        pass
+
+            rows.append(row)
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     with output_path.open("w", newline="", encoding="utf-8") as output:

--- a/projects/guidellm/postprocess/guidellm/plugin.py
+++ b/projects/guidellm/postprocess/guidellm/plugin.py
@@ -6,7 +6,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from projects.caliper.engine.kpi.dataclasses import KpiCatalogEntry
+from projects.caliper.engine.kpi import KpiCatalogEntry, KpiComputationStatus, KpiRecord
 from projects.caliper.engine.model import (
     ParseResult,
     PostProcessingPlugin,
@@ -234,15 +234,13 @@ class GuideLLMPlugin(PostProcessingPlugin):
 
         return paths
 
-    def compute_kpis(
-        self, model: UnifiedRunModel
-    ) -> list[dict[str, Any]] | tuple[list[dict[str, Any]], dict[str, Any]]:
-        """Compute KPI values from the unified model with optional status details."""
+    def compute_kpis(self, model: UnifiedRunModel) -> tuple[list[KpiRecord], KpiComputationStatus]:
+        """Compute KPI values using dataclasses with status details."""
         return self.kpi_handler.compute_kpis(model)
 
     def export_kpis_to_csv(
         self,
-        kpi_records: list[dict[str, Any]],
+        kpi_records: list[KpiRecord],
         output_path: Path,
         include_header_comments: bool = True,
     ) -> str:

--- a/projects/llm_d/orchestration/config.d/prom.yaml
+++ b/projects/llm_d/orchestration/config.d/prom.yaml
@@ -1,2 +1,2 @@
 capture:
-  enabled: true
+  enabled: false

--- a/projects/llm_d/orchestration/presets.d/cluster_config.yaml
+++ b/projects/llm_d/orchestration/presets.d/cluster_config.yaml
@@ -65,5 +65,6 @@ cluster_athena-fire:
 cluster_dodo:
   cpt.kpi.labels.platform: OCP
   model_cache.pvc.access_mode: ReadWriteMany
-  model_cache.pvc.storage_class_name: nfs-rwx
-  workloads.pvc_storage_class: nfs-rwx
+  model_cache.pvc.storage_class_name: rook-cephfs-fast
+  workloads.pvc_storage_class: rook-cephfs-fast
+  platform.gateway.status_address_name: gateway-external

--- a/projects/llm_d/orchestration/test_phase.py
+++ b/projects/llm_d/orchestration/test_phase.py
@@ -820,11 +820,8 @@ def run_guidellm_benchmark(*, endpoint_url: str) -> None:
         end_time = update_test_labels_with_timing("benchmark", "end")
 
         # Capture prometheus metrics if enabled
-        if config.project.get_config("prom", print=False).get("capture", {}).get("enabled", False):
-            try:
-                capture_prometheus(start_time, end_time)
-            except Exception as e:
-                logging.warning(f"Failed to capture Prometheus metrics: {e}")
+        if config.project.get_config("prom.capture.enabled"):
+            capture_prometheus(start_time, end_time)
 
 
 def capture_inference_service_state(llmisvc_name: str) -> None:

--- a/projects/llm_d/postprocess/llm_d/csv_dashboard.py
+++ b/projects/llm_d/postprocess/llm_d/csv_dashboard.py
@@ -68,27 +68,69 @@ def export_kpis_to_csv(
     kpi_records: list[KpiRecord],
     output_path: Path,
     include_header_comments: bool = True,
+    *,
+    model=None,
 ) -> str:
     """Export KPI records to CSV format with llm-d dashboard schema.
 
+    This function generates dashboard KPIs independently from the original model data,
+    following the e1780be approach while using the new dataclass architecture.
+    The main KPI handling and CSV handling are kept separate.
+
     Args:
-        kpi_records: KPI records from compute_kpis()
+        kpi_records: KPI records from compute_kpis() (not used, for interface compatibility)
         output_path: Path where to write the CSV file
         include_header_comments: Whether to include descriptive header comments
 
     Returns:
         Path to the generated CSV file
     """
+    # Get the cached model from the current plugin instance
+    # This allows independent dashboard KPI generation for CSV export
+    import inspect
+
     from projects.guidellm.postprocess.guidellm.dashboard import (
         export_dashboard_kpis_to_csv,
         normalize_product_version,
     )
 
+    frame = inspect.currentframe()
+    try:
+        # Walk up the call stack to find the plugin instance
+        plugin_instance = None
+        while frame:
+            if "self" in frame.f_locals:
+                obj = frame.f_locals["self"]
+                if hasattr(obj, "_cached_model"):
+                    plugin_instance = obj
+                    break
+            frame = frame.f_back
+    finally:
+        del frame
+
+    if plugin_instance is None or not hasattr(plugin_instance, "_cached_model"):
+        # Fallback: create empty CSV
+        import csv
+
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with output_path.open("w", newline="", encoding="utf-8") as csvfile:
+            writer = csv.DictWriter(csvfile, fieldnames=DASHBOARD_FIELDNAMES, extrasaction="ignore")
+            writer.writeheader()
+        print("Exported 0 dashboard CSV rows (no cached model available)")
+        return str(output_path)
+
+    # Generate dashboard KPIs independently from the cached model
+    from projects.guidellm.postprocess.guidellm.dashboard import compute_dashboard_kpis
+
+    model = plugin_instance._cached_model
+    dashboard_kpis = compute_dashboard_kpis(model, prefix="llmd")
+
     def metadata_row(labels: dict[str, Any]) -> dict[str, Any]:
+        """Extract metadata for CSV row from dashboard KPI labels."""
         accelerator = labels.get("gpu_type") or labels.get("accelerator", "")
-        model = labels.get("hf_model_id") or labels.get("model_name", "")
-        run_model = model.replace("/", "-")
-        tp = labels.get("tensor_parallel_size") or labels.get("TP", "")
+        model_id = labels.get("hf_model_id") or labels.get("model_name", "")
+        run_model = model_id.replace("/", "-")
+        tp = labels.get("tensor_parallel_size", "")
         replicas = labels.get("replicas", "")
         version = normalize_product_version(
             labels.get("product_version") or labels.get("version", "")
@@ -96,19 +138,20 @@ def export_kpis_to_csv(
         deployment_profile = labels.get("deployment_profile", "")
         if version and deployment_profile:
             version = f"{version}-{deployment_profile}"
+
         return {
             "run": "-".join(str(value) for value in (accelerator, run_model, tp) if value),
             "accelerator": accelerator,
-            "model": model,
+            "model": model_id,
             "version": version,
             "prompt toks": labels.get("prompt_toks", ""),
             "output toks": labels.get("output_toks", ""),
             "TP": tp,
-            "DP": labels.get("DP") or labels.get("data_parallel_size") or 0,
-            "EP": labels.get("EP") or labels.get("expert_parallel_size") or 0,
+            "DP": labels.get("DP") or labels.get("data_parallel_size") or "",
+            "EP": labels.get("EP") or labels.get("expert_parallel_size") or "",
             "replicas": replicas,
-            "prefill_pod_count": labels.get("prefill_pod_count", 0),
-            "decode_pod_count": labels.get("decode_pod_count", 0),
+            "prefill_pod_count": labels.get("prefill_pod_count", ""),
+            "decode_pod_count": labels.get("decode_pod_count", ""),
             "router_config": labels.get("router_config", ""),
             "uuid": labels.get("run_uuid", ""),
             "runtime_args": labels.get("runtime_args", ""),
@@ -121,8 +164,11 @@ def export_kpis_to_csv(
             "notes": labels.get("notes", ""),
         }
 
+    # Convert KpiRecord dataclasses to dicts for export_dashboard_kpis_to_csv
+    dashboard_kpi_dicts = [kpi.to_dict() for kpi in dashboard_kpis]
+
     return export_dashboard_kpis_to_csv(
-        kpi_records,
+        dashboard_kpi_dicts,
         output_path,
         prefix="llmd",
         fieldnames=DASHBOARD_FIELDNAMES,

--- a/projects/llm_d/postprocess/llm_d/csv_dashboard.py
+++ b/projects/llm_d/postprocess/llm_d/csv_dashboard.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+from projects.caliper.engine.kpi.dataclasses import KpiRecord
+
 DASHBOARD_FIELDNAMES = [
     "run",
     "accelerator",
@@ -63,7 +65,7 @@ DASHBOARD_FIELDNAMES = [
 
 
 def export_kpis_to_csv(
-    kpi_records: list[dict[str, Any]],
+    kpi_records: list[KpiRecord],
     output_path: Path,
     include_header_comments: bool = True,
 ) -> str:

--- a/projects/llm_d/postprocess/llm_d/parsing/kpis.py
+++ b/projects/llm_d/postprocess/llm_d/parsing/kpis.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from projects.caliper.engine.kpi import (
     KpiCatalogEntry,
+    KpiComputationStatus,
     KpiRecord,
     build_catalog_from_functions,
     get_kpi_functions,
@@ -73,7 +74,7 @@ class GuideLLMKpiHandler:
     @staticmethod
     def compute_kpis(
         model: UnifiedRunModel,
-    ) -> list[dict[str, Any]] | tuple[list[dict[str, Any]], dict[str, Any]]:
+    ) -> tuple[list[KpiRecord], KpiComputationStatus]:
         """
         Compute KPI values from the unified model.
 
@@ -84,7 +85,7 @@ class GuideLLMKpiHandler:
             List of KPI records, or tuple of (KPI records, status details) if warnings present
         """
         ts = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
-        out: list[dict[str, Any]] = []
+        out: list[KpiRecord] = []
 
         # Import the module containing the KPI functions
         from projects.guidellm.postprocess.guidellm.parsing import kpis as guidellm_kpis
@@ -99,7 +100,8 @@ class GuideLLMKpiHandler:
         ]
 
         if not valid_records:
-            return out
+            status = KpiComputationStatus.success_status(0, len(model.unified_result_records))
+            return out, status
 
         # Check for unknown gpu_type in records
         unknown_gpu_records = []
@@ -109,7 +111,7 @@ class GuideLLMKpiHandler:
             if gpu_type and gpu_type.lower() == "unknown":
                 unknown_gpu_records.append(r.test_base_path)
 
-        # If unknown GPU types found, return empty KPIs with error status
+        # If unknown GPU types found, return failure status
         if unknown_gpu_records:
             error_msg = (
                 f"Found gpu_type='unknown' in {len(unknown_gpu_records)} test paths: "
@@ -117,15 +119,8 @@ class GuideLLMKpiHandler:
                 "Unknown GPU types prevent reliable KPI analysis. "
                 "Please ensure GPU detection is working correctly or set gpu_type manually in test labels."
             )
-
-            status_details = {
-                "status": "failed",
-                "success": False,
-                "message": error_msg,
-                "warnings": [],
-            }
-
-            return [], status_details
+            status = KpiComputationStatus.failure_status(error_msg)
+            return [], status
 
         # Group records by test path for curve KPIs (same test, different rates)
         from collections import defaultdict
@@ -133,6 +128,9 @@ class GuideLLMKpiHandler:
         records_by_test = defaultdict(list)
         for r in valid_records:
             records_by_test[r.test_base_path].append(r)
+
+        # Track which records actually produced KPIs
+        processed_records = set()
 
         # Generate scalar KPIs for each record
         for r in valid_records:
@@ -171,7 +169,8 @@ class GuideLLMKpiHandler:
                     is_curve=False,  # Scalar KPI
                 )
 
-                out.append(kpi_record.to_dict())
+                out.append(kpi_record)
+                processed_records.add(r.test_base_path)  # Track that this record produced a KPI
 
         # Generate curve KPIs for records that have performance curves
         for r in valid_records:
@@ -220,6 +219,9 @@ class GuideLLMKpiHandler:
                     y_help=kpi_func._kpi_y_help,
                 )
 
-                out.append(kpi_record.to_dict())
+                out.append(kpi_record)
+                processed_records.add(r.test_base_path)  # Track that this record produced a KPI
 
-        return out
+        # Create success status
+        status = KpiComputationStatus.success_status(len(processed_records), len(valid_records))
+        return out, status

--- a/projects/llm_d/postprocess/llm_d/plugin.py
+++ b/projects/llm_d/postprocess/llm_d/plugin.py
@@ -75,6 +75,8 @@ class LlmDGuideLLMPlugin(GuideLLMPlugin):
 
     def compute_kpis(self, model: UnifiedRunModel) -> tuple[list[KpiRecord], KpiComputationStatus]:
         """Compute KPI values using dataclasses with status details."""
+        # Store model for independent dashboard KPI generation in CSV export
+        self._cached_model = model
         return super().compute_kpis(model)
 
     def export_kpis_to_csv(
@@ -86,7 +88,11 @@ class LlmDGuideLLMPlugin(GuideLLMPlugin):
         """Export KPI records to CSV format with llm-d dashboard schema."""
         from . import csv_dashboard
 
-        return csv_dashboard.export_kpis_to_csv(kpi_records, output_path, include_header_comments)
+        # Pass the cached model to the CSV export function
+        cached_model = getattr(self, "_cached_model", None)
+        return csv_dashboard.export_kpis_to_csv(
+            kpi_records, output_path, include_header_comments, model=cached_model
+        )
 
 
 def get_plugin() -> PostProcessingPlugin:

--- a/projects/llm_d/postprocess/llm_d/plugin.py
+++ b/projects/llm_d/postprocess/llm_d/plugin.py
@@ -8,8 +8,8 @@ from typing import Any
 
 import yaml
 
+from projects.caliper.engine.kpi import KpiCatalogEntry, KpiComputationStatus, KpiRecord
 from projects.caliper.engine.kpi.analyze import AnalysisConfig
-from projects.caliper.engine.kpi.dataclasses import KpiCatalogEntry
 from projects.caliper.engine.model import (
     ParseResult,
     PostProcessingPlugin,
@@ -45,6 +45,9 @@ analysis_config = AnalysisConfig(
 class LlmDGuideLLMPlugin(GuideLLMPlugin):
     """Keep generic GuideLLM outputs and add the llm-d dashboard projection."""
 
+    def __init__(self):
+        super().__init__()
+
     def parse(self, nodes: list[TestBaseNode]) -> ParseResult:
         parsed = enrich_guidellm_parse_result(super().parse(nodes), nodes)
         nodes_by_path = {str(node.test_path): node for node in nodes}
@@ -70,12 +73,13 @@ class LlmDGuideLLMPlugin(GuideLLMPlugin):
     def kpi_catalog(self) -> list[KpiCatalogEntry]:
         return self.kpi_handler.get_catalog()
 
-    def compute_kpis(self, model: UnifiedRunModel) -> list[dict[str, Any]]:
+    def compute_kpis(self, model: UnifiedRunModel) -> tuple[list[KpiRecord], KpiComputationStatus]:
+        """Compute KPI values using dataclasses with status details."""
         return super().compute_kpis(model)
 
     def export_kpis_to_csv(
         self,
-        kpi_records: list[dict[str, Any]],
+        kpi_records: list[KpiRecord],
         output_path: Path,
         include_header_comments: bool = True,
     ) -> str:

--- a/projects/llm_d/tests/test_profiles.py
+++ b/projects/llm_d/tests/test_profiles.py
@@ -144,6 +144,7 @@ def test_guidellm_benchmark_uses_original_model_name_as_processor(
     core_config.project.set_config("runtime.model_name", "openai/gpt-oss-120b")
     core_config.project.set_config("runtime.deployment_profile", "release-distributed-default")
     core_config.project.set_config("runtime.benchmark_key", "concurrent-1k-1k")
+    core_config.project.set_config("prom.capture.enabled", False)
 
     captured: dict[str, object] = {}
 

--- a/projects/mcp_gateway/postprocess/mcp_gateway/parsing/kpis.py
+++ b/projects/mcp_gateway/postprocess/mcp_gateway/parsing/kpis.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 import inspect
 from datetime import UTC, datetime
-from typing import Any
 
 from projects.caliper.engine.kpi import (
     Format,
     HigherBetter,
     KpiCatalogEntry,
+    KpiComputationStatus,
     KPIMetadata,
     KpiRecord,
     LowerBetter,
@@ -259,10 +259,10 @@ class MCPGatewayKpiHandler:
         return build_catalog_from_functions(current_module)
 
     @staticmethod
-    def compute_kpis(model: UnifiedRunModel) -> list[dict[str, Any]]:
+    def compute_kpis(model: UnifiedRunModel) -> tuple[list[KpiRecord], KpiComputationStatus]:
         """Compute KPI values from the unified model."""
         ts = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
-        out: list[dict[str, Any]] = []
+        out: list[KpiRecord] = []
         current_module = inspect.getmodule(MCPGatewayKpiHandler)
         kpi_functions = get_kpi_functions(current_module)
 
@@ -273,7 +273,8 @@ class MCPGatewayKpiHandler:
         ]
 
         if not valid_records:
-            return out
+            status = KpiComputationStatus.success_status(0, len(model.unified_result_records))
+            return out, status
 
         for r in valid_records:
             base_labels = {**r.distinguishing_labels}
@@ -308,6 +309,8 @@ class MCPGatewayKpiHandler:
                     is_curve=False,  # Scalar KPI
                 )
 
-                out.append(kpi_record.to_dict())
+                out.append(kpi_record)
 
-        return out
+        # Create success status
+        status = KpiComputationStatus.success_status(len(valid_records), len(valid_records))
+        return out, status

--- a/projects/mcp_gateway/postprocess/mcp_gateway/plugin.py
+++ b/projects/mcp_gateway/postprocess/mcp_gateway/plugin.py
@@ -3,10 +3,9 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
 
+from projects.caliper.engine.kpi import KpiCatalogEntry, KpiComputationStatus, KpiRecord
 from projects.caliper.engine.kpi.analyze import AnalysisConfig
-from projects.caliper.engine.kpi.dataclasses import KpiCatalogEntry
 from projects.caliper.engine.model import (
     ParseResult,
     PostProcessingPlugin,
@@ -38,7 +37,7 @@ class MCPGatewayPlugin(PostProcessingPlugin):
     def parse(self, nodes: list[TestBaseNode]) -> ParseResult:
         return self.parser.parse(nodes)
 
-    def compute_kpis(self, model: UnifiedRunModel) -> list[dict[str, Any]]:
+    def compute_kpis(self, model: UnifiedRunModel) -> tuple[list[KpiRecord], KpiComputationStatus]:
         return self.kpi_handler.compute_kpis(model)
 
     def kpi_catalog(self) -> list[KpiCatalogEntry]:

--- a/projects/rhaiis/postprocess/curve_kpis.py
+++ b/projects/rhaiis/postprocess/curve_kpis.py
@@ -1,0 +1,126 @@
+"""Curve KPI definitions for RHAIIS dashboard metrics."""
+
+from __future__ import annotations
+
+from projects.caliper.engine.kpi import (
+    Curve,
+    HigherBetter,
+    KPIMetadata,
+    LowerBetter,
+)
+
+
+@HigherBetter()
+@Curve(
+    x_unit="connections",
+    x_help="Input concurrency",
+    y_unit="tokens/s",
+    y_help="Output token throughput",
+    x_format="{:.0f}",
+    y_format="{:.1f}",
+)
+@KPIMetadata(help="Output token throughput at different concurrency levels", unit="tokens/s")
+def rhaiis_output_tok_per_sec_curve(unified_record) -> list[tuple[int, float]]:
+    """Output Token Throughput vs Concurrency Curve KPI."""
+    curves = unified_record.metrics.get("performance_curves", {})
+    intended_concurrency = curves.get("intended_concurrency", [])
+    output_tok_per_sec = curves.get("output_tok_per_sec", [])
+
+    if (
+        not intended_concurrency
+        or not output_tok_per_sec
+        or len(intended_concurrency) != len(output_tok_per_sec)
+    ):
+        return []
+
+    return [
+        (int(x), float(y))
+        for x, y in zip(intended_concurrency, output_tok_per_sec, strict=False)
+        if x > 0 and y > 0
+    ]
+
+
+@HigherBetter()
+@Curve(
+    x_unit="connections",
+    x_help="Input concurrency",
+    y_unit="tokens/s",
+    y_help="Total token throughput",
+    x_format="{:.0f}",
+    y_format="{:.1f}",
+)
+@KPIMetadata(help="Total token throughput at different concurrency levels", unit="tokens/s")
+def rhaiis_total_tok_per_sec_curve(unified_record) -> list[tuple[int, float]]:
+    """Total Token Throughput vs Concurrency Curve KPI."""
+    curves = unified_record.metrics.get("performance_curves", {})
+    intended_concurrency = curves.get("intended_concurrency", [])
+    total_tok_per_sec = curves.get("total_tok_per_sec", [])
+
+    if (
+        not intended_concurrency
+        or not total_tok_per_sec
+        or len(intended_concurrency) != len(total_tok_per_sec)
+    ):
+        return []
+
+    return [
+        (int(x), float(y))
+        for x, y in zip(intended_concurrency, total_tok_per_sec, strict=False)
+        if x > 0 and y > 0
+    ]
+
+
+@LowerBetter()
+@Curve(
+    x_unit="connections",
+    x_help="Input concurrency",
+    y_unit="s",
+    y_help="Time to first token P95",
+    x_format="{:.0f}",
+    y_format="{:.4f}",
+)
+@KPIMetadata(help="TTFT P95 latency at different concurrency levels", unit="s")
+def rhaiis_ttft_p95_curve(unified_record) -> list[tuple[int, float]]:
+    """TTFT P95 Latency vs Concurrency Curve KPI."""
+    curves = unified_record.metrics.get("performance_curves", {})
+    intended_concurrency = curves.get("intended_concurrency", [])
+    ttft_p95 = curves.get("ttft_p95", [])
+
+    if not intended_concurrency or not ttft_p95 or len(intended_concurrency) != len(ttft_p95):
+        return []
+
+    return [
+        (int(x), float(y))
+        for x, y in zip(intended_concurrency, ttft_p95, strict=False)
+        if x > 0 and y > 0
+    ]
+
+
+@HigherBetter()
+@Curve(
+    x_unit="connections",
+    x_help="Input concurrency",
+    y_unit="req/s",
+    y_help="Measured request rate",
+    x_format="{:.0f}",
+    y_format="{:.1f}",
+)
+@KPIMetadata(help="Measured request rate at different concurrency levels", unit="req/s")
+def rhaiis_measured_rps_curve(unified_record) -> list[tuple[int, float]]:
+    """Measured RPS vs Concurrency Curve KPI."""
+    curves = unified_record.metrics.get("performance_curves", {})
+    intended_concurrency = curves.get("intended_concurrency", [])
+    measured_rps = curves.get("measured_rps", [])
+
+    if (
+        not intended_concurrency
+        or not measured_rps
+        or len(intended_concurrency) != len(measured_rps)
+    ):
+        return []
+
+    return [
+        (int(x), float(y))
+        for x, y in zip(intended_concurrency, measured_rps, strict=False)
+        if x > 0 and y > 0
+    ]

--- a/projects/rhaiis/postprocess/kpis.py
+++ b/projects/rhaiis/postprocess/kpis.py
@@ -1,6 +1,15 @@
 from __future__ import annotations
 
-from projects.caliper.engine.kpi import KpiCatalogEntry, KpiComputationStatus, KpiRecord
+from datetime import UTC, datetime
+
+from projects.caliper.engine.kpi import (
+    KpiCatalogEntry,
+    KpiComputationStatus,
+    KpiRecord,
+    build_catalog_from_functions,
+    get_kpi_functions,
+    is_curve_kpi,
+)
 from projects.caliper.engine.model import UnifiedRunModel
 from projects.guidellm.postprocess.guidellm.dashboard import (
     compute_dashboard_kpis,
@@ -12,11 +21,94 @@ class RhaiisKpiHandler:
     @staticmethod
     def get_catalog() -> list[KpiCatalogEntry]:
         """Get KPI catalog entries for RHAIIS dashboards."""
-        return dashboard_kpi_catalog(prefix="rhaiis")
+        # Get dashboard scalar KPIs
+        dashboard_catalog = dashboard_kpi_catalog(prefix="rhaiis")
+
+        # Get curve KPI catalog
+        from . import curve_kpis
+
+        curve_catalog = build_catalog_from_functions(curve_kpis)
+
+        # Combine both catalogs
+        return dashboard_catalog + curve_catalog
 
     @staticmethod
     def compute_kpis(model: UnifiedRunModel) -> tuple[list[KpiRecord], KpiComputationStatus]:
-        """Compute dashboard KPIs from unified run model."""
-        kpi_records = compute_dashboard_kpis(model, prefix="rhaiis")
-        status = KpiComputationStatus.success_status(len(kpi_records))
-        return kpi_records, status
+        """Compute both scalar dashboard KPIs and curve KPIs from unified run model."""
+        ts = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+        all_kpis: list[KpiRecord] = []
+
+        # 1. Get dashboard scalar KPIs (per rate point)
+        dashboard_kpis = compute_dashboard_kpis(model, prefix="rhaiis")
+        all_kpis.extend(dashboard_kpis)
+
+        # 2. Generate curve KPIs from performance curves
+        from . import curve_kpis
+
+        kpi_functions = get_kpi_functions(curve_kpis)
+
+        valid_records = [
+            r
+            for r in model.unified_result_records
+            if r.run_identity.get("guidellm") and not r.metrics.get("no_benchmarks_found")
+        ]
+
+        processed_records = 0
+
+        for record in valid_records:
+            # Check if this record has performance curves
+            curves = record.metrics.get("performance_curves", {})
+            if not curves:
+                continue
+
+            # Track that we processed this record
+            record_had_kpis = False
+
+            # Extract labels from the record
+            base_labels = {**record.distinguishing_labels}
+            metadata = {"run_path": record.test_base_path}
+
+            # Generate curve KPIs
+            for kpi_id, kpi_func in kpi_functions.items():
+                if not is_curve_kpi(kpi_func):
+                    continue
+
+                try:
+                    # Get curve data from function
+                    raw_values = kpi_func(record)
+                    # Convert to [[x, y], [x, y]] format
+                    values = [[float(x), float(y)] for x, y in raw_values] if raw_values else []
+                except (TypeError, ValueError, KeyError):
+                    values = []
+
+                # Skip empty curves
+                if not values:
+                    continue
+
+                # Create curve KPI record
+                curve_kpi = KpiRecord(
+                    kpi_id=kpi_id,
+                    values=values,
+                    run_id=record.test_base_path,
+                    timestamp=ts,
+                    labels=base_labels,
+                    metadata=metadata,
+                    is_curve=True,
+                    higher_is_better=kpi_func._kpi_higher_is_better,
+                    unit=kpi_func._kpi_unit,
+                    x_unit=kpi_func._kpi_x_unit,
+                    x_help=kpi_func._kpi_x_help,
+                    y_unit=kpi_func._kpi_y_unit,
+                    y_help=kpi_func._kpi_y_help,
+                )
+
+                all_kpis.append(curve_kpi)
+                record_had_kpis = True
+
+            if record_had_kpis:
+                processed_records += 1
+
+        status = KpiComputationStatus.success_status(
+            processed_records, len(model.unified_result_records)
+        )
+        return all_kpis, status

--- a/projects/rhaiis/postprocess/kpis.py
+++ b/projects/rhaiis/postprocess/kpis.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
-
+from projects.caliper.engine.kpi import KpiCatalogEntry, KpiComputationStatus, KpiRecord
 from projects.caliper.engine.model import UnifiedRunModel
 from projects.guidellm.postprocess.guidellm.dashboard import (
     compute_dashboard_kpis,
@@ -11,9 +10,13 @@ from projects.guidellm.postprocess.guidellm.dashboard import (
 
 class RhaiisKpiHandler:
     @staticmethod
-    def get_catalog() -> list[dict[str, Any]]:
+    def get_catalog() -> list[KpiCatalogEntry]:
+        """Get KPI catalog entries for RHAIIS dashboards."""
         return dashboard_kpi_catalog(prefix="rhaiis")
 
     @staticmethod
-    def compute_kpis(model: UnifiedRunModel) -> list[dict[str, Any]]:
-        return compute_dashboard_kpis(model, prefix="rhaiis")
+    def compute_kpis(model: UnifiedRunModel) -> tuple[list[KpiRecord], KpiComputationStatus]:
+        """Compute dashboard KPIs from unified run model."""
+        kpi_records = compute_dashboard_kpis(model, prefix="rhaiis")
+        status = KpiComputationStatus.success_status(len(kpi_records))
+        return kpi_records, status

--- a/projects/rhaiis/postprocess/plugin.py
+++ b/projects/rhaiis/postprocess/plugin.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+from projects.caliper.engine.kpi import KpiComputationStatus, KpiRecord
 from projects.caliper.engine.model import (
     ParseResult,
     PostProcessingPlugin,
@@ -74,12 +75,13 @@ class RhaiisPlugin(PostProcessingPlugin):
     ) -> list[str]:
         return []
 
-    def compute_kpis(self, model: UnifiedRunModel) -> list[dict[str, Any]]:
+    def compute_kpis(self, model: UnifiedRunModel) -> tuple[list[KpiRecord], KpiComputationStatus]:
+        """Compute KPIs using dataclasses with status details."""
         return self.kpi_handler.compute_kpis(model)
 
     def export_kpis_to_csv(
         self,
-        kpi_records: list[dict[str, Any]],
+        kpi_records: list[KpiRecord],
         output_path: Path,
         include_header_comments: bool = True,
     ) -> str:

--- a/projects/skeleton/postprocess/default/parsing/kpis.py
+++ b/projects/skeleton/postprocess/default/parsing/kpis.py
@@ -6,13 +6,13 @@ import inspect
 import re
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
 
 from projects.caliper.engine.kpi import (
     # KPI function decorators and utilities
     Format,
     HigherBetter,
     KpiCatalogEntry,
+    KpiComputationStatus,
     KPIMetadata,
     KpiRecord,
     LowerBetter,
@@ -93,11 +93,11 @@ class SkeletonKpiHandler:
         return build_catalog_from_functions(current_module)
 
     @staticmethod
-    def compute_kpis(model: UnifiedRunModel) -> list[dict[str, Any]]:
+    def compute_kpis(model: UnifiedRunModel) -> tuple[list[KpiRecord], KpiComputationStatus]:
         """Compute KPI values using annotated functions."""
         current_module = inspect.getmodule(SkeletonKpiHandler)
         kpi_functions = get_kpi_functions(current_module)
-        kpis = []
+        kpis: list[KpiRecord] = []
         timestamp = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
         for record in model.unified_result_records:
@@ -153,6 +153,8 @@ class SkeletonKpiHandler:
 
                 kpi_record = KpiRecord(**kpi_kwargs)
 
-                kpis.append(kpi_record.to_dict())
+                kpis.append(kpi_record)
 
-        return kpis
+        # Create success status
+        status = KpiComputationStatus.success_status(len(kpis), len(model.unified_result_records))
+        return kpis, status

--- a/projects/skeleton/postprocess/default/plugin.py
+++ b/projects/skeleton/postprocess/default/plugin.py
@@ -6,8 +6,8 @@ import logging
 from pathlib import Path
 from typing import Any
 
+from projects.caliper.engine.kpi import KpiCatalogEntry, KpiComputationStatus, KpiRecord
 from projects.caliper.engine.kpi.analyze import AnalysisConfig
-from projects.caliper.engine.kpi.dataclasses import KpiCatalogEntry
 from projects.caliper.engine.model import (
     ParseResult,
     PostProcessingPlugin,
@@ -90,7 +90,7 @@ class SkeletonDefaultPlugin(PostProcessingPlugin):
         )
         return paths
 
-    def compute_kpis(self, model: UnifiedRunModel) -> list[dict[str, Any]]:
+    def compute_kpis(self, model: UnifiedRunModel) -> tuple[list[KpiRecord], KpiComputationStatus]:
         """Compute KPI values from the unified model."""
         return self.kpi_handler.compute_kpis(model)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard reporting now includes curve-based KPIs for concurrency, throughput, latency, and request rate.
  * KPI reports provide structured computation statuses and typed records across supported integrations.
  * Prometheus captures support head-only scanning by default, with an option to scan the full database.

* **Changes**
  * Cluster workloads now use CephFS-backed storage and an external inference gateway.
  * Dashboard CSV exports group curve metrics by concurrency.
  * Test label generation writes only the current metadata format.
  * Metric capture failures now propagate instead of becoming warnings.
  * MLflow exports preserve partial failures and report unsuccessful exports accurately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->