### PR TITLE
fix(rhaiis/guidellm): populate turns/prefix_tokens/prefix_count/request_type in dashboard CSV

### DIFF
--- a/projects/guidellm/postprocess/guidellm/dashboard.py
+++ b/projects/guidellm/postprocess/guidellm/dashboard.py
@@ -256,6 +256,10 @@ def _extract_dashboard_metrics(node: TestBaseNode) -> tuple[dict[str, Any], dict
         "guidellm_version": metadata.get("guidellm_version", ""),
         "prompt_toks": int(float(tokens["prompt_tokens"])) if "prompt_tokens" in tokens else "",
         "output_toks": int(float(tokens["output_tokens"])) if "output_tokens" in tokens else "",
+        "turns": int(float(tokens["turns"])) if "turns" in tokens else "",
+        "prefix_tokens": int(float(tokens["prefix_tokens"])) if "prefix_tokens" in tokens else "",
+        "prefix_count": int(float(tokens["prefix_count"])) if "prefix_count" in tokens else "",
+        "request_type": args.get("request_type", "") if isinstance(args, dict) else "",
         "guidellm_start_time_ms": int(min(starts) * 1000) if starts else "",
         "guidellm_end_time_ms": int(max(ends) * 1000) if ends else "",
     }
@@ -364,6 +368,10 @@ def compute_dashboard_kpis(model: UnifiedRunModel, *, prefix: str) -> list[dict[
             "guidellm_version": str(record.metrics.get("guidellm_version", "")),
             "prompt_toks": str(record.metrics.get("prompt_toks", "")),
             "output_toks": str(record.metrics.get("output_toks", "")),
+            "turns": str(record.metrics.get("turns", "")),
+            "prefix_tokens": str(record.metrics.get("prefix_tokens", "")),
+            "prefix_count": str(record.metrics.get("prefix_count", "")),
+            "request_type": str(record.metrics.get("request_type", "")),
             "guidellm_start_time_ms": str(record.metrics.get("guidellm_start_time_ms", "")),
             "guidellm_end_time_ms": str(record.metrics.get("guidellm_end_time_ms", "")),
         }

--- a/projects/rhaiis/orchestration/runtime_config.py
+++ b/projects/rhaiis/orchestration/runtime_config.py
@@ -115,6 +115,31 @@ def _translate_args(args: dict, engine: str) -> dict:
     return translated
 
 
+def _resolve_boolean_flag_conflicts(args: dict) -> dict:
+    """Drop the earlier-set side of conflicting "no-<flag>" / "<flag>" pairs.
+
+    Config overrides (e.g. rhaiis.engines.vllm.args.enable-prefix-caching)
+    set a specific key without clearing a conflicting sibling default
+    (e.g. no-enable-prefix-caching), so both can end up in the merged args.
+    These share one vLLM/argparse CLI destination (BooleanOptionalAction),
+    where whichever flag is passed last wins. Emitting only the
+    later-inserted key avoids deploying both contradictory flags.
+    """
+    keys_in_order = list(args.keys())
+    losers = set()
+    for key in keys_in_order:
+        if not key.startswith("no-"):
+            continue
+        positive_key = key[len("no-") :]
+        if positive_key not in args:
+            continue
+        earlier_key = (
+            key if keys_in_order.index(key) < keys_in_order.index(positive_key) else positive_key
+        )
+        losers.add(earlier_key)
+    return {key: value for key, value in args.items() if key not in losers}
+
+
 def merge_engine_args(
     overrides: dict,
     model: dict,
@@ -144,7 +169,7 @@ def merge_engine_args(
 
     base.update(wl)
     base.update(overrides)
-    return base
+    return _resolve_boolean_flag_conflicts(base)
 
 
 def merge_env_vars(accelerator: str, model: dict) -> dict:

--- a/projects/rhaiis/orchestration/runtime_config.py
+++ b/projects/rhaiis/orchestration/runtime_config.py
@@ -116,14 +116,11 @@ def _translate_args(args: dict, engine: str) -> dict:
 
 
 def _resolve_boolean_flag_conflicts(args: dict) -> dict:
-    """Drop the earlier-set side of conflicting "no-<flag>" / "<flag>" pairs.
+    """If both "no-<flag>" and "<flag>" are set, drop the earlier one.
 
-    Config overrides (e.g. rhaiis.engines.vllm.args.enable-prefix-caching)
-    set a specific key without clearing a conflicting sibling default
-    (e.g. no-enable-prefix-caching), so both can end up in the merged args.
-    These share one vLLM/argparse CLI destination (BooleanOptionalAction),
-    where whichever flag is passed last wins. Emitting only the
-    later-inserted key avoids deploying both contradictory flags.
+    A config override can add one without clearing the other's default.
+    Keeping only the later-set key matches argparse's last-flag-wins
+    behavior for these paired CLI flags.
     """
     keys_in_order = list(args.keys())
     losers = set()

--- a/projects/rhaiis/postprocess/plugin.py
+++ b/projects/rhaiis/postprocess/plugin.py
@@ -118,9 +118,7 @@ class RhaiisPlugin(PostProcessingPlugin):
                 "prefix_tokens": labels.get("prefix_tokens", ""),
                 "prefix_count": labels.get("prefix_count", ""),
                 "request_type": labels.get("request_type", ""),
-                "prefix_caching": _prefix_caching_from_runtime_args(
-                    labels.get("runtime_args", "")
-                ),
+                "prefix_caching": _prefix_caching_from_runtime_args(labels.get("runtime_args", "")),
             }
 
         return export_dashboard_kpis_to_csv(

--- a/projects/rhaiis/postprocess/plugin.py
+++ b/projects/rhaiis/postprocess/plugin.py
@@ -20,22 +20,27 @@ def _prefix_caching_from_runtime_args(runtime_args: str) -> str:
 
     runtime_args is a semicolon-separated "key: value" echo of the deployed
     engine args (e.g. from rhaiis.engines.vllm.args), such as
-    "...; no-enable-prefix-caching: True; ...". These are a boolean
-    optional pair, so a "false" value flips the meaning (e.g.
+    "...; no-enable-prefix-caching: True; ...". enable-prefix-caching and
+    no-enable-prefix-caching are a boolean optional pair sharing one vLLM
+    CLI destination, so if both appear (e.g. a config override appended
+    one without removing the other's default), the one appearing LAST
+    wins, matching argparse's actual behavior. A "false" value flips the
+    meaning of whichever flag it's attached to (e.g.
     no-enable-prefix-caching: false means prefix caching is NOT disabled).
     Returns "" when neither flag is present (i.e. not explicitly set).
     """
-    args = {}
+    result = ""
     for part in runtime_args.split(";"):
         key, sep, value = part.strip().partition(":")
-        if sep:
-            args[key.strip()] = value.strip().lower()
-
-    if "no-enable-prefix-caching" in args:
-        return "no" if args["no-enable-prefix-caching"] == "true" else "yes"
-    if "enable-prefix-caching" in args:
-        return "yes" if args["enable-prefix-caching"] == "true" else "no"
-    return ""
+        if not sep:
+            continue
+        key = key.strip()
+        value = value.strip().lower()
+        if key == "no-enable-prefix-caching":
+            result = "no" if value == "true" else "yes"
+        elif key == "enable-prefix-caching":
+            result = "yes" if value == "true" else "no"
+    return result
 
 
 class RhaiisPlugin(PostProcessingPlugin):

--- a/projects/rhaiis/postprocess/plugin.py
+++ b/projects/rhaiis/postprocess/plugin.py
@@ -16,18 +16,9 @@ from .parser import RhaiisParser
 
 
 def _prefix_caching_from_runtime_args(runtime_args: str) -> str:
-    """Derive yes/no prefix-caching status from the vLLM runtime_args string.
-
-    runtime_args is a semicolon-separated "key: value" echo of the deployed
-    engine args (e.g. from rhaiis.engines.vllm.args), such as
-    "...; no-enable-prefix-caching: True; ...". enable-prefix-caching and
-    no-enable-prefix-caching are a boolean optional pair sharing one vLLM
-    CLI destination, so if both appear (e.g. a config override appended
-    one without removing the other's default), the one appearing LAST
-    wins, matching argparse's actual behavior. A "false" value flips the
-    meaning of whichever flag it's attached to (e.g.
-    no-enable-prefix-caching: false means prefix caching is NOT disabled).
-    Returns "" when neither flag is present (i.e. not explicitly set).
+    """Return "yes"/"no" from the enable/no-enable-prefix-caching flag in
+    runtime_args, or "" if neither is set. If both appear, the last one
+    wins (matches vLLM/argparse's BooleanOptionalAction behavior).
     """
     result = ""
     for part in runtime_args.split(";"):

--- a/projects/rhaiis/postprocess/plugin.py
+++ b/projects/rhaiis/postprocess/plugin.py
@@ -20,19 +20,21 @@ def _prefix_caching_from_runtime_args(runtime_args: str) -> str:
 
     runtime_args is a semicolon-separated "key: value" echo of the deployed
     engine args (e.g. from rhaiis.engines.vllm.args), such as
-    "...; no-enable-prefix-caching: True; ...". Returns "" when neither flag
-    is present (i.e. not explicitly set).
+    "...; no-enable-prefix-caching: True; ...". These are a boolean
+    optional pair, so a "false" value flips the meaning (e.g.
+    no-enable-prefix-caching: false means prefix caching is NOT disabled).
+    Returns "" when neither flag is present (i.e. not explicitly set).
     """
     args = {}
     for part in runtime_args.split(";"):
         key, sep, value = part.strip().partition(":")
         if sep:
-            args[key.strip()] = value.strip()
+            args[key.strip()] = value.strip().lower()
 
-    if args.get("no-enable-prefix-caching", "").lower() == "true":
-        return "no"
-    if args.get("enable-prefix-caching", "").lower() == "true":
-        return "yes"
+    if "no-enable-prefix-caching" in args:
+        return "no" if args["no-enable-prefix-caching"] == "true" else "yes"
+    if "enable-prefix-caching" in args:
+        return "yes" if args["enable-prefix-caching"] == "true" else "no"
     return ""
 
 

--- a/projects/rhaiis/postprocess/plugin.py
+++ b/projects/rhaiis/postprocess/plugin.py
@@ -91,6 +91,10 @@ class RhaiisPlugin(PostProcessingPlugin):
                 "guidellm_version": labels.get("guidellm_version", ""),
                 "mlflow_run_id": labels.get("mlflow_run_id", ""),
                 "mlflow_experiment_id": labels.get("mlflow_experiment_id", ""),
+                "turns": labels.get("turns", ""),
+                "prefix_tokens": labels.get("prefix_tokens", ""),
+                "prefix_count": labels.get("prefix_count", ""),
+                "request_type": labels.get("request_type", ""),
             }
 
         return export_dashboard_kpis_to_csv(

--- a/projects/rhaiis/postprocess/plugin.py
+++ b/projects/rhaiis/postprocess/plugin.py
@@ -15,6 +15,27 @@ from .kpis import RhaiisKpiHandler
 from .parser import RhaiisParser
 
 
+def _prefix_caching_from_runtime_args(runtime_args: str) -> str:
+    """Derive yes/no prefix-caching status from the vLLM runtime_args string.
+
+    runtime_args is a semicolon-separated "key: value" echo of the deployed
+    engine args (e.g. from rhaiis.engines.vllm.args), such as
+    "...; no-enable-prefix-caching: True; ...". Returns "" when neither flag
+    is present (i.e. not explicitly set).
+    """
+    args = {}
+    for part in runtime_args.split(";"):
+        key, sep, value = part.strip().partition(":")
+        if sep:
+            args[key.strip()] = value.strip()
+
+    if args.get("no-enable-prefix-caching", "").lower() == "true":
+        return "no"
+    if args.get("enable-prefix-caching", "").lower() == "true":
+        return "yes"
+    return ""
+
+
 class RhaiisPlugin(PostProcessingPlugin):
     def __init__(self) -> None:
         self.parser = RhaiisParser()
@@ -95,6 +116,9 @@ class RhaiisPlugin(PostProcessingPlugin):
                 "prefix_tokens": labels.get("prefix_tokens", ""),
                 "prefix_count": labels.get("prefix_count", ""),
                 "request_type": labels.get("request_type", ""),
+                "prefix_caching": _prefix_caching_from_runtime_args(
+                    labels.get("runtime_args", "")
+                ),
             }
 
         return export_dashboard_kpis_to_csv(


### PR DESCRIPTION
## Problem

Multi-turn benchmark runs (profile6: `prompt_tokens=1000,output_tokens=1000,turns=5,prefix_tokens=512,prefix_count=10`) were exporting `turns`, `prefix_tokens`, `prefix_count`, `request_type`, and `prefix_caching` as empty in the dashboard CSV, causing the dashboard to drop those rows since it can't display null data for these fields.

## Root cause

Two gaps in the GuideLLM → RHAIIS dashboard export pipeline:

1. `_extract_dashboard_metrics()` in `projects/guidellm/postprocess/guidellm/dashboard.py` already parses the `--data` CLI string into a `tokens` dict that includes `turns`/`prefix_tokens`/`prefix_count`, but the `extra` metrics dict it builds only copied out `prompt_tokens`/`output_tokens`.
2. Even with that fixed, the values wouldn't reach the CSV: `compute_dashboard_kpis()` only forwards a fixed allowlist of `record.metrics` keys into KPI labels (previously just `guidellm_version`/`prompt_toks`/`output_toks`/timestamps), and `RhaiisPlugin.metadata_row()` in `projects/rhaiis/postprocess/plugin.py` never mapped `turns`/`prefix_tokens`/`prefix_count`/`request_type`/`prefix_caching` from labels onto the corresponding CSV columns — so those columns were unconditionally `""` for every run.

Additionally, while validating `prefix_caching` against a real CI run, found a related orchestration bug: `/var rhaiis.engines.vllm.args.enable-prefix-caching: true` sets a specific config key without clearing the base config's conflicting `no-enable-prefix-caching: true`, so the deployed pod ended up with **both** contradictory CLI flags (`--no-enable-prefix-caching ... --enable-prefix-caching`), relying on argparse's implicit last-flag-wins behavior.

## Fix

- `dashboard.py::_extract_dashboard_metrics`: extract `turns`/`prefix_tokens`/`prefix_count` from the parsed `data` tokens, and `request_type` from the run's `args`, into `extra`.
- `dashboard.py::compute_dashboard_kpis`: forward these 4 keys into the KPI `metadata_labels`.
- `rhaiis/postprocess/plugin.py::metadata_row`: map the 4 labels onto the corresponding dashboard CSV columns.
- `rhaiis/postprocess/plugin.py`: derive `prefix_caching` ("yes"/"no"/`""`) by parsing the already-captured `runtime_args` string for the `enable-prefix-caching`/`no-enable-prefix-caching` vLLM flag pair. Handles explicit `false` values, and resolves conflicts (both flags present) by taking whichever appears **last**, matching vLLM/argparse's actual `BooleanOptionalAction` behavior.
- `runtime_config.py::merge_engine_args`: now calls a new `_resolve_boolean_flag_conflicts()` helper that drops the earlier-set side of any conflicting `no-<flag>`/`<flag>` pair, so only one unambiguous flag is ever actually deployed — fixing the ambiguity at the source rather than just working around it in the CSV parser.

## Verification

- Existing test suites (`projects/guidellm`, `projects/rhaiis`) pass unchanged.
- Ran a synthetic profile6-shaped `benchmarks.json` end-to-end through `RhaiisParser → RhaiisKpiHandler.compute_kpis → RhaiisPlugin.export_kpis_to_csv`; confirmed `turns`, `prefix_tokens`, `prefix_count`, `request_type` land in the correct CSV columns (verified against a real `consolidated_dashboard.csv` header/column ordering).
- Unit-verified `_prefix_caching_from_runtime_args` against 8 cases including both single-flag true/false variants, not-set, and the actual conflicting-flags scenario reproduced from a real CI run (`forge-rhaiis-20260903-160247`, where `/var rhaiis.engines.vllm.args.enable-prefix-caching: true` was applied on top of the base config's `no-enable-prefix-caching: true`). Confirmed via the run's real `inferenceservice.deployments.yaml` that the deployed container's args end with `... --no-enable-prefix-caching ... --enable-prefix-caching` — the parser now correctly reports `"yes"` for this case.
- Unit-verified `_resolve_boolean_flag_conflicts` against the same real scenario (only `enable-prefix-caching` survives), the reverse order, and the no-conflict case (left untouched).
- `ruff check` and `ruff format --check` both pass on changed files and the full repo.

## Caveat

`request_type` isn't part of any profile's `--data` string — forge never passes `--request-type` explicitly. This extracts it from the top-level `args` dict in `benchmarks.json` (`args.get("request_type")`), which is a safe no-op (falls back to `""`) if that key isn't present for a given GuideLLM version/run. Checked a real (non-profile6) `benchmarks.json` and confirmed `request_type` is absent from its `args` for that run — not yet verified against a real profile6 artifact containing `request_type`. Worth double-checking on the next real multi-turn run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Dashboard metrics and KPI labels now include turn count, prefix-token details, request type, and prefix-caching status.
  - CSV KPI exports now include prefix-caching information alongside existing benchmark metadata.

- **Bug Fixes**
  - Conflicting engine flags now follow command-line ordering, so the last specified option determines the effective setting.
  - Missing metadata values are handled consistently without interrupting metric or export generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->