### PR TITLE
[rhaiis] Complete SGLang Prometheus metrics enablement

### DIFF
--- a/projects/rhaiis/orchestration/manifests.py
+++ b/projects/rhaiis/orchestration/manifests.py
@@ -100,16 +100,11 @@ def build_inferenceservice(
     annotations: dict[str, str] = {
         "serving.kserve.io/deploymentMode": "RawDeployment",
         "storage.kserve.io/readonly": "false",
+        "serving.kserve.io/enable-prometheus-scraping": "true",
+        "prometheus.io/scrape": "true",
+        "prometheus.io/path": "/metrics",
+        "prometheus.io/port": str(engine_port),
     }
-    if engine != "sglang":
-        annotations.update(
-            {
-                "serving.kserve.io/enable-prometheus-scraping": "true",
-                "prometheus.io/scrape": "true",
-                "prometheus.io/path": "/metrics",
-                "prometheus.io/port": str(engine_port),
-            }
-        )
 
     metadata: dict[str, Any] = {
         "annotations": annotations,
@@ -119,7 +114,9 @@ def build_inferenceservice(
 
     if labels:
         meta_labels = dict(labels)
-        if engine in ("sglang", "trtllm"):
+        # SGLang now supports Prometheus metrics via --enable-metrics flag (PR #196)
+        # Only TRT-LLM needs to be excluded from OpenDataHub monitoring
+        if engine == "trtllm":
             meta_labels["monitoring.opendatahub.io/scrape"] = "false"
         metadata["labels"] = meta_labels
 

--- a/projects/rhaiis/orchestration/test_phase.py
+++ b/projects/rhaiis/orchestration/test_phase.py
@@ -202,7 +202,10 @@ def _run_test(
         mlflow_destination = None
 
     try:
-        isvc_labels = {"opendatahub.io/dashboard": "true"}
+        isvc_labels = {
+            "opendatahub.io/dashboard": "true",
+            "deployment_uuid": run_uuid,
+        }
         if profiler_enabled and engine == "vllm":
             isvc_labels["vllm-profiler/enabled"] = "true"
         elif profiler_enabled and engine != "vllm":


### PR DESCRIPTION
## Summary

PR #196 added the `--enable-metrics` flag to SGLang but didn't enable Prometheus scraping in the InferenceService manifest. This caused SGLang to expose the `/metrics` endpoint without Prometheus actually scraping it.

This PR completes the feature by enabling Prometheus to scrape SGLang metrics.

## Changes

- ✅ Removed SGLang exclusion from Prometheus scraping annotations
- ✅ Enabled metrics collection for all engines (vLLM, SGLang)  
- ✅ Only excluding TRT-LLM from OpenDataHub monitoring (SGLang now included)

## Testing

After this change, SGLang deployments will:
- Expose `/metrics` endpoint on port 8080 (already working from PR #196)
- Have Prometheus scraping enabled via K8s annotations (NEW)
- Appear in Grafana dashboards alongside vLLM metrics (NEW)

## Related

- Fixes the gap left by #196
- Matches the implementation already done in Model Furnace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Monitoring**
  - Prometheus metrics scraping is now enabled consistently across all supported inference engines.
  - SGLang metrics can now be collected through Prometheus.
  - TensorRT-LLM retains its monitoring configuration to prevent conflicting scrape behavior.
  - Inference service deployments now include a unique deployment identifier, improving traceability across monitoring and dashboard views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->